### PR TITLE
doc: bump version number

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "prealpha-v11.1"
+var tag = "prealpha-v11.2"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
1. Purpose or design rationale of this PR


2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 


3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
