### PR TITLE
docs(contracts): OZ-L01 Misleading Comment

### DIFF
--- a/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
+++ b/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
@@ -169,7 +169,7 @@ contract L2USDCGateway is L2ERC20Gateway, IUSDCDestinationBridge {
             (_l1USDC, _token, _from, _to, _amount, _data)
         );
 
-        // 4. Send message to L1ScrollMessenger.
+        // 4. Send message to L2ScrollMessenger.
         IL2ScrollMessenger(messenger).sendMessage{value: msg.value}(counterpart, 0, _message, _gasLimit);
 
         emit WithdrawERC20(_l1USDC, _token, _from, _to, _amount, _data);


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fixed the issue reported by Openzepplin (**L-01 Misleading Comment**) during **Scroll USDC Gateway** audit. The following are the details:

> The comment in line 172 of the `L2USDCGateway` contract should say `L2ScrollMessenger` instead of `L1ScrollMessenger`.
>
> Consider resolving this instance of incorrect documentation to improve the clarity and readability of the codebase.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] docs: Documentation-only changes

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
