### PR TITLE
feat(contracts): add a non-upgradeable version of `IScrollStandardERC20`

### DIFF
--- a/contracts/src/L2/gateways/L2CustomERC20Gateway.sol
+++ b/contracts/src/L2/gateways/L2CustomERC20Gateway.sol
@@ -9,7 +9,7 @@ import {IL2ERC20Gateway, L2ERC20Gateway} from "./L2ERC20Gateway.sol";
 import {IL2ScrollMessenger} from "../IL2ScrollMessenger.sol";
 import {IL1ERC20Gateway} from "../../L1/gateways/IL1ERC20Gateway.sol";
 import {ScrollGatewayBase, IScrollGateway} from "../../libraries/gateway/ScrollGatewayBase.sol";
-import {IScrollStandardERC20} from "../../libraries/token/IScrollStandardERC20.sol";
+import {IScrollERC20} from "../../libraries/token/IScrollERC20.sol";
 
 /// @title L2ERC20Gateway
 /// @notice The `L2ERC20Gateway` is used to withdraw custom ERC20 compatible tokens in layer 2 and
@@ -80,7 +80,7 @@ contract L2CustomERC20Gateway is OwnableUpgradeable, ScrollGatewayBase, L2ERC20G
         require(_l1Token != address(0), "token address cannot be 0");
         require(_l1Token == tokenMapping[_l2Token], "l1 token mismatch");
 
-        IScrollStandardERC20(_l2Token).mint(_to, _amount);
+        IScrollERC20(_l2Token).mint(_to, _amount);
 
         _doCallback(_to, _data);
 
@@ -126,7 +126,7 @@ contract L2CustomERC20Gateway is OwnableUpgradeable, ScrollGatewayBase, L2ERC20G
         }
 
         // 2. Burn token.
-        IScrollStandardERC20(_token).burn(_from, _amount);
+        IScrollERC20(_token).burn(_from, _amount);
 
         // 3. Generate message passed to L1StandardERC20Gateway.
         bytes memory _message = abi.encodeWithSelector(

--- a/contracts/src/L2/gateways/L2GatewayRouter.sol
+++ b/contracts/src/L2/gateways/L2GatewayRouter.sol
@@ -10,7 +10,6 @@ import {IL2ERC20Gateway} from "./IL2ERC20Gateway.sol";
 import {IL2ScrollMessenger} from "../IL2ScrollMessenger.sol";
 import {IL1ETHGateway} from "../../L1/gateways/IL1ETHGateway.sol";
 import {IScrollGateway} from "../../libraries/gateway/IScrollGateway.sol";
-import {IScrollStandardERC20} from "../../libraries/token/IScrollStandardERC20.sol";
 
 /// @title L2GatewayRouter
 /// @notice The `L2GatewayRouter` is the main entry for withdrawing Ether and ERC20 tokens.

--- a/contracts/src/L2/gateways/L2StandardERC20Gateway.sol
+++ b/contracts/src/L2/gateways/L2StandardERC20Gateway.sol
@@ -10,7 +10,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IL2ERC20Gateway, L2ERC20Gateway} from "./L2ERC20Gateway.sol";
 import {IL2ScrollMessenger} from "../IL2ScrollMessenger.sol";
 import {IL1ERC20Gateway} from "../../L1/gateways/IL1ERC20Gateway.sol";
-import {IScrollStandardERC20} from "../../libraries/token/IScrollStandardERC20.sol";
+import {IScrollERC20} from "../../libraries/token/IScrollERC20.sol";
 import {ScrollStandardERC20} from "../../libraries/token/ScrollStandardERC20.sol";
 import {IScrollStandardERC20Factory} from "../../libraries/token/IScrollStandardERC20Factory.sol";
 import {ScrollGatewayBase, IScrollGateway} from "../../libraries/gateway/ScrollGatewayBase.sol";
@@ -107,7 +107,7 @@ contract L2StandardERC20Gateway is Initializable, ScrollGatewayBase, L2ERC20Gate
             _deployL2Token(_deployData, _l1Token);
         }
 
-        IScrollStandardERC20(_l2Token).mint(_to, _amount);
+        IScrollERC20(_l2Token).mint(_to, _amount);
 
         _doCallback(_to, _callData);
 
@@ -138,7 +138,7 @@ contract L2StandardERC20Gateway is Initializable, ScrollGatewayBase, L2ERC20Gate
         require(_l1Token != address(0), "no corresponding l1 token");
 
         // 2. Burn token.
-        IScrollStandardERC20(_token).burn(_from, _amount);
+        IScrollERC20(_token).burn(_from, _amount);
 
         // 3. Generate message passed to L1StandardERC20Gateway.
         bytes memory _message = abi.encodeWithSelector(

--- a/contracts/src/libraries/token/IScrollERC20.sol
+++ b/contracts/src/libraries/token/IScrollERC20.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.0;
 
-import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
-import {IERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
 
 // The recommended ERC20 implementation for bridge token.
 // deployed in L2 when original token is on L1
 // deployed in L1 when original token is on L2
-interface IScrollStandardERC20Upgradeable is IERC20Upgradeable, IERC20PermitUpgradeable {
+interface IScrollERC20 is IERC20, IERC20Permit {
     /// @notice Return the address of Gateway the token belongs to.
     function gateway() external view returns (address);
 

--- a/contracts/src/libraries/token/IScrollERC20Upgradeable.sol
+++ b/contracts/src/libraries/token/IScrollERC20Upgradeable.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.0;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {IERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
 
 // The recommended ERC20 implementation for bridge token.
 // deployed in L2 when original token is on L1
 // deployed in L1 when original token is on L2
-interface IScrollStandardERC20 is IERC20, IERC20Permit {
+interface IScrollERC20Upgradeable is IERC20Upgradeable, IERC20PermitUpgradeable {
     /// @notice Return the address of Gateway the token belongs to.
     function gateway() external view returns (address);
 

--- a/contracts/src/libraries/token/ScrollStandardERC20.sol
+++ b/contracts/src/libraries/token/ScrollStandardERC20.sol
@@ -4,14 +4,21 @@ pragma solidity ^0.8.0;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
-import {IScrollStandardERC20Upgradeable} from "./IScrollStandardERC20Upgradeable.sol";
+import {IScrollERC20Upgradeable} from "./IScrollERC20Upgradeable.sol";
 import {IERC677Receiver} from "../callbacks/IERC677Receiver.sol";
 
-contract ScrollStandardERC20 is ERC20PermitUpgradeable, IScrollStandardERC20Upgradeable {
-    /// @inheritdoc IScrollStandardERC20Upgradeable
+/// @notice The `ScrollStandardERC20` is the ERC20 token contract created by
+/// `L2StandardERC20Gateway` when the first time the L1 ERC20 is bridged via
+/// `L1StandardERC20Gateway`.
+/// @dev The reason that `ScrollStandardERC20` inherits `IScrollERC20Upgradeable` is because we need
+/// to use the `initialize` function from the `ERC20PermitUpgradeable` to initialize the ERC20
+/// token. However, the token contract is NOT upgradable afterwards because
+/// `ScrollStandardERC20Factory` uses `Clones` to deploy the `ScrollStandardERC20` contract.
+contract ScrollStandardERC20 is ERC20PermitUpgradeable, IScrollERC20Upgradeable {
+    /// @inheritdoc IScrollERC20Upgradeable
     address public override gateway;
 
-    /// @inheritdoc IScrollStandardERC20Upgradeable
+    /// @inheritdoc IScrollERC20Upgradeable
     address public override counterpart;
 
     uint8 private decimals_;
@@ -73,12 +80,12 @@ contract ScrollStandardERC20 is ERC20PermitUpgradeable, IScrollStandardERC20Upgr
         return length > 0;
     }
 
-    /// @inheritdoc IScrollStandardERC20Upgradeable
+    /// @inheritdoc IScrollERC20Upgradeable
     function mint(address _to, uint256 _amount) external onlyGateway {
         _mint(_to, _amount);
     }
 
-    /// @inheritdoc IScrollStandardERC20Upgradeable
+    /// @inheritdoc IScrollERC20Upgradeable
     function burn(address _from, uint256 _amount) external onlyGateway {
         _burn(_from, _amount);
     }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR make `IScrollStandardERC20` both upgradeable and non-upgradeable.

## 2. Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


## 3. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
