### PR TITLE
fix(contracts): OZ-N06 Unpinned Compiler Version

### DIFF
--- a/contracts/src/misc/ScrollOwner.sol
+++ b/contracts/src/misc/ScrollOwner.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity =0.8.16;
 
 import {AccessControlEnumerable} from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR partially fixed the issue reported by Openzepplin (**N-06 Unpinned Compiler Version**) during **ScrollOwner and Rate Limiter** audit. The following are the details:

> `ScrollOwner.sol` , `IETHRateLimiter.sol` and `ITokenRateLimiter.sol` use an unpinned Solidity version.
>
> Consider pinning the version of the Solidity compiler to match the pinned version in the other contracts. This should help prevent the introduction of unexpected bugs due to incompatible future releases.

The interface is unpinned for future compatible.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` tag to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
