### PR TITLE
fix: handle importGenesisBatch in bridge-history calldata decoder

### DIFF
--- a/bridge-history-api/utils/utils_test.go
+++ b/bridge-history-api/utils/utils_test.go
@@ -33,4 +33,11 @@ func TestGetBatchRangeFromCalldataV2(t *testing.T) {
 	assert.Equal(t, start, uint64(10))
 	assert.Equal(t, finish, uint64(20))
 	assert.Equal(t, batchIndex, uint64(2))
+
+	// genesis batch
+	batchIndex, start, finish, err = utils.GetBatchRangeFromCalldataV2(common.Hex2Bytes("3fdeecb200000000000000000000000000000000000000000000000000000000000000402dcb5308098d24a37fc1487a229fcedb09fa4343ede39cbad365bc925535bb09000000000000000000000000000000000000000000000000000000000000005900000000000000000000000000000000000000000000000000c252bc9780c4d83cf11f14b8cd03c92c4d18ce07710ba836d31d12da216c8330000000000000000000000000000000000000000000000000000000000000000000000000000000"))
+	assert.NoError(t, err)
+	assert.Equal(t, start, uint64(0))
+	assert.Equal(t, finish, uint64(0))
+	assert.Equal(t, batchIndex, uint64(0))
 }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.1.8"
+var tag = "v4.1.9"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

Previously, we'd need to make sure that `bridge-history-cross-msg-fetcher` starts indexing from **after** the genesis import transaction, otherwise it would fail with an error like this:

```
fetch batch info at beginning failed:    err="abi: cannot marshal in to go slice: offset 20713321202029229986436779211628261885493806088121370744442237493162838178601 would go over slice boundary (len=192)"
```

The reason is that we're collecting `CommitBatch` events, that can be emitted by two functions of `ScrollChain`: `commitBatch` and `importGenesisBatch`. This PR adds decoder support for the latter.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes
