### PR TITLE
fix(coordinator): use uint32 for timestamp to enable RLP encoding

### DIFF
--- a/common/message/message.go
+++ b/common/message/message.go
@@ -36,8 +36,8 @@ type AuthMsg struct {
 type Identity struct {
 	// Roller name
 	Name string `json:"name"`
-	// Time of message creation
-	Timestamp int64 `json:"timestamp"`
+	// Unverified Unix timestamp of message creation
+	Timestamp uint32 `json:"timestamp"`
 	// Roller public key
 	PublicKey string `json:"publicKey"`
 	// Version is common.Version+ZkVersion. Use the following to check the latest ZkVersion version.

--- a/common/message/message_test.go
+++ b/common/message/message_test.go
@@ -16,7 +16,7 @@ func TestAuthMessageSignAndVerify(t *testing.T) {
 	authMsg := &AuthMsg{
 		Identity: &Identity{
 			Name:      "testRoller",
-			Timestamp: time.Now().UnixNano(),
+			Timestamp: uint32(time.Now().Unix()),
 		},
 	}
 	assert.NoError(t, authMsg.Sign(privkey))

--- a/coordinator/manager_test.go
+++ b/coordinator/manager_test.go
@@ -127,7 +127,7 @@ func testFailedHandshake(t *testing.T) {
 	authMsg := &message.AuthMsg{
 		Identity: &message.Identity{
 			Name:      name,
-			Timestamp: time.Now().UnixNano(),
+			Timestamp: uint32(time.Now().Unix()),
 		},
 	}
 	assert.NoError(t, authMsg.Sign(privkey))
@@ -145,7 +145,7 @@ func testFailedHandshake(t *testing.T) {
 	authMsg = &message.AuthMsg{
 		Identity: &message.Identity{
 			Name:      name,
-			Timestamp: time.Now().UnixNano(),
+			Timestamp: uint32(time.Now().Unix()),
 		},
 	}
 	assert.NoError(t, authMsg.Sign(privkey))
@@ -415,7 +415,7 @@ func (r *mockRoller) connectToCoordinator() (*client2.Client, ethereum.Subscript
 	authMsg := &message.AuthMsg{
 		Identity: &message.Identity{
 			Name:      r.rollerName,
-			Timestamp: time.Now().UnixNano(),
+			Timestamp: uint32(time.Now().Unix()),
 		},
 	}
 	_ = authMsg.Sign(r.privKey)

--- a/roller/roller.go
+++ b/roller/roller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -104,10 +105,16 @@ func (r *Roller) Start() {
 
 // Register registers Roller to the coordinator through Websocket.
 func (r *Roller) Register() error {
+	timestamp := time.Now().Unix()
+
+	if timestamp < 0 || timestamp > math.MaxUint32 {
+		panic("Expected current time to be between the years 1970 and 2106")
+	}
+
 	authMsg := &message.AuthMsg{
 		Identity: &message.Identity{
 			Name:      r.cfg.RollerName,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: uint32(timestamp),
 			PublicKey: r.PublicKey(),
 			Version:   version.Version,
 		},


### PR DESCRIPTION
Previously we had this error:

```
rlp: type int64 is not RLP-serializable (struct field message.Identity.Timestamp)
```