### PR TITLE
Fix bug in coordinator.GetNumberOfIdleRollers function

### DIFF
--- a/coordinator/rollers.go
+++ b/coordinator/rollers.go
@@ -107,18 +107,18 @@ func (m *Manager) freeTaskIDForRoller(pk string, id string) {
 
 // GetNumberOfIdleRollers return the count of idle rollers.
 func (m *Manager) GetNumberOfIdleRollers() int {
-	var pubkeys []string
+	var count int
 	for i, pk := range m.rollerPool.Keys() {
 		if val, ok := m.rollerPool.Get(pk); ok {
 			r := val.(*rollerNode)
 			if r.TaskIDs.Count() == 0 {
-				pubkeys = append(pubkeys, pk)
+				count++
 			}
 		} else {
 			log.Error("rollerPool Get fail", "pk", pk, "idx", i, "pk len", len(pubkeys))
 		}
 	}
-	return len(pubkeys)
+	return count
 }
 
 func (m *Manager) selectRoller() *rollerNode {


### PR DESCRIPTION
1. Purpose or design rationale of this PR
Purpose:
Fix the mistake count of idle roller number.
Relate log:
`no roller assigned                       id=0x4a1f6742636e796abc6d489b576aa1329ca3b29efafb228e5bb1f5472ba84bb4 number of idle rollers=11`

3. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
No

4. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
No