### PR TITLE
build(jenkinsfile): replace status_check with comment in coverage test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     environment {
         GO111MODULE = 'on'
         PATH="/home/ubuntu/.cargo/bin:$PATH"
-        //LOG_DOCKER = 'true'
+        // LOG_DOCKER = 'true'
     }
     stages {
         stage('Build') {


### PR DESCRIPTION
1. Purpose or design rationale of this PR
cancel coverage check, make it as comment 

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
no

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
no