### PR TITLE
fix: add gas multiplier

### DIFF
--- a/bridge/sender/sender.go
+++ b/bridge/sender/sender.go
@@ -166,6 +166,10 @@ func (s *Sender) getFeeData(auth *bind.TransactOpts, target *common.Address, val
 		// estimate gas price
 		var gasPrice *big.Int
 		gasPrice, err = s.client.SuggestGasPrice(s.ctx)
+
+		gasPrice = gasPrice.Mul(gasPrice, big.NewInt(15))
+		gasPrice = gasPrice.Div(gasPrice, big.NewInt(10))
+
 		if err != nil {
 			return nil, err
 		}

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "prealpha-v11.15"
+var tag = "prealpha-v11.16"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
1. Purpose or design rationale of this PR

It seems that sometimes txs get stuck in mempool, even if we did not skip a nonce. This is a temporary quick fix to attempt to solve this issue.

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 

Yes

4. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?

No