### PR TITLE
build: add nightly-2022-12-10 rust builder image

### DIFF
--- a/build/dockerfiles/intermediate/Makefile
+++ b/build/dockerfiles/intermediate/Makefile
@@ -1,6 +1,6 @@
 GO_VERSION := 1.18
 PYTHON_VERSION := 3.10
-RUST_VERSION := nightly-2022-08-23
+RUST_VERSION := nightly-2022-12-10
 
 .PHONY: all go-alpine-builder rust-builder rust-alpine-builder go-rust-alpine-builder go-rust-builder py-runner
 

--- a/build/dockerfiles/intermediate/go-alpine-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/go-alpine-builder.Dockerfile
@@ -4,4 +4,4 @@ FROM golang:1.18-alpine
 
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 
-RUN apk add --no-cache gcc musl-dev linux-headers git ca-certificates
+RUN apk add --no-cache gcc musl-dev linux-headers git ca-certificates openssl-dev

--- a/build/dockerfiles/intermediate/go-rust-alpine-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/go-rust-alpine-builder.Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.18-alpine
 ARG CARGO_CHEF_TAG=0.1.41
-ARG DEFAULT_RUST_TOOLCHAIN=nightly-2022-08-23
+ARG DEFAULT_RUST_TOOLCHAIN=nightly-2022-12-10
 
-RUN apk add --no-cache gcc musl-dev linux-headers git ca-certificates
+RUN apk add --no-cache gcc musl-dev linux-headers git ca-certificates openssl-dev
 
 # RUN apk add --no-cache libc6-compat
 # RUN apk add --no-cache gcompat

--- a/build/dockerfiles/intermediate/go-rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/go-rust-builder.Dockerfile
@@ -14,7 +14,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV CARGO_HOME=/root/.cargo
 
 # Add Toolchain
-RUN rustup toolchain install nightly-2022-08-23
+RUN rustup toolchain install nightly-2022-12-10
 
 # TODO: make this ARG
 ENV CARGO_CHEF_TAG=0.1.41

--- a/build/dockerfiles/intermediate/rust-alpine-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/rust-alpine-builder.Dockerfile
@@ -1,10 +1,11 @@
 ARG ALPINE_VERSION=3.15
 FROM alpine:${ALPINE_VERSION}
 ARG CARGO_CHEF_TAG=0.1.41
-ARG DEFAULT_RUST_TOOLCHAIN=nightly-2022-08-23
+ARG DEFAULT_RUST_TOOLCHAIN=nightly-2022-12-10
 
 RUN apk add --no-cache \
         ca-certificates \
+        openssl-dev \
         gcc \
         git \
         musl-dev

--- a/build/dockerfiles/intermediate/rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/rust-builder.Dockerfile
@@ -13,4 +13,4 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Add Toolchain
-RUN rustup toolchain install nightly-2022-08-23
+RUN rustup toolchain install nightly-2022-12-10


### PR DESCRIPTION
1. Purpose or design rationale of this PR


2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 


3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
