### PR TITLE
fix(contracts): OZ-M01 `L2USDCGateway` Is Missing Rate Limiter Functionality

### DIFF
--- a/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
+++ b/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
@@ -158,6 +158,9 @@ contract L2USDCGateway is L2ERC20Gateway, IUSDCDestinationBridge {
         }
         require(_data.length == 0, "call is not allowed");
 
+        // rate limit
+        _addUsedAmount(_token, _amount);
+
         // 2. Transfer token into this contract.
         IERC20Upgradeable(_token).safeTransferFrom(_from, address(this), _amount);
         IFiatToken(_token).burn(_amount);


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fixed the issue reported by Openzepplin (**M-01 L2USDCGateway Is Missing Rate Limiter Functionality**) during **Scroll USDC Gateway** audit. The following are the details:

> The `L1USDCGateway` contract inherits from `L1ERC20Gateway` . When a user initiates a deposit, the `_transferERC20In` function is called, which in turn invokes the rate limiter function `_addUsedAmount` . However, the `L2USDCGateway` contract inherits from `L2ERC20Gateway` which does not call the rate limiter `_addUsedAmount` function. This means that USDC withdrawals will not be subject to rate limiting.
>
> Consider ensuring that `_addUsedAmount` is called when users make a withdrawal in USDC.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
