### PR TITLE
fix(l1-watcher): soft delete blocks when reorg

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.2.21"
+var tag = "v4.2.22"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -99,7 +99,7 @@ func TestL1BlockOrm(t *testing.T) {
 	// mock blocks
 	block1 := L1Block{Number: 1, Hash: "hash1"}
 	block2 := L1Block{Number: 2, Hash: "hash2"}
-	block2AfterReorg := L1Block{Number: 2, Hash: "hash3"}
+	block1AfterReorg := L1Block{Number: 1, Hash: "hash3"}
 
 	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block1, block2})
 	assert.NoError(t, err)
@@ -115,23 +115,22 @@ func TestL1BlockOrm(t *testing.T) {
 	assert.Equal(t, "hash2", blocks[1].Hash)
 
 	// reorg handling: insert another block with same height and different hash
-	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block2AfterReorg})
+	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block1AfterReorg})
 	assert.NoError(t, err)
 
 	blocks, err = l1BlockOrm.GetL1Blocks(context.Background(), map[string]interface{}{})
 	assert.NoError(t, err)
-	assert.Len(t, blocks, 2)
-	assert.Equal(t, "hash1", blocks[0].Hash)
-	assert.Equal(t, "hash3", blocks[1].Hash)
+	assert.Len(t, blocks, 1)
+	assert.Equal(t, "hash3", blocks[0].Hash)
 
-	err = l1BlockOrm.UpdateL1GasOracleStatusAndOracleTxHash(context.Background(), "hash1", types.GasOracleImported, "txhash1")
+	err = l1BlockOrm.UpdateL1GasOracleStatusAndOracleTxHash(context.Background(), "hash3", types.GasOracleImported, "txhash3")
 	assert.NoError(t, err)
 
 	updatedBlocks, err := l1BlockOrm.GetL1Blocks(context.Background(), map[string]interface{}{})
 	assert.NoError(t, err)
-	assert.Len(t, updatedBlocks, 2)
+	assert.Len(t, updatedBlocks, 1)
 	assert.Equal(t, types.GasOracleImported, types.GasOracleStatus(updatedBlocks[0].GasOracleStatus))
-	assert.Equal(t, "txhash1", updatedBlocks[0].OracleTxHash)
+	assert.Equal(t, "txhash3", updatedBlocks[0].OracleTxHash)
 }
 
 func TestL2BlockOrm(t *testing.T) {

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -99,38 +99,41 @@ func TestL1BlockOrm(t *testing.T) {
 	// mock blocks
 	block1 := L1Block{Number: 1, Hash: "hash1"}
 	block2 := L1Block{Number: 2, Hash: "hash2"}
-	block1AfterReorg := L1Block{Number: 1, Hash: "hash3"}
+	block3 := L1Block{Number: 3, Hash: "hash3"}
+	block2AfterReorg := L1Block{Number: 2, Hash: "hash2-reorg"}
 
-	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block1, block2})
+	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block1, block2, block3})
 	assert.NoError(t, err)
 
 	height, err := l1BlockOrm.GetLatestL1BlockHeight(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(2), height)
+	assert.Equal(t, uint64(3), height)
 
 	blocks, err := l1BlockOrm.GetL1Blocks(context.Background(), map[string]interface{}{})
 	assert.NoError(t, err)
-	assert.Len(t, blocks, 2)
+	assert.Len(t, blocks, 3)
 	assert.Equal(t, "hash1", blocks[0].Hash)
 	assert.Equal(t, "hash2", blocks[1].Hash)
+	assert.Equal(t, "hash3", blocks[2].Hash)
 
 	// reorg handling: insert another block with same height and different hash
-	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block1AfterReorg})
+	err = l1BlockOrm.InsertL1Blocks(context.Background(), []L1Block{block2AfterReorg})
 	assert.NoError(t, err)
 
 	blocks, err = l1BlockOrm.GetL1Blocks(context.Background(), map[string]interface{}{})
 	assert.NoError(t, err)
-	assert.Len(t, blocks, 1)
-	assert.Equal(t, "hash3", blocks[0].Hash)
+	assert.Len(t, blocks, 2)
+	assert.Equal(t, "hash1", blocks[0].Hash)
+	assert.Equal(t, "hash2-reorg", blocks[1].Hash)
 
-	err = l1BlockOrm.UpdateL1GasOracleStatusAndOracleTxHash(context.Background(), "hash3", types.GasOracleImported, "txhash3")
+	err = l1BlockOrm.UpdateL1GasOracleStatusAndOracleTxHash(context.Background(), "hash1", types.GasOracleImported, "txhash1")
 	assert.NoError(t, err)
 
 	updatedBlocks, err := l1BlockOrm.GetL1Blocks(context.Background(), map[string]interface{}{})
 	assert.NoError(t, err)
-	assert.Len(t, updatedBlocks, 1)
+	assert.Len(t, updatedBlocks, 2)
 	assert.Equal(t, types.GasOracleImported, types.GasOracleStatus(updatedBlocks[0].GasOracleStatus))
-	assert.Equal(t, "txhash3", updatedBlocks[0].OracleTxHash)
+	assert.Equal(t, "txhash1", updatedBlocks[0].OracleTxHash)
 }
 
 func TestL2BlockOrm(t *testing.T) {


### PR DESCRIPTION
### Purpose or design rationale of this PR

When reorg happened in block number x, soft delete blocks with number `>= x` in L1Block.

Btw, if we want to maintain L1Block table the same as canonical chain, reorg handling logic needs to be added in L1 watcher. e.g., finding the first mismatch parent hash when getting block height. But since L1Block table is only used in storing base fee now, it's not urgent to add this feature.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
