### PR TITLE
(don't merge)Revert "Revert "use load_or_create_params for now""

### DIFF
--- a/common/libzkp/impl/Cargo.toml
+++ b/common/libzkp/impl/Cargo.toml
@@ -15,7 +15,6 @@ poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "scro
 [dependencies]
 zkevm = { git = "https://github.com/scroll-tech/scroll-zkevm", rev="78ab7a7" }
 types = { git = "https://github.com/scroll-tech/scroll-zkevm", rev="78ab7a7" }
-halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
 
 log = "0.4"
 env_logger = "0.9.0"

--- a/common/libzkp/impl/src/prove.rs
+++ b/common/libzkp/impl/src/prove.rs
@@ -1,12 +1,11 @@
 use crate::utils::{c_char_to_str, c_char_to_vec, vec_to_c_char};
-use halo2_proofs::SerdeFormat;
 use libc::c_char;
 use std::cell::OnceCell;
 use std::panic;
 use std::ptr::null;
 use types::eth::BlockTrace;
 use zkevm::circuit::AGG_DEGREE;
-use zkevm::utils::{load_params, load_seed};
+use zkevm::utils::{load_or_create_params, load_seed};
 use zkevm::{circuit::DEGREE, prover::Prover};
 
 static mut PROVER: OnceCell<Prover> = OnceCell::new();
@@ -18,8 +17,9 @@ pub unsafe extern "C" fn init_prover(params_path: *const c_char, seed_path: *con
 
     let params_path = c_char_to_str(params_path);
     let seed_path = c_char_to_str(seed_path);
-    let params = load_params(params_path, *DEGREE, SerdeFormat::RawBytesUnchecked).unwrap();
-    let agg_params = load_params(params_path, *AGG_DEGREE, SerdeFormat::RawBytesUnchecked).unwrap();
+    // FIXME: will use load_params after https://github.com/scroll-tech/scroll-zkevm/pull/135/files
+    let params = load_or_create_params(params_path, *DEGREE).unwrap();
+    let agg_params = load_or_create_params(params_path, *AGG_DEGREE).unwrap();
     let seed = load_seed(seed_path).unwrap();
     let p = Prover::from_params_and_seed(params, agg_params, seed);
     PROVER.set(p).unwrap();

--- a/common/libzkp/impl/src/verify.rs
+++ b/common/libzkp/impl/src/verify.rs
@@ -1,12 +1,11 @@
 use crate::utils::{c_char_to_str, c_char_to_vec};
-use halo2_proofs::SerdeFormat;
 use libc::c_char;
 use std::fs::File;
 use std::io::Read;
 use std::panic;
 use zkevm::circuit::{AGG_DEGREE, DEGREE};
 use zkevm::prover::AggCircuitProof;
-use zkevm::utils::load_params;
+use zkevm::utils::load_or_create_params;
 use zkevm::verifier::Verifier;
 
 static mut VERIFIER: Option<&Verifier> = None;
@@ -21,9 +20,9 @@ pub unsafe extern "C" fn init_verifier(params_path: *const c_char, agg_vk_path: 
     let mut f = File::open(agg_vk_path).unwrap();
     let mut agg_vk = vec![];
     f.read_to_end(&mut agg_vk).unwrap();
-
-    let params = load_params(params_path, *DEGREE, SerdeFormat::RawBytesUnchecked).unwrap();
-    let agg_params = load_params(params_path, *AGG_DEGREE, SerdeFormat::RawBytesUnchecked).unwrap();
+    // FIXME: will use load_params after https://github.com/scroll-tech/scroll-zkevm/pull/135/files
+    let params = load_or_create_params(params_path, *DEGREE).unwrap();
+    let agg_params = load_or_create_params(params_path, *AGG_DEGREE).unwrap();
 
     let v = Box::new(Verifier::from_params(params, agg_params, Some(agg_vk)));
     VERIFIER = Some(Box::leak(v))


### PR DESCRIPTION
This reverts commit 00e280d0d5dd3d64c23e2815006ccc439051d624.

1. Purpose or design rationale of this PR


2. Does this PR involve a new deployment, and involve a new git tag & docker image tag? If so, has `tag` in `common/version.go` been updated? 


3. Is this PR a breaking change? If so, have it been attached a `breaking-change` label?
