### PR TITLE
[intermediate-dockerfiles] add `g++` to docker image `py-runner:3.10`

### DIFF
--- a/contrib/intermediate-dockerfiles/py-runner
+++ b/contrib/intermediate-dockerfiles/py-runner
@@ -1,3 +1,3 @@
 FROM python:3.10-alpine3.15
 
-RUN apk add --no-cache gcc make musl-dev
+RUN apk add --no-cache gcc g++ make musl-dev


### PR DESCRIPTION
Docker image `scrolltech/py-runner:3.10` and latest have already been pushed.