### PR TITLE
fix(Build): fix tag build error

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -23,5 +23,8 @@ clean: ## Empty out the bin folder
 docker:
 	DOCKER_BUILDKIT=1 docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/bridge.Dockerfile
 
+docker_clean:
+	DOCKER_BUILDKIT=1 docker build --no-cache -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/bridge.Dockerfile
+
 docker_push:
 	docker push scrolltech/${IMAGE_NAME}:${IMAGE_VERSION}

--- a/build/push-docker-tag.Jenkinsfile
+++ b/build/push-docker-tag.Jenkinsfile
@@ -42,8 +42,8 @@ pipeline {
                                     return;
                                 }
                                 sh "docker login --username=${dockerUser} --password=${dockerPassword}"
-                                sh "make -C bridge docker"
-                                sh "make -C coordinator docker"
+                                sh "make -C bridge docker_clean"
+                                sh "make -C coordinator docker_clean"
                                 sh "docker tag scrolltech/bridge:latest scrolltech/bridge:${TAGNAME}"
                                 sh "docker tag scrolltech/coordinator:latest scrolltech/coordinator:${TAGNAME}"
                                 sh "docker push scrolltech/bridge:${TAGNAME}"

--- a/coordinator/Makefile
+++ b/coordinator/Makefile
@@ -35,5 +35,8 @@ clean: ## Empty out the bin folder
 docker:
 	DOCKER_BUILDKIT=1 docker build -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/coordinator.Dockerfile
 
+docker_clean:
+	DOCKER_BUILDKIT=1 docker build --no-cache -t scrolltech/${IMAGE_NAME}:${IMAGE_VERSION} ${REPO_ROOT_DIR}/ -f ${REPO_ROOT_DIR}/build/dockerfiles/coordinator.Dockerfile
+
 docker_push:
 	docker push scrolltech/${IMAGE_NAME}:${IMAGE_VERSION}


### PR DESCRIPTION
1. Purpose or design rationale of this [PR]
(https://scrollco.slack.com/archives/C02PKAQ2430/p1675959771132019)
Avoid cached docker build from CI to solve this error


2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
no


3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
no
