### PR TITLE
fix(chunk proposer): treat L2 tx gas check as soft limit

### DIFF
--- a/bridge/internal/controller/watcher/chunk_proposer.go
+++ b/bridge/internal/controller/watcher/chunk_proposer.go
@@ -106,15 +106,6 @@ func (p *ChunkProposer) proposeChunk() (*bridgeTypes.Chunk, error) {
 		)
 	}
 
-	if totalTxGasUsed > p.maxTxGasPerChunk {
-		return nil, fmt.Errorf(
-			"the first block exceeds l2 tx gas limit; block number: %v, gas used: %v, max gas limit: %v",
-			firstBlock.Header.Number,
-			totalTxGasUsed,
-			p.maxTxGasPerChunk,
-		)
-	}
-
 	if totalL1CommitGas > p.maxL1CommitGasPerChunk {
 		return nil, fmt.Errorf(
 			"the first block exceeds l1 commit gas limit; block number: %v, commit gas: %v, max commit gas limit: %v",
@@ -130,6 +121,16 @@ func (p *ChunkProposer) proposeChunk() (*bridgeTypes.Chunk, error) {
 			firstBlock.Header.Number,
 			totalL1CommitCalldataSize,
 			p.maxL1CommitCalldataSizePerChunk,
+		)
+	}
+
+	// Check if the first block breaks any soft limits.
+	if totalTxGasUsed > p.maxTxGasPerChunk {
+		log.Warn(
+			"The first block in chunk exceeds l2 tx gas limit",
+			"block number", firstBlock.Header.Number,
+			"gas used", totalTxGasUsed,
+			"max gas limit", p.maxTxGasPerChunk,
 		)
 	}
 

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.0.3"
+var tag = "v4.0.4"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

Currently, `chunk-proposer` will get stuck if a block contains too much gas. However, we cannot specify an exact gas limit for the zkEVM, as it depends on the specific operation: We can process much more gas if it's a contract deployment, less if it's a series of keccak calls.

This PR changes this behaviour; now, if a block is over the L2 gas limit config, we will simply log a warning and continue with the chunk proposal process.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes
