### PR TITLE
fix(coordinator): Fix bug in coordinator.GetNumberOfIdleRollers function.

### DIFF
--- a/coordinator/rollers.go
+++ b/coordinator/rollers.go
@@ -107,14 +107,14 @@ func (m *Manager) freeTaskIDForRoller(pk string, id string) {
 
 // GetNumberOfIdleRollers return the count of idle rollers.
 func (m *Manager) GetNumberOfIdleRollers() (count int) {
-	for _, pk := range m.rollerPool.Keys() {
+	for i, pk := range m.rollerPool.Keys() {
 		if val, ok := m.rollerPool.Get(pk); ok {
 			r := val.(*rollerNode)
 			if r.TaskIDs.Count() == 0 {
 				count++
 			}
 		} else {
-			log.Error("rollerPool Get fail", "pk", pubkeys[i], "idx", i, "pk len", len(pubkeys))
+			log.Error("rollerPool Get fail", "pk", pk, "idx", i, "pk len", pk)
 		}
 	}
 	return count


### PR DESCRIPTION
1. Purpose or design rationale of this PR
Purpose:
Fix the mistake count of idle roller number.
Relate log like:
no roller assigned                       id=0x4a1f6742636e796abc6d489b576aa1329ca3b29efafb228e5bb1f5472ba84bb4 number of idle rollers=11

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
Yes, and updated.

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
No