### PR TITLE
fix: update Dockerfile to use go compilation cache

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -25,7 +25,7 @@ clean: ## Empty out the bin folder
 	@rm -rf build/bin
 
 docker:
-	docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/bridge.Dockerfile
+	DOCKER_BUILDKIT=1 docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/bridge.Dockerfile
 
 docker_push:
 	docker push scrolltech/${IMAGE_NAME}:${IMAGE_VERSION}

--- a/build/dockerfiles/bridge.Dockerfile
+++ b/build/dockerfiles/bridge.Dockerfile
@@ -1,6 +1,7 @@
 # Download Go dependencies
 FROM scrolltech/go-builder:1.18 as base
 
+WORKDIR /src
 COPY go.work* ./
 COPY ./bridge/go.* ./bridge/
 COPY ./common/go.* ./common/
@@ -12,12 +13,13 @@ RUN go mod download -x
 # Build bridge
 FROM base as builder
 
-COPY ./ /
-RUN cd /bridge/cmd && go build -v -p 4 -o bridge
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd /src/bridge/cmd && go build -v -p 4 -o /bin/bridge
 
 # Pull bridge into a second stage deploy alpine container
 FROM alpine:latest
 
-COPY --from=builder /bridge/cmd/bridge /bin/
+COPY --from=builder /bin/bridge /bin/
 
 ENTRYPOINT ["bridge"]

--- a/build/dockerfiles/bridge.Dockerfile.dockerignore
+++ b/build/dockerfiles/bridge.Dockerfile.dockerignore
@@ -1,7 +1,5 @@
 assets/
-coordinator/
 docs/
 integration-test/
 l2geth/
-roller/
 rpc-gateway/

--- a/build/dockerfiles/coordinator.Dockerfile
+++ b/build/dockerfiles/coordinator.Dockerfile
@@ -1,6 +1,7 @@
 # Download Go dependencies
 FROM scrolltech/go-builder:1.18 as base
 
+WORKDIR /src
 COPY go.work* ./
 COPY ./bridge/go.* ./bridge/
 COPY ./common/go.* ./common/
@@ -12,12 +13,14 @@ RUN go mod download -x
 # Build coordinator
 FROM base as builder
 
-COPY ./ /
-RUN cd /coordinator/cmd && go build -v -p 4 -o coordinator
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd /src/coordinator/cmd && go build -v -p 4 -o /bin/coordinator
 
 # Pull coordinator into a second stage deploy alpine container
 FROM alpine:latest
 
-COPY --from=builder /coordinator/cmd/coordinator /bin/
+COPY --from=builder /bin/coordinator /bin/
 
 ENTRYPOINT ["coordinator"]
+

--- a/build/dockerfiles/coordinator.Dockerfile.dockerignore
+++ b/build/dockerfiles/coordinator.Dockerfile.dockerignore
@@ -1,8 +1,6 @@
 assets/
-bridge/
 contracts/
 docs/
 integration-test/
 l2geth/
-roller/
 rpc-gateway/

--- a/coordinator/Makefile
+++ b/coordinator/Makefile
@@ -17,7 +17,7 @@ clean: ## Empty out the bin folder
 	@rm -rf build/bin
 
 docker:
-	docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/coordinator.Dockerfile
+	DOCKER_BUILDKIT=1 docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/coordinator.Dockerfile
 
 docker_push:
 	docker push scrolltech/${IMAGE_NAME}:${IMAGE_VERSION}

--- a/database/Makefile
+++ b/database/Makefile
@@ -14,7 +14,7 @@ lint: ## Lint the files - used for CI
 	GOBIN=$(PWD)/build/bin go run ../build/lint.go
 
 docker:
-	docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/${IMAGE_NAME}.Dockerfile
+	DOCKER_BUILDKIT=1 docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/${IMAGE_NAME}.Dockerfile
 
 docker_push:
 	docker push scrolltech/${IMAGE_NAME}:${IMAGE_VERSION}


### PR DESCRIPTION
According to this blog - https://www.docker.com/blog/containerize-your-go-developer-environment-part-3/

- Replace `COPY ./ /` with `--mount=target=.` (cannot be set as `--mount=target=/`, so add `WORKDIR /src`)
- Add `--mount=type=cache,target=/root/.cache/go-build` for go cache
- The mount target is read-only, so fix to output build to `/bin/` folder