### PR TITLE
ci(github): add conventionalcommits requirement into pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,15 @@
 
 ## 2. PR title
 
-Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), and should start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):
+Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):
 
 - [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
 - [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
-- [ ] docs: Documentation only changes
+- [ ] docs: Documentation-only changes
 - [ ] feat: A new feature
 - [ ] fix: A bug fix
 - [ ] perf: A code change that improves performance
-- [ ] refactor: A code change that neither fixes a bug nor adds a feature
+- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
 - [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - [ ] test: Adding missing tests or correcting existing tests
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Add conventionalcommits requirement. Uniswap also uses this https://github.com/Uniswap/interface#pr-title


## 2. Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


## 3. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
