### PR TITLE
feat(contracts): revert subsequent batches

### DIFF
--- a/contracts/src/L1/rollup/IScrollChain.sol
+++ b/contracts/src/L1/rollup/IScrollChain.sol
@@ -61,7 +61,8 @@ interface IScrollChain {
     /// @notice Revert a pending batch.
     /// @dev one can only revert unfinalized batches.
     /// @param batchHeader The header of current batch, see the encoding in comments of `commitBatch`.
-    function revertBatch(bytes calldata batchHeader) external;
+    /// @param count The number of subsequent batches to revert, including current batch.
+    function revertBatch(bytes calldata batchHeader, uint256 count) external;
 
     /// @notice Finalize a committed batch on layer 1.
     /// @param batchHeader The header of current batch, see the encoding in comments of `commitBatch.

--- a/contracts/src/L1/rollup/ScrollChain.sol
+++ b/contracts/src/L1/rollup/ScrollChain.sol
@@ -244,7 +244,9 @@ contract ScrollChain is OwnableUpgradeable, IScrollChain {
     }
 
     /// @inheritdoc IScrollChain
-    function revertBatch(bytes calldata _batchHeader) external onlyOwner {
+    function revertBatch(bytes calldata _batchHeader, uint256 _count) external onlyOwner {
+        require(_count > 0, "count must be nonzero");
+
         (uint256 memPtr, bytes32 _batchHash) = _loadBatchHeader(_batchHeader);
 
         // check batch hash
@@ -254,10 +256,11 @@ contract ScrollChain is OwnableUpgradeable, IScrollChain {
         // check finalization
         require(_batchIndex > lastFinalizedBatchIndex, "can only revert unfinalized batch");
 
-        while (true) {
+        while (_count > 0) {
             committedBatches[_batchIndex] = bytes32(0);
             unchecked {
                 _batchIndex += 1;
+                _count -= 1;
             }
 
             emit RevertBatch(_batchHash);

--- a/contracts/src/test/ScrollChain.t.sol
+++ b/contracts/src/test/ScrollChain.t.sol
@@ -401,7 +401,7 @@ contract ScrollChainTest is DSTestPlus {
         // caller not owner, revert
         hevm.startPrank(address(1));
         hevm.expectRevert("Ownable: caller is not the owner");
-        rollup.revertBatch(new bytes(89));
+        rollup.revertBatch(new bytes(89), 1);
         hevm.stopPrank();
 
         rollup.updateSequencer(address(this), true);
@@ -437,20 +437,24 @@ contract ScrollChainTest is DSTestPlus {
         // commit another batch
         rollup.commitBatch(0, batchHeader1, chunks, new bytes(0));
 
+        // count must be nonzero, revert
+        hevm.expectRevert("count must be nonzero");
+        rollup.revertBatch(batchHeader0, 0);
+
         // incorrect batch hash, revert
         hevm.expectRevert("incorrect batch hash");
         batchHeader1[0] = bytes1(uint8(1)); // change version to 1
-        rollup.revertBatch(batchHeader1);
+        rollup.revertBatch(batchHeader1, 1);
         batchHeader1[0] = bytes1(uint8(0)); // change back
 
         // can only revert unfinalized batch, revert
         hevm.expectRevert("can only revert unfinalized batch");
-        rollup.revertBatch(batchHeader0);
+        rollup.revertBatch(batchHeader0, 1);
 
         // succeed to revert next two pending batches.
         assertGt(uint256(rollup.committedBatches(1)), 0);
         assertGt(uint256(rollup.committedBatches(2)), 0);
-        rollup.revertBatch(batchHeader1);
+        rollup.revertBatch(batchHeader1, 2);
         assertEq(uint256(rollup.committedBatches(1)), 0);
         assertEq(uint256(rollup.committedBatches(2)), 0);
     }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR enables `revertBatch` to revert all subsequent batches.

## 2. Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


## 3. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
