### PR TITLE
fix: fix github "Intermediate Docker" workflow

### DIFF
--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -34,6 +34,12 @@ jobs:
     - name: Build
       run: |
         make all
+      environment:
+        GO_VERSION: ${{ inputs.GO_VERSION }}
+        RUST_VERSION: ${{ inputs.RUST_VERSION }}
     - name: Publish
       run: |
         make publish
+      environment:
+        GO_VERSION: ${{ inputs.GO_VERSION }}
+        RUST_VERSION: ${{ inputs.RUST_VERSION }}


### PR DESCRIPTION
### Purpose or design rationale of this PR

The github "Intermediate Docker" workflow yml miss setting ENV (`GO_VERSION` & `RUST_VERSION`, which are required in building the intermediate dockers) even if provided in workflow inputs. This PR fix the yml and feed workflow inputs into env.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
