### PR TITLE
build(jenkins): remove changeset condition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,18 +17,6 @@ pipeline {
     }
     stages {
         stage('Build') {
-            when {
-                anyOf {
-                    changeset "Jenkinsfile"
-                    changeset "build/**"
-                    changeset "go.work**"
-                    changeset "bridge/**"
-                    changeset "coordinator/**"
-                    changeset "common/**"
-                    changeset "database/**"
-                    changeset "tests/**"
-                }
-            }
             parallel {
                 stage('Build Prerequisite') {
                     steps {
@@ -70,18 +58,6 @@ pipeline {
             }
         }
         stage('Parallel Test') {
-            when {
-                anyOf {
-                    changeset "Jenkinsfile"
-                    changeset "build/**"
-                    changeset "go.work**"
-                    changeset "bridge/**"
-                    changeset "coordinator/**"
-                    changeset "common/**"
-                    changeset "database/**"
-                    changeset "tests/**"
-                }
-            }
             parallel{
                 stage('Test bridge package') {
                     steps {
@@ -126,18 +102,6 @@ pipeline {
             }
         }
         stage('Compare Coverage') {
-            when {
-                anyOf {
-                    changeset "Jenkinsfile"
-                    changeset "build/**"
-                    changeset "go.work**"
-                    changeset "bridge/**"
-                    changeset "coordinator/**"
-                    changeset "common/**"
-                    changeset "database/**"
-                    changeset "tests/**"
-                }
-            }
             steps {
                 sh "./build/post-test-report-coverage.sh"
                 script {


### PR DESCRIPTION
1. Purpose or design rationale of this PR
previously we add changeset to avoid running CI if unnecessary.
but it also introduces the missing of running easily.
This PR removes changeset as @Thegaram suggests, as we don't have many contracts PRs (which is the current only tests excluded by changeset)


2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
N/A

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
N/A
