### PR TITLE
fix: `cargo-chef` panic issue

### DIFF
--- a/build/dockerfiles/intermediate/go-rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/go-rust-builder.Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache gcc musl-dev linux-headers git ca-certificates
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \

--- a/build/dockerfiles/intermediate/rust-alpine-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/rust-alpine-builder.Dockerfile
@@ -6,11 +6,13 @@ ARG DEFAULT_RUST_TOOLCHAIN=nightly-2022-08-23
 RUN apk add --no-cache \
         ca-certificates \
         gcc \
+        git \
         musl-dev
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \


### PR DESCRIPTION
@Thegaram and @colinlyguo helped find and debug a `cargo-chef` panic issue as:
```
> [builder 2/4] RUN cargo chef cook --release --recipe-path recipe.json:
#  Updating [crates.io](http://crates.io/) index
# thread ‘main’ panicked at ‘Process terminated by signal’, /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/cargo-chef-0.1.41/src/recipe.rs:162:21
```

@Thegaram helped found the solution in this `cargo-chef` issue - https://github.com/LukeMathWalker/cargo-chef/issues/107

I build and tested the base docker image `rust-alpine-builder` and `testnet/whitelist_backend` (with base image) on both local Mac and staging server. It worked for me.

***Should we update these two docker images to another `tag` or just remain the same (since we don't update rust version)?***