### PR TITLE
fix(libzkp): load_params and seed in zk

### DIFF
--- a/common/libzkp/impl/src/prove.rs
+++ b/common/libzkp/impl/src/prove.rs
@@ -3,7 +3,7 @@ use libc::c_char;
 use std::cell::OnceCell;
 use types::eth::BlockTrace;
 use zkevm::circuit::AGG_DEGREE;
-use zkevm::utils::{load_or_create_params, load_or_create_seed};
+use zkevm::utils::{load_params, load_seed};
 use zkevm::{circuit::DEGREE, prover::Prover};
 
 static mut PROVER: OnceCell<Prover> = OnceCell::new();
@@ -15,9 +15,9 @@ pub unsafe extern "C" fn init_prover(params_path: *const c_char, seed_path: *con
 
     let params_path = c_char_to_str(params_path);
     let seed_path = c_char_to_str(seed_path);
-    let params = load_or_create_params(params_path, *DEGREE).unwrap();
-    let agg_params = load_or_create_params(params_path, *AGG_DEGREE).unwrap();
-    let seed = load_or_create_seed(seed_path).unwrap();
+    let params = load_params(params_path, *DEGREE).unwrap();
+    let agg_params = load_params(params_path, *AGG_DEGREE).unwrap();
+    let seed = load_seed(seed_path).unwrap();
     let p = Prover::from_params_and_seed(params, agg_params, seed);
     PROVER.set(p).unwrap();
 }

--- a/common/libzkp/impl/src/verify.rs
+++ b/common/libzkp/impl/src/verify.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::Read;
 use zkevm::circuit::{AGG_DEGREE, DEGREE};
 use zkevm::prover::AggCircuitProof;
-use zkevm::utils::load_or_create_params;
+use zkevm::utils::load_params;
 use zkevm::verifier::Verifier;
 
 static mut VERIFIER: Option<&Verifier> = None;
@@ -20,8 +20,8 @@ pub unsafe extern "C" fn init_verifier(params_path: *const c_char, agg_vk_path: 
     let mut agg_vk = vec![];
     f.read_to_end(&mut agg_vk).unwrap();
 
-    let params = load_or_create_params(params_path, *DEGREE).unwrap();
-    let agg_params = load_or_create_params(params_path, *AGG_DEGREE).unwrap();
+    let params = load_params(params_path, *DEGREE).unwrap();
+    let agg_params = load_params(params_path, *AGG_DEGREE).unwrap();
 
     let v = Box::new(Verifier::from_params(params, agg_params, Some(agg_vk)));
     VERIFIER = Some(Box::leak(v))

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v3.0.7"
+var tag = "v3.0.8"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
1. Purpose or design rationale of this PR
init zk: `load_or_create_xxx()` --> `load_xxx()` because we always download the params and seed files, never generate them locally.
Sometimes, we forget to download files but it runs with different params files(generate locally), which will cause bugs.

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
yes

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
no