### PR TITLE
fix(build): update verifier lib path

### DIFF
--- a/build/dockerfiles/coordinator.Dockerfile
+++ b/build/dockerfiles/coordinator.Dockerfile
@@ -34,17 +34,17 @@ RUN go mod download -x
 # Build coordinator
 FROM base as builder
 COPY . .
-RUN cp -r ./common/libzkp/interface ./coordinator/verifier/lib
-COPY --from=zkp-builder /app/target/release/libzkp.so ./coordinator/verifier/lib/
-COPY --from=zkp-builder /app/target/release/libzktrie.so ./coordinator/verifier/lib/
-RUN cd ./coordinator && go build -v -p 4 -o /bin/coordinator ./cmd && mv verifier/lib /bin/
+RUN cp -r ./common/libzkp/interface ./coordinator/internal/logic/verifier/lib
+COPY --from=zkp-builder /app/target/release/libzkp.so ./coordinator/internal/logic/verifier/lib/
+COPY --from=zkp-builder /app/target/release/libzktrie.so ./coordinator/internal/logic/verifier/lib/
+RUN cd ./coordinator && go build -v -p 4 -o /bin/coordinator ./cmd && mv internal/logic/verifier/lib /bin/
 
 # Pull coordinator into a second stage deploy alpine container
 FROM ubuntu:20.04
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/src/coordinator/verifier/lib
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/src/coordinator/internal/logic/verifier/lib
 # ENV CHAIN_ID=534353
-RUN mkdir -p /src/coordinator/verifier/lib
-COPY --from=builder /bin/lib /src/coordinator/verifier/lib
+RUN mkdir -p /src/coordinator/internal/logic/verifier/lib
+COPY --from=builder /bin/lib /src/coordinator/internal/logic/verifier/lib
 COPY --from=builder /bin/coordinator /bin/
 
 

--- a/build/run_tests.sh
+++ b/build/run_tests.sh
@@ -3,7 +3,7 @@ set -uex
 
 profile_name=$1
 
-exclude_dirs=("scroll-tech/bridge/cmd" "scroll-tech/bridge/tests" "scroll-tech/bridge/mock_bridge" "scroll-tech/coordinator/cmd" "scroll-tech/coordinator/verifier")
+exclude_dirs=("scroll-tech/bridge/cmd" "scroll-tech/bridge/tests" "scroll-tech/bridge/mock_bridge" "scroll-tech/coordinator/cmd" "scroll-tech/coordinator/internal/logic/verifier")
 
 all_packages=$(go list ./... | grep -v "^scroll-tech/${profile_name}$")
 coverpkg="scroll-tech/${profile_name}"

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.0.27"
+var tag = "v4.0.28"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

`coordinator/verifier` was moved in https://github.com/scroll-tech/scroll/pull/521. However, some related build instructions were not updated.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes
