### PR TITLE
feat(contracts): add fallback contract deployment script

### DIFF
--- a/contracts/scripts/foundry/DeployFallbackContracts.s.sol
+++ b/contracts/scripts/foundry/DeployFallbackContracts.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+
+import {Fallback} from "../../src/misc/Fallback.sol";
+
+contract DeployFallbackContracts is Script {
+    uint256 DEPLOYER_PRIVATE_KEY = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    uint256 NUM_CONTRACTS = vm.envUint("NUM_CONTRACTS");
+
+    function run() external {
+        vm.startBroadcast(DEPLOYER_PRIVATE_KEY);
+
+        for (uint256 ii = 0; ii < NUM_CONTRACTS; ++ii) {
+            Fallback fallbackContract = new Fallback();
+            logAddress("FALLBACK", address(fallbackContract));
+        }
+
+        vm.stopBroadcast();
+    }
+
+    function logAddress(string memory name, address addr) internal view {
+        console.log(string(abi.encodePacked(name, "=", vm.toString(address(addr)))));
+    }
+}


### PR DESCRIPTION
### Purpose or design rationale of this PR

If we have a contract (e.g. `GatewayRouter`) deployed on address `A` on L1, it is possible to accidentally send funds to this address on L2. @Turupawn suggested that we deploy a fallback contract for L1 address on L2 (and vice versa) to help users avoid such errors. 

The fallback contract was added in https://github.com/scroll-tech/scroll/pull/522. This PR adds the corresponding deployment script. Once this is merged, we can add this to the deployment flow in https://github.com/scroll-tech/testnet.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [X] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes
