### PR TITLE
fix(contracts): OZ-N01 Unused Imports

### DIFF
--- a/contracts/src/L1/gateways/L1ERC20Gateway.sol
+++ b/contracts/src/L1/gateways/L1ERC20Gateway.sol
@@ -9,8 +9,6 @@ import {IL1ERC20Gateway} from "./IL1ERC20Gateway.sol";
 import {IL1GatewayRouter} from "./IL1GatewayRouter.sol";
 
 import {IL2ERC20Gateway} from "../../L2/gateways/IL2ERC20Gateway.sol";
-import {IScrollMessenger} from "../../libraries/IScrollMessenger.sol";
-import {ScrollConstants} from "../../libraries/constants/ScrollConstants.sol";
 import {ScrollGatewayBase} from "../../libraries/gateway/ScrollGatewayBase.sol";
 import {IMessageDropCallback} from "../../libraries/callbacks/IMessageDropCallback.sol";
 

--- a/contracts/src/L1/gateways/usdc/L1USDCGateway.sol
+++ b/contracts/src/L1/gateways/usdc/L1USDCGateway.sol
@@ -2,9 +2,6 @@
 
 pragma solidity =0.8.16;
 
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
-
 import {IFiatToken} from "../../../interfaces/IFiatToken.sol";
 import {IUSDCBurnableSourceBridge} from "../../../interfaces/IUSDCBurnableSourceBridge.sol";
 import {IL2ERC20Gateway} from "../../../L2/gateways/IL2ERC20Gateway.sol";

--- a/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
+++ b/contracts/src/L2/gateways/usdc/L2USDCGateway.sol
@@ -12,7 +12,7 @@ import {IL1ERC20Gateway} from "../../../L1/gateways/IL1ERC20Gateway.sol";
 import {IL2ScrollMessenger} from "../../IL2ScrollMessenger.sol";
 import {IL2ERC20Gateway} from "../IL2ERC20Gateway.sol";
 
-import {ScrollGatewayBase, IScrollGateway} from "../../../libraries/gateway/ScrollGatewayBase.sol";
+import {ScrollGatewayBase} from "../../../libraries/gateway/ScrollGatewayBase.sol";
 import {L2ERC20Gateway} from "../L2ERC20Gateway.sol";
 
 /// @title L2USDCGateway


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR partially fixed the issue reported by Openzepplin (**N-01 Unused Imports**) during **Scroll USDC Gateway** audit. The following are the details:

> Throughout the codebase there are imports that are unused and could be removed. For instance:
> + Import `IScrollMessenger` of `L1ERC20Gateway.sol`
> + Import `ScrollConstants` of `L1ERC20Gateway.sol`
> + Import `OwnableUpgradeable` of `L1USDCGateway.sol`
> + Import `IERC20Upgradeable` of `L1USDCGateway.sol`
> + Import `IL1ERC20Gateway` of `L1USDCGateway.sol`
> + Import `IL2ERC20Gateway` of `L2USDCGateway.sol`
> + Import `IScrollGateway` of `L2USDCGateway.sol`
>
> Consider removing unused imports to improve the overall clarity and readability of the codebase.

The `IERC20Upgradeable` of `L1USDCGateway.sol` and `IL2ERC20Gateway` of `L2USDCGateway.sol` are used for `inheritdoc`.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
