### PR TITLE
fix `xargs` parameter deprecation for `-i` (portability to macOS)

### DIFF
--- a/build/dockerfiles/coordinator.Dockerfile
+++ b/build/dockerfiles/coordinator.Dockerfile
@@ -13,7 +13,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY ./common/libzkp/impl .
 RUN cargo build --release
-RUN find ./ | grep libzktrie.so | xargs -i cp {} /app/target/release/
+RUN find ./ | grep libzktrie.so | xargs -I{} cp {} /app/target/release/
 
 
 # Download Go dependencies

--- a/coordinator/Makefile
+++ b/coordinator/Makefile
@@ -16,7 +16,7 @@ test:
 libzkp:
 	cd ../common/libzkp/impl && cargo build --release && cp ./target/release/libzkp.a ../interface/
 	rm -rf ./verifier/lib && cp -r ../common/libzkp/interface ./verifier/lib
-	find ../common | grep libzktrie.so | xargs -i cp {} ./verifier/lib/
+	find ../common | grep libzktrie.so | xargs -I{} cp {} ./verifier/lib/
 
 coordinator: libzkp ## Builds the Coordinator instance.
 	go build -ldflags "-X scroll-tech/common/version.ZkVersion=${ZK_VERSION}" -o $(PWD)/build/bin/coordinator ./cmd

--- a/roller/Makefile
+++ b/roller/Makefile
@@ -12,7 +12,7 @@ endif
 libzkp:
 	cd ../common/libzkp/impl && cargo build --release && cp ./target/release/libzkp.a ../interface/
 	rm -rf ./prover/lib && cp -r ../common/libzkp/interface ./prover/lib
-	find ../common | grep libzktrie.so | xargs -i cp {} ./prover/lib/
+	find ../common | grep libzktrie.so | xargs -I{} cp {} ./prover/lib/
 
 roller: libzkp ## Build the Roller instance.
 	GOBIN=$(PWD)/build/bin go build -ldflags "-X scroll-tech/common/version.ZkVersion=${ZK_VERSION}" -o $(PWD)/build/bin/roller ./cmd


### PR DESCRIPTION
1. Purpose or design rationale of this PR
We were using a deprecated parameter to `xargs`, `-i`; in particular is it no longer supported on macOS's `xargs` version, `shell_cmds-279.100.3`. Using `-I{}` should fix this while keeping portability (confirmed on Ubuntu 22.04's `xargs` version, `4.8.0`).

2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 
no

3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
on