### PR TITLE
bugfix(docker app): Clean the exited container by `--rm` after container stopped.

### DIFF
--- a/common/docker/docker_app.go
+++ b/common/docker/docker_app.go
@@ -80,7 +80,7 @@ func (b *App) RunDBApp(t *testing.T, option, keyword string) {
 	app.RunApp(nil)
 }
 
-// Free clear all running images
+// Free clear all running images, double check and recycle docker container.
 func (b *App) Free() {
 	if b.l1gethImg != nil {
 		_ = b.l1gethImg.Stop()

--- a/common/docker/docker_db.go
+++ b/common/docker/docker_db.go
@@ -82,7 +82,7 @@ func (i *ImgDB) Endpoint() string {
 }
 
 func (i *ImgDB) prepare() []string {
-	cmd := []string{"docker", "run", "--name", i.name, "-p", fmt.Sprintf("%d:5432", i.port)}
+	cmd := []string{"docker", "run", "--rm", "--name", i.name, "-p", fmt.Sprintf("%d:5432", i.port)}
 	envs := []string{
 		"-e", "POSTGRES_PASSWORD=" + i.password,
 		"-e", fmt.Sprintf("POSTGRES_DB=%s", i.dbName),

--- a/common/docker/docker_geth.go
+++ b/common/docker/docker_geth.go
@@ -125,7 +125,7 @@ func (i *ImgGeth) Stop() error {
 }
 
 func (i *ImgGeth) prepare() []string {
-	cmds := []string{"docker", "run", "--name", i.name}
+	cmds := []string{"docker", "run", "--rm", "--name", i.name}
 	var ports []string
 	if i.httpPort != 0 {
 		ports = append(ports, []string{"-p", strconv.Itoa(i.httpPort) + ":8545"}...)


### PR DESCRIPTION
1. Purpose or design rationale of this PR
This PR aims to reduce error(exit status 125) caused by `name collisions`(cased by the same container name).
This error occurs infrequently and was discovered by Peter, [`discuss connection`](https://scrollco.slack.com/archives/C02PKAQ2430/p1680711616408899).

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
No.

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
No.