### PR TITLE
fix(docker redis): Fix redis docker randomly panic.

### DIFF
--- a/common/docker/docker_redis.go
+++ b/common/docker/docker_redis.go
@@ -62,14 +62,13 @@ func (r *ImgRedis) Start() error {
 	// Wait result of keyword.
 	select {
 	case <-okCh:
-		utils.TryTimes(10, func() bool {
+		utils.TryTimes(3, func() bool {
 			r.id = GetContainerID(r.name)
 			return r.id != ""
 		})
 	case <-time.After(time.Second * 10):
 	}
 
-	r.cmd.Log("redis message", "name", r.name, "id", r.id)
 	// Set redis status.
 	r.running = r.id != ""
 	if !r.running {

--- a/common/docker/interface.go
+++ b/common/docker/interface.go
@@ -33,6 +33,8 @@ func GetContainerID(name string) string {
 	filter := filters.NewArgs()
 	filter.Add("name", name)
 	lst, _ := cli.ContainerList(context.Background(), types.ContainerListOptions{
+		Latest:  true,
+		Limit:   1,
 		Filters: filter,
 	})
 	if len(lst) > 0 {


### PR DESCRIPTION
1. Purpose or design rationale of this PR
Because of redis docker start too fast, in order to check docker status we have to add register function before start it.

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
No

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
No