### PR TITLE
fix(contracts): disallow committing a batch twice

### DIFF
--- a/contracts/src/L1/rollup/ScrollChain.sol
+++ b/contracts/src/L1/rollup/ScrollChain.sol
@@ -182,7 +182,7 @@ contract ScrollChain is OwnableUpgradeable, IScrollChain {
         uint256 _batchIndex = BatchHeaderV0Codec.batchIndex(batchPtr);
         uint256 _totalL1MessagesPoppedOverall = BatchHeaderV0Codec.totalL1MessagePopped(batchPtr);
         require(committedBatches[_batchIndex] == _parentBatchHash, "incorrect parent batch hash");
-        require(committedBatches[_batchIndex + 1] == 0, "batch has already been committed");
+        require(committedBatches[_batchIndex + 1] == 0, "batch already committed");
 
         // load `dataPtr` and reserve the memory region for chunk data hashes
         uint256 dataPtr;

--- a/contracts/src/test/ScrollChain.t.sol
+++ b/contracts/src/test/ScrollChain.t.sol
@@ -143,7 +143,7 @@ contract ScrollChainTest is DSTestPlus {
         assertGt(uint256(rollup.committedBatches(1)), 0);
 
         // batch is already committed, revert
-        hevm.expectRevert("batch has already been committed");
+        hevm.expectRevert("batch already committed");
         rollup.commitBatch(0, batchHeader0, chunks, new bytes(0));
     }
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Disallow committing a batch if it is already committed before. Must revert first.

## 2. Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


## 3. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
