### PR TITLE
fix(contracts): OZ-L02 Lack of `gap` Variable

### DIFF
--- a/contracts/src/libraries/gateway/CCTPGatewayBase.sol
+++ b/contracts/src/libraries/gateway/CCTPGatewayBase.sol
@@ -43,6 +43,9 @@ abstract contract CCTPGatewayBase is ScrollGatewayBase {
     /// @notice Mapping from destination domain CCTP nonce to status.
     mapping(uint256 => CCTPMessageStatus) public status;
 
+    /// @dev The storage slots for future usage.
+    uint256[47] private __gap;
+
     /***************
      * Constructor *
      ***************/


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fixed the issue reported by Openzepplin (L-01 Misleading Comment) during Scroll USDC Gateway audit. The following are the details:

> The `CCTPGatewayBase` contract does not contain a `gap` variable although it is upgradeable.
>
> Consider adding a gap variable following OpenZeppelin's upgradeable contracts guide to avoid future storage collisions.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x]  fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
