### PR TITLE
Revert "fix: add gas multiplier (#275)"

### DIFF
--- a/bridge/sender/sender.go
+++ b/bridge/sender/sender.go
@@ -166,10 +166,6 @@ func (s *Sender) getFeeData(auth *bind.TransactOpts, target *common.Address, val
 		// estimate gas price
 		var gasPrice *big.Int
 		gasPrice, err = s.client.SuggestGasPrice(s.ctx)
-
-		gasPrice = gasPrice.Mul(gasPrice, big.NewInt(15))
-		gasPrice = gasPrice.Div(gasPrice, big.NewInt(10))
-
 		if err != nil {
 			return nil, err
 		}

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "prealpha-v11.17"
+var tag = "prealpha-v11.18"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
This reverts commit 41d71fc274467a2922a6af706237caa788933a61.

1. Purpose or design rationale of this PR

I increased gas price to make sure our transactions our prioritized. But this lead to an overall increase in the network's gas price. Now we use local accounts instead.

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 

Yes

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?

No