### PR TITLE
ci(github): temp fix `gacts/install-geth-tools`

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -43,6 +43,8 @@ jobs:
         version: '0.8.16'
     - name: Install Geth Tools
       uses: gacts/install-geth-tools@v1
+      with:
+        version: 1.10.19
     - name: Lint
       working-directory: 'bridge'
       run: |
@@ -92,6 +94,8 @@ jobs:
         version: '0.8.16'
     - name: Install Geth Tools
       uses: gacts/install-geth-tools@v1
+      with:
+        version: 1.10.19
     - name: Build prerequisites
       run: |
         make dev_docker

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -88,6 +88,8 @@ jobs:
         version: '0.8.16'
     - name: Install Geth Tools
       uses: gacts/install-geth-tools@v1
+      with:
+        version: 1.10.19
     - name: Build prerequisites
       run: |
         make dev_docker

--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -104,6 +104,8 @@ jobs:
         version: '0.8.16'
     - name: Install Geth Tools
       uses: gacts/install-geth-tools@v1
+      with:
+        version: 1.10.19
     - name: Build prerequisites
       run: |
         make dev_docker

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -81,6 +81,8 @@ jobs:
         version: '0.8.16'
     - name: Install Geth Tools
       uses: gacts/install-geth-tools@v1
+      with:
+        version: 1.10.19
     - name: Build prerequisites
       run: |
         make dev_docker

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -33,6 +33,8 @@ jobs:
         version: '0.8.16'
     - name: Install Geth Tools
       uses: gacts/install-geth-tools@v1
+      with:
+        version: 1.10.19
     - name: Build prerequisites
       run: |
         make dev_docker


### PR DESCRIPTION
### Purpose or design rationale of this PR

There might be something wrong with `gacts/install-geth-tools@v1`'s release.

`1.12.0` works  (see https://github.com/scroll-tech/scroll/pull/765)
<img width="734" alt="image" src="https://github.com/scroll-tech/scroll/assets/37070449/eaf27e03-3bc9-4f3c-8e8b-7a9a7598e6e4">

but `1.12.1` not found (see https://github.com/scroll-tech/scroll/pull/769)
<img width="674" alt="image" src="https://github.com/scroll-tech/scroll/assets/37070449/867b85b3-cc42-4a17-8fbc-6a99a50df791">

This PR pin the geth tool version as  `1.12.0`  to avoid such an issue.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes
