### PR TITLE
build: rearrange docker build orders

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,15 +18,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push coordinator docker
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./build/dockerfiles/coordinator.Dockerfile
-        push: true
-        tags: scrolltech/coordinator:${{github.ref_name}}
-        # cache-from: type=gha,scope=${{ github.workflow }}
-        # cache-to: type=gha,scope=${{ github.workflow }}
     - name: Build and push event_watcher docker
       uses: docker/build-push-action@v2
       with:
@@ -79,5 +70,14 @@ jobs:
         file: ./build/dockerfiles/bridgehistoryapi-server.Dockerfile
         push: true
         tags: scrolltech/bridgehistoryapi-server:${{github.ref_name}}
+        # cache-from: type=gha,scope=${{ github.workflow }}
+        # cache-to: type=gha,scope=${{ github.workflow }}
+    - name: Build and push coordinator docker
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./build/dockerfiles/coordinator.Dockerfile
+        push: true
+        tags: scrolltech/coordinator:${{github.ref_name}}
         # cache-from: type=gha,scope=${{ github.workflow }}
         # cache-to: type=gha,scope=${{ github.workflow }}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

coordinator docker build takes too long.  we can publish other images first


## 2. Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


## 3. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
