### PR TITLE
set the solity version to greater than 0.8.16

### DIFF
--- a/contracts/src/External.sol
+++ b/contracts/src/External.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";

--- a/contracts/src/L1/L1ScrollMessenger.sol
+++ b/contracts/src/L1/L1ScrollMessenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 

--- a/contracts/src/L1/gateways/EnforcedTxGateway.sol
+++ b/contracts/src/L1/gateways/EnforcedTxGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ECDSAUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";

--- a/contracts/src/L1/gateways/L1CustomERC20Gateway.sol
+++ b/contracts/src/L1/gateways/L1CustomERC20Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/src/L1/gateways/L1ERC1155Gateway.sol
+++ b/contracts/src/L1/gateways/L1ERC1155Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC1155Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";

--- a/contracts/src/L1/gateways/L1ERC721Gateway.sol
+++ b/contracts/src/L1/gateways/L1ERC721Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";

--- a/contracts/src/L1/gateways/L1ETHGateway.sol
+++ b/contracts/src/L1/gateways/L1ETHGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/src/L1/gateways/L1GatewayRouter.sol
+++ b/contracts/src/L1/gateways/L1GatewayRouter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/src/L1/gateways/L1StandardERC20Gateway.sol
+++ b/contracts/src/L1/gateways/L1StandardERC20Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/L1/gateways/L1WETHGateway.sol
+++ b/contracts/src/L1/gateways/L1WETHGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/L1/gateways/usdc/L1USDCGateway.sol
+++ b/contracts/src/L1/gateways/usdc/L1USDCGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {L1CustomERC20Gateway} from "../L1CustomERC20Gateway.sol";
 

--- a/contracts/src/L1/rollup/L1MessageQueue.sol
+++ b/contracts/src/L1/rollup/L1MessageQueue.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/src/L1/rollup/L2GasPriceOracle.sol
+++ b/contracts/src/L1/rollup/L2GasPriceOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/src/L1/rollup/MultipleVersionRollupVerifier.sol
+++ b/contracts/src/L1/rollup/MultipleVersionRollupVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/src/L1/rollup/ScrollChain.sol
+++ b/contracts/src/L1/rollup/ScrollChain.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/src/L1/rollup/ScrollChainCommitmentVerifier.sol
+++ b/contracts/src/L1/rollup/ScrollChainCommitmentVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ScrollChain} from "./ScrollChain.sol";
 import {ZkTrieVerifier} from "../../libraries/verifier/ZkTrieVerifier.sol";

--- a/contracts/src/L2/L2ScrollMessenger.sol
+++ b/contracts/src/L2/L2ScrollMessenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 

--- a/contracts/src/L2/gateways/L2CustomERC20Gateway.sol
+++ b/contracts/src/L2/gateways/L2CustomERC20Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/src/L2/gateways/L2ERC1155Gateway.sol
+++ b/contracts/src/L2/gateways/L2ERC1155Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC1155Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC1155/IERC1155Upgradeable.sol";

--- a/contracts/src/L2/gateways/L2ERC721Gateway.sol
+++ b/contracts/src/L2/gateways/L2ERC721Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";

--- a/contracts/src/L2/gateways/L2ETHGateway.sol
+++ b/contracts/src/L2/gateways/L2ETHGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 

--- a/contracts/src/L2/gateways/L2GatewayRouter.sol
+++ b/contracts/src/L2/gateways/L2GatewayRouter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/src/L2/gateways/L2StandardERC20Gateway.sol
+++ b/contracts/src/L2/gateways/L2StandardERC20Gateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/L2/gateways/L2WETHGateway.sol
+++ b/contracts/src/L2/gateways/L2WETHGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
+++ b/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/src/L2/predeploys/L1BlockContainer.sol
+++ b/contracts/src/L2/predeploys/L1BlockContainer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {IL1BlockContainer} from "./IL1BlockContainer.sol";
 import {IL1GasPriceOracle} from "./IL1GasPriceOracle.sol";

--- a/contracts/src/L2/predeploys/L1GasPriceOracle.sol
+++ b/contracts/src/L2/predeploys/L1GasPriceOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableBase} from "../../libraries/common/OwnableBase.sol";
 import {IWhitelist} from "../../libraries/common/IWhitelist.sol";

--- a/contracts/src/L2/predeploys/L2MessageQueue.sol
+++ b/contracts/src/L2/predeploys/L2MessageQueue.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {AppendOnlyMerkleTree} from "../../libraries/common/AppendOnlyMerkleTree.sol";
 import {OwnableBase} from "../../libraries/common/OwnableBase.sol";

--- a/contracts/src/L2/predeploys/L2TxFeeVault.sol
+++ b/contracts/src/L2/predeploys/L2TxFeeVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {FeeVault} from "../../libraries/FeeVault.sol";
 

--- a/contracts/src/L2/predeploys/WETH9.sol
+++ b/contracts/src/L2/predeploys/WETH9.sol
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 // solhint-disable reason-string
 

--- a/contracts/src/L2/predeploys/Whitelist.sol
+++ b/contracts/src/L2/predeploys/Whitelist.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableBase} from "../../libraries/common/OwnableBase.sol";
 import {IWhitelist} from "../../libraries/common/IWhitelist.sol";

--- a/contracts/src/gas-swap/GasSwap.sol
+++ b/contracts/src/gas-swap/GasSwap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/contracts/src/libraries/oracle/SimpleGasOracle.sol
+++ b/contracts/src/libraries/oracle/SimpleGasOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/contracts/src/libraries/token/ScrollStandardERC20.sol
+++ b/contracts/src/libraries/token/ScrollStandardERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";

--- a/contracts/src/libraries/token/ScrollStandardERC20Factory.sol
+++ b/contracts/src/libraries/token/ScrollStandardERC20Factory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/src/misc/Fallback.sol
+++ b/contracts/src/misc/Fallback.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/mocks/MockCaller.sol
+++ b/contracts/src/mocks/MockCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 contract MockCaller {
     function callTarget(address to, bytes calldata data) external payable {

--- a/contracts/src/mocks/MockERC20.sol
+++ b/contracts/src/mocks/MockERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
 

--- a/contracts/src/mocks/MockGasSwapTarget.sol
+++ b/contracts/src/mocks/MockGasSwapTarget.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/mocks/MockPatriciaMerkleTrieVerifier.sol
+++ b/contracts/src/mocks/MockPatriciaMerkleTrieVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {PatriciaMerkleTrieVerifier} from "../libraries/verifier/PatriciaMerkleTrieVerifier.sol";
 

--- a/contracts/src/mocks/MockZkTrieVerifier.sol
+++ b/contracts/src/mocks/MockZkTrieVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ZkTrieVerifier} from "../libraries/verifier/ZkTrieVerifier.sol";
 

--- a/contracts/src/package.json
+++ b/contracts/src/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@scroll-tech/contracts",
     "description": "A library for interacting with Scroll contracts.",
-    "version": "0.0.4",
+    "version": "0.0.10",
     "repository": {
       "type": "git",
       "url": "https://github.com/scroll-tech/scroll.git"
@@ -18,6 +18,7 @@
         "L2/IL2ScrollMessenger.sol",
         "interfaces",
         "libraries/callbacks",
+        "libraries/constants",
         "libraries/gateway",
         "libraries/oracle/IGasOracle.sol",
         "libraries/token/IScrollERC20.sol",

--- a/contracts/src/test/L1CustomERC20Gateway.t.sol
+++ b/contracts/src/test/L1CustomERC20Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/L1ERC1155Gateway.t.sol
+++ b/contracts/src/test/L1ERC1155Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {MockERC1155} from "solmate/test/utils/mocks/MockERC1155.sol";

--- a/contracts/src/test/L1ERC721Gateway.t.sol
+++ b/contracts/src/test/L1ERC721Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC721} from "solmate/test/utils/mocks/MockERC721.sol";
 import {ERC721TokenReceiver} from "solmate/tokens/ERC721.sol";

--- a/contracts/src/test/L1ETHGateway.t.sol
+++ b/contracts/src/test/L1ETHGateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/contracts/src/test/L1GasPriceOracle.t.sol
+++ b/contracts/src/test/L1GasPriceOracle.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L1GatewayRouter.t.sol
+++ b/contracts/src/test/L1GatewayRouter.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/L1GatewayTestBase.t.sol
+++ b/contracts/src/test/L1GatewayTestBase.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L1ScrollMessengerTest.t.sol
+++ b/contracts/src/test/L1ScrollMessengerTest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L1StandardERC20Gateway.t.sol
+++ b/contracts/src/test/L1StandardERC20Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/L1WETHGateway.t.sol
+++ b/contracts/src/test/L1WETHGateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {WETH} from "solmate/tokens/WETH.sol";
 

--- a/contracts/src/test/L2CustomERC20Gateway.t.sol
+++ b/contracts/src/test/L2CustomERC20Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/L2ERC1155Gateway.t.sol
+++ b/contracts/src/test/L2ERC1155Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {MockERC1155} from "solmate/test/utils/mocks/MockERC1155.sol";

--- a/contracts/src/test/L2ERC721Gateway.t.sol
+++ b/contracts/src/test/L2ERC721Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {MockERC721} from "solmate/test/utils/mocks/MockERC721.sol";

--- a/contracts/src/test/L2ETHGateway.t.sol
+++ b/contracts/src/test/L2ETHGateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/contracts/src/test/L2GasPriceOracle.t.sol
+++ b/contracts/src/test/L2GasPriceOracle.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L2GatewayRouter.t.sol
+++ b/contracts/src/test/L2GatewayRouter.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/L2GatewayTestBase.t.sol
+++ b/contracts/src/test/L2GatewayTestBase.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L2MessageQueue.t.sol
+++ b/contracts/src/test/L2MessageQueue.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L2ScrollMessenger.t.sol
+++ b/contracts/src/test/L2ScrollMessenger.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L2StandardERC20Gateway.t.sol
+++ b/contracts/src/test/L2StandardERC20Gateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/L2TxFeeVault.t.sol
+++ b/contracts/src/test/L2TxFeeVault.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/L2USDCGateway.t.sol
+++ b/contracts/src/test/L2USDCGateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 

--- a/contracts/src/test/L2WETHGateway.t.sol
+++ b/contracts/src/test/L2WETHGateway.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {WETH} from "solmate/tokens/WETH.sol";
 

--- a/contracts/src/test/MultipleVersionRollupVerifier.t.sol
+++ b/contracts/src/test/MultipleVersionRollupVerifier.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/ScrollChain.t.sol
+++ b/contracts/src/test/ScrollChain.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/ScrollStandardERC20Factory.t.sol
+++ b/contracts/src/test/ScrollStandardERC20Factory.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {WETH} from "solmate/tokens/WETH.sol";

--- a/contracts/src/test/SimpleGasOracle.t.sol
+++ b/contracts/src/test/SimpleGasOracle.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {WETH} from "solmate/tokens/WETH.sol";

--- a/contracts/src/test/Whitelist.t.sol
+++ b/contracts/src/test/Whitelist.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {WETH} from "solmate/tokens/WETH.sol";

--- a/contracts/src/test/WithdrawTrieVerifier.t.sol
+++ b/contracts/src/test/WithdrawTrieVerifier.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 

--- a/contracts/src/test/mocks/MockERC1155Recipient.sol
+++ b/contracts/src/test/mocks/MockERC1155Recipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC1155TokenReceiver} from "solmate/tokens/ERC1155.sol";
 

--- a/contracts/src/test/mocks/MockERC721Recipient.sol
+++ b/contracts/src/test/mocks/MockERC721Recipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC721TokenReceiver} from "solmate/tokens/ERC721.sol";
 

--- a/contracts/src/test/mocks/MockGatewayRecipient.sol
+++ b/contracts/src/test/mocks/MockGatewayRecipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {IScrollGatewayCallback} from "../../libraries/callbacks/IScrollGatewayCallback.sol";
 

--- a/contracts/src/test/mocks/MockRollupVerifier.sol
+++ b/contracts/src/test/mocks/MockRollupVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {IRollupVerifier} from "../../libraries/verifier/IRollupVerifier.sol";
 

--- a/contracts/src/test/mocks/MockScrollChain.sol
+++ b/contracts/src/test/mocks/MockScrollChain.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {ScrollChain} from "../../L1/rollup/ScrollChain.sol";
 

--- a/contracts/src/test/mocks/MockScrollMessenger.sol
+++ b/contracts/src/test/mocks/MockScrollMessenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {IScrollMessenger} from "../../libraries/IScrollMessenger.sol";
 

--- a/contracts/src/test/mocks/MockZkEvmVerifier.sol
+++ b/contracts/src/test/mocks/MockZkEvmVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {IZkEvmVerifier} from "../../libraries/verifier/IZkEvmVerifier.sol";
 

--- a/contracts/src/test/mocks/tokens/FeeOnTransferToken.sol
+++ b/contracts/src/test/mocks/tokens/FeeOnTransferToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 

--- a/contracts/src/test/mocks/tokens/TransferReentrantToken.sol
+++ b/contracts/src/test/mocks/tokens/TransferReentrantToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity =0.8.16;
+pragma solidity ^0.8.16;
 
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

Changed the contracts solidity files version from `=0.8.16` to `^0.8.16` so developers can also use version of solidity greater than `0.8.16` in the npm library.
Also added the new cerated `"libraries/constants"` to the npm library because it's a dependency from the gateway contracts.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
