### PR TITLE
test(rollup-relayer): add chunk and batch proposer limit tests

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.2.24"
+var tag = "v4.2.25"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/watcher/batch_proposer.go
+++ b/rollup/internal/controller/watcher/batch_proposer.go
@@ -48,7 +48,8 @@ func NewBatchProposer(ctx context.Context, cfg *config.BatchProposerConfig, db *
 		"maxChunkNumPerBatch", cfg.MaxChunkNumPerBatch,
 		"maxL1CommitGasPerBatch", cfg.MaxL1CommitGasPerBatch,
 		"maxL1CommitCalldataSizePerBatch", cfg.MaxL1CommitCalldataSizePerBatch,
-		"batchTimeoutSec", cfg.BatchTimeoutSec)
+		"batchTimeoutSec", cfg.BatchTimeoutSec,
+		"gasCostIncreaseMultiplier", cfg.GasCostIncreaseMultiplier)
 
 	return &BatchProposer{
 		ctx:                             ctx,
@@ -178,6 +179,7 @@ func (p *BatchProposer) proposeBatchChunks() ([]*orm.Chunk, *types.BatchMeta, er
 	// Add extra gas costs
 	totalL1CommitGas += 4 * 2100                     // 4 one-time cold sload for commitBatch
 	totalL1CommitGas += 20000                        // 1 time sstore
+	totalL1CommitGas += 21000                        // base fee for tx
 	totalL1CommitGas += types.CalldataNonZeroByteGas // version in calldata
 
 	// adjusting gas:

--- a/rollup/internal/controller/watcher/batch_proposer_test.go
+++ b/rollup/internal/controller/watcher/batch_proposer_test.go
@@ -13,54 +13,118 @@ import (
 	"scroll-tech/rollup/internal/orm"
 )
 
-// TODO: Add unit tests that the limits are enforced correctly.
-func testBatchProposer(t *testing.T) {
-	db := setupDB(t)
-	defer database.CloseDB(db)
+func testBatchProposerLimits(t *testing.T) {
+	tests := []struct {
+		name                       string
+		maxChunkNum                uint64
+		maxL1CommitGas             uint64
+		maxL1CommitCalldataSize    uint32
+		expectedBatchesLen         int
+		expectedChunksInFirstBatch uint64
+	}{
+		{
+			name:                       "Timeout",
+			maxChunkNum:                10,
+			maxL1CommitGas:             50000000000,
+			maxL1CommitCalldataSize:    1000000,
+			expectedBatchesLen:         1,
+			expectedChunksInFirstBatch: 2,
+		},
+		{
+			name:                    "MaxL1CommitGasPerBatchIs0",
+			maxChunkNum:             10,
+			maxL1CommitGas:          0,
+			maxL1CommitCalldataSize: 1000000,
+			expectedBatchesLen:      0,
+		},
+		{
+			name:                    "MaxL1CommitCalldataSizePerBatchIs0",
+			maxChunkNum:             10,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 0,
+			expectedBatchesLen:      0,
+		},
+		{
+			name:                       "MaxChunkNumPerBatchIs1",
+			maxChunkNum:                1,
+			maxL1CommitGas:             50000000000,
+			maxL1CommitCalldataSize:    1000000,
+			expectedBatchesLen:         1,
+			expectedChunksInFirstBatch: 1,
+		},
+		{
+			name:                       "MaxL1CommitGasPerBatchIsFirstChunk",
+			maxChunkNum:                1,
+			maxL1CommitGas:             100000,
+			maxL1CommitCalldataSize:    1000000,
+			expectedBatchesLen:         1,
+			expectedChunksInFirstBatch: 1,
+		},
+		{
+			name:                       "MaxL1CommitCalldataSizePerBatchIsFirstChunk",
+			maxChunkNum:                1,
+			maxL1CommitGas:             50000000000,
+			maxL1CommitCalldataSize:    298,
+			expectedBatchesLen:         1,
+			expectedChunksInFirstBatch: 1,
+		},
+	}
 
-	l2BlockOrm := orm.NewL2Block(db)
-	err := l2BlockOrm.InsertL2Blocks(context.Background(), []*types.WrappedBlock{wrappedBlock1, wrappedBlock2})
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupDB(t)
+			defer database.CloseDB(db)
 
-	cp := NewChunkProposer(context.Background(), &config.ChunkProposerConfig{
-		MaxBlockNumPerChunk:             100,
-		MaxTxNumPerChunk:                10000,
-		MaxL1CommitGasPerChunk:          50000000000,
-		MaxL1CommitCalldataSizePerChunk: 1000000,
-		MaxRowConsumptionPerChunk:       1048319,
-		ChunkTimeoutSec:                 300,
-	}, db, nil)
-	cp.TryProposeChunk()
+			l2BlockOrm := orm.NewL2Block(db)
+			err := l2BlockOrm.InsertL2Blocks(context.Background(), []*types.WrappedBlock{wrappedBlock1, wrappedBlock2})
+			assert.NoError(t, err)
 
-	bp := NewBatchProposer(context.Background(), &config.BatchProposerConfig{
-		MaxChunkNumPerBatch:             10,
-		MaxL1CommitGasPerBatch:          50000000000,
-		MaxL1CommitCalldataSizePerBatch: 1000000,
-		BatchTimeoutSec:                 300,
-	}, db, nil)
-	bp.TryProposeBatch()
+			cp := NewChunkProposer(context.Background(), &config.ChunkProposerConfig{
+				MaxBlockNumPerChunk:             1,
+				MaxTxNumPerChunk:                10000,
+				MaxL1CommitGasPerChunk:          50000000000,
+				MaxL1CommitCalldataSizePerChunk: 1000000,
+				MaxRowConsumptionPerChunk:       1000000,
+				ChunkTimeoutSec:                 300,
+				GasCostIncreaseMultiplier:       1.2,
+			}, db, nil)
+			cp.TryProposeChunk() // chunk1 contains block1
+			cp.TryProposeChunk() // chunk2 contains block2
 
-	batchOrm := orm.NewBatch(db)
-	// get all batches.
-	batches, err := batchOrm.GetBatches(context.Background(), map[string]interface{}{}, []string{}, 0)
-	assert.NoError(t, err)
-	assert.Len(t, batches, 1)
-	assert.Equal(t, uint64(0), batches[0].StartChunkIndex)
-	assert.Equal(t, uint64(0), batches[0].EndChunkIndex)
-	assert.Equal(t, types.RollupPending, types.RollupStatus(batches[0].RollupStatus))
-	assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(batches[0].ProvingStatus))
+			chunkOrm := orm.NewChunk(db)
+			chunks, err := chunkOrm.GetChunksInRange(context.Background(), 0, 1)
+			assert.NoError(t, err)
+			assert.Equal(t, uint64(6006), chunks[0].TotalL1CommitGas)
+			assert.Equal(t, uint32(298), chunks[0].TotalL1CommitCalldataSize)
+			assert.Equal(t, uint64(93982), chunks[1].TotalL1CommitGas)
+			assert.Equal(t, uint32(5735), chunks[1].TotalL1CommitCalldataSize)
 
-	chunkOrm := orm.NewChunk(db)
-	dbChunks, err := chunkOrm.GetChunksInRange(context.Background(), 0, 0)
-	assert.NoError(t, err)
-	assert.Len(t, batches, 1)
-	assert.Equal(t, batches[0].Hash, dbChunks[0].BatchHash)
-	assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(dbChunks[0].ProvingStatus))
+			bp := NewBatchProposer(context.Background(), &config.BatchProposerConfig{
+				MaxChunkNumPerBatch:             tt.maxChunkNum,
+				MaxL1CommitGasPerBatch:          tt.maxL1CommitGas,
+				MaxL1CommitCalldataSizePerBatch: tt.maxL1CommitCalldataSize,
+				BatchTimeoutSec:                 300,
+				GasCostIncreaseMultiplier:       1.2,
+			}, db, nil)
+			bp.TryProposeBatch()
 
-	blockOrm := orm.NewL2Block(db)
-	blocks, err := blockOrm.GetL2Blocks(context.Background(), map[string]interface{}{}, []string{}, 0)
-	assert.NoError(t, err)
-	assert.Len(t, blocks, 2)
-	assert.Equal(t, dbChunks[0].Hash, blocks[0].ChunkHash)
-	assert.Equal(t, dbChunks[0].Hash, blocks[1].ChunkHash)
+			batchOrm := orm.NewBatch(db)
+			batches, err := batchOrm.GetBatches(context.Background(), map[string]interface{}{}, []string{}, 0)
+			assert.NoError(t, err)
+			assert.Len(t, batches, tt.expectedBatchesLen)
+			if tt.expectedBatchesLen > 0 {
+				assert.Equal(t, uint64(0), batches[0].StartChunkIndex)
+				assert.Equal(t, tt.expectedChunksInFirstBatch-1, batches[0].EndChunkIndex)
+				assert.Equal(t, types.RollupPending, types.RollupStatus(batches[0].RollupStatus))
+				assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(batches[0].ProvingStatus))
+
+				dbChunks, err := chunkOrm.GetChunksInRange(context.Background(), 0, tt.expectedChunksInFirstBatch-1)
+				assert.NoError(t, err)
+				for _, chunk := range dbChunks {
+					assert.Equal(t, batches[0].Hash, chunk.BatchHash)
+					assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(chunk.ProvingStatus))
+				}
+			}
+		})
+	}
 }

--- a/rollup/internal/controller/watcher/batch_proposer_test.go
+++ b/rollup/internal/controller/watcher/batch_proposer_test.go
@@ -120,6 +120,7 @@ func testBatchProposerLimits(t *testing.T) {
 
 				dbChunks, err := chunkOrm.GetChunksInRange(context.Background(), 0, tt.expectedChunksInFirstBatch-1)
 				assert.NoError(t, err)
+				assert.Len(t, dbChunks, int(tt.expectedChunksInFirstBatch))
 				for _, chunk := range dbChunks {
 					assert.Equal(t, batches[0].Hash, chunk.BatchHash)
 					assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(chunk.ProvingStatus))

--- a/rollup/internal/controller/watcher/batch_proposer_test.go
+++ b/rollup/internal/controller/watcher/batch_proposer_test.go
@@ -144,3 +144,61 @@ func testBatchProposerLimits(t *testing.T) {
 		})
 	}
 }
+
+func testBatchCommitGasAndCalldataSizeEstimation(t *testing.T) {
+	db := setupDB(t)
+	defer database.CloseDB(db)
+
+	l2BlockOrm := orm.NewL2Block(db)
+	err := l2BlockOrm.InsertL2Blocks(context.Background(), []*types.WrappedBlock{wrappedBlock1, wrappedBlock2})
+	assert.NoError(t, err)
+
+	cp := NewChunkProposer(context.Background(), &config.ChunkProposerConfig{
+		MaxBlockNumPerChunk:             1,
+		MaxTxNumPerChunk:                10000,
+		MaxL1CommitGasPerChunk:          50000000000,
+		MaxL1CommitCalldataSizePerChunk: 1000000,
+		MaxRowConsumptionPerChunk:       1000000,
+		ChunkTimeoutSec:                 300,
+		GasCostIncreaseMultiplier:       1.2,
+	}, db, nil)
+	cp.TryProposeChunk() // chunk1 contains block1
+	cp.TryProposeChunk() // chunk2 contains block2
+
+	chunkOrm := orm.NewChunk(db)
+	chunks, err := chunkOrm.GetChunksInRange(context.Background(), 0, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(6006), chunks[0].TotalL1CommitGas)
+	assert.Equal(t, uint32(298), chunks[0].TotalL1CommitCalldataSize)
+	assert.Equal(t, uint64(93982), chunks[1].TotalL1CommitGas)
+	assert.Equal(t, uint32(5735), chunks[1].TotalL1CommitCalldataSize)
+
+	bp := NewBatchProposer(context.Background(), &config.BatchProposerConfig{
+		MaxChunkNumPerBatch:             10,
+		MaxL1CommitGasPerBatch:          50000000000,
+		MaxL1CommitCalldataSizePerBatch: 1000000,
+		BatchTimeoutSec:                 0,
+		GasCostIncreaseMultiplier:       1.2,
+	}, db, nil)
+	bp.TryProposeBatch()
+
+	batchOrm := orm.NewBatch(db)
+	batches, err := batchOrm.GetBatches(context.Background(), map[string]interface{}{}, []string{}, 0)
+	assert.NoError(t, err)
+	assert.Len(t, batches, 1)
+	assert.Equal(t, uint64(0), batches[0].StartChunkIndex)
+	assert.Equal(t, uint64(1), batches[0].EndChunkIndex)
+	assert.Equal(t, types.RollupPending, types.RollupStatus(batches[0].RollupStatus))
+	assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(batches[0].ProvingStatus))
+
+	dbChunks, err := chunkOrm.GetChunksInRange(context.Background(), 0, 1)
+	assert.NoError(t, err)
+	assert.Len(t, dbChunks, 2)
+	for _, chunk := range dbChunks {
+		assert.Equal(t, batches[0].Hash, chunk.BatchHash)
+		assert.Equal(t, types.ProvingTaskUnassigned, types.ProvingStatus(chunk.ProvingStatus))
+	}
+
+	assert.Equal(t, uint64(153916), batches[0].TotalL1CommitGas)
+	assert.Equal(t, uint32(6033), batches[0].TotalL1CommitCalldataSize)
+}

--- a/rollup/internal/controller/watcher/batch_proposer_test.go
+++ b/rollup/internal/controller/watcher/batch_proposer_test.go
@@ -19,14 +19,24 @@ func testBatchProposerLimits(t *testing.T) {
 		maxChunkNum                uint64
 		maxL1CommitGas             uint64
 		maxL1CommitCalldataSize    uint32
+		batchTimeoutSec            uint64
 		expectedBatchesLen         int
-		expectedChunksInFirstBatch uint64
+		expectedChunksInFirstBatch uint64 // only be checked when expectedBatchesLen > 0
 	}{
+		{
+			name:                    "NoLimitReached",
+			maxChunkNum:             10,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			batchTimeoutSec:         1000000000000,
+			expectedBatchesLen:      0,
+		},
 		{
 			name:                       "Timeout",
 			maxChunkNum:                10,
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    1000000,
+			batchTimeoutSec:            0,
 			expectedBatchesLen:         1,
 			expectedChunksInFirstBatch: 2,
 		},
@@ -35,6 +45,7 @@ func testBatchProposerLimits(t *testing.T) {
 			maxChunkNum:             10,
 			maxL1CommitGas:          0,
 			maxL1CommitCalldataSize: 1000000,
+			batchTimeoutSec:         1000000000000,
 			expectedBatchesLen:      0,
 		},
 		{
@@ -42,6 +53,7 @@ func testBatchProposerLimits(t *testing.T) {
 			maxChunkNum:             10,
 			maxL1CommitGas:          50000000000,
 			maxL1CommitCalldataSize: 0,
+			batchTimeoutSec:         1000000000000,
 			expectedBatchesLen:      0,
 		},
 		{
@@ -49,22 +61,25 @@ func testBatchProposerLimits(t *testing.T) {
 			maxChunkNum:                1,
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    1000000,
+			batchTimeoutSec:            1000000000000,
 			expectedBatchesLen:         1,
 			expectedChunksInFirstBatch: 1,
 		},
 		{
 			name:                       "MaxL1CommitGasPerBatchIsFirstChunk",
-			maxChunkNum:                1,
+			maxChunkNum:                10,
 			maxL1CommitGas:             100000,
 			maxL1CommitCalldataSize:    1000000,
+			batchTimeoutSec:            1000000000000,
 			expectedBatchesLen:         1,
 			expectedChunksInFirstBatch: 1,
 		},
 		{
 			name:                       "MaxL1CommitCalldataSizePerBatchIsFirstChunk",
-			maxChunkNum:                1,
+			maxChunkNum:                10,
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    298,
+			batchTimeoutSec:            1000000000000,
 			expectedBatchesLen:         1,
 			expectedChunksInFirstBatch: 1,
 		},
@@ -103,7 +118,7 @@ func testBatchProposerLimits(t *testing.T) {
 				MaxChunkNumPerBatch:             tt.maxChunkNum,
 				MaxL1CommitGasPerBatch:          tt.maxL1CommitGas,
 				MaxL1CommitCalldataSizePerBatch: tt.maxL1CommitCalldataSize,
-				BatchTimeoutSec:                 300,
+				BatchTimeoutSec:                 tt.batchTimeoutSec,
 				GasCostIncreaseMultiplier:       1.2,
 			}, db, nil)
 			bp.TryProposeBatch()

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -80,7 +80,8 @@ func NewChunkProposer(ctx context.Context, cfg *config.ChunkProposerConfig, db *
 		"maxL1CommitGasPerChunk", cfg.MaxL1CommitGasPerChunk,
 		"maxL1CommitCalldataSizePerChunk", cfg.MaxL1CommitCalldataSizePerChunk,
 		"maxRowConsumptionPerChunk", cfg.MaxRowConsumptionPerChunk,
-		"chunkTimeoutSec", cfg.ChunkTimeoutSec)
+		"chunkTimeoutSec", cfg.ChunkTimeoutSec,
+		"gasCostIncreaseMultiplier", cfg.GasCostIncreaseMultiplier)
 
 	return &ChunkProposer{
 		ctx:                             ctx,

--- a/rollup/internal/controller/watcher/chunk_proposer_test.go
+++ b/rollup/internal/controller/watcher/chunk_proposer_test.go
@@ -21,9 +21,20 @@ func testChunkProposerLimits(t *testing.T) {
 		maxL1CommitGas             uint64
 		maxL1CommitCalldataSize    uint64
 		maxRowConsumption          uint64
+		chunkTimeoutSec            uint64
 		expectedChunksLen          int
-		expectedBlocksInFirstChunk int
+		expectedBlocksInFirstChunk int // only be checked when expectedChunksLen > 0
 	}{
+		{
+			name:                    "NoLimitReached",
+			maxBlockNum:             100,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			chunkTimeoutSec:         1000000000000,
+			expectedChunksLen:       0,
+		},
 		{
 			name:                       "Timeout",
 			maxBlockNum:                100,
@@ -31,6 +42,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    1000000,
 			maxRowConsumption:          1000000,
+			chunkTimeoutSec:            0,
 			expectedChunksLen:          1,
 			expectedBlocksInFirstChunk: 2,
 		},
@@ -41,6 +53,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:          50000000000,
 			maxL1CommitCalldataSize: 1000000,
 			maxRowConsumption:       1000000,
+			chunkTimeoutSec:         1000000000000,
 			expectedChunksLen:       0,
 		},
 		{
@@ -50,6 +63,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:          0,
 			maxL1CommitCalldataSize: 1000000,
 			maxRowConsumption:       1000000,
+			chunkTimeoutSec:         1000000000000,
 			expectedChunksLen:       0,
 		},
 		{
@@ -59,6 +73,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:          50000000000,
 			maxL1CommitCalldataSize: 0,
 			maxRowConsumption:       1000000,
+			chunkTimeoutSec:         1000000000000,
 			expectedChunksLen:       0,
 		},
 		{
@@ -68,6 +83,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:          50000000000,
 			maxL1CommitCalldataSize: 1000000,
 			maxRowConsumption:       0,
+			chunkTimeoutSec:         1000000000000,
 			expectedChunksLen:       0,
 		},
 		{
@@ -77,6 +93,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    1000000,
 			maxRowConsumption:          1000000,
+			chunkTimeoutSec:            1000000000000,
 			expectedChunksLen:          1,
 			expectedBlocksInFirstChunk: 1,
 		},
@@ -87,6 +104,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    1000000,
 			maxRowConsumption:          1000000,
+			chunkTimeoutSec:            1000000000000,
 			expectedChunksLen:          1,
 			expectedBlocksInFirstChunk: 1,
 		},
@@ -97,6 +115,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:             60,
 			maxL1CommitCalldataSize:    1000000,
 			maxRowConsumption:          1000000,
+			chunkTimeoutSec:            1000000000000,
 			expectedChunksLen:          1,
 			expectedBlocksInFirstChunk: 1,
 		},
@@ -107,6 +126,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    298,
 			maxRowConsumption:          1000000,
+			chunkTimeoutSec:            1000000000000,
 			expectedChunksLen:          1,
 			expectedBlocksInFirstChunk: 1,
 		},
@@ -117,6 +137,7 @@ func testChunkProposerLimits(t *testing.T) {
 			maxL1CommitGas:             50000000000,
 			maxL1CommitCalldataSize:    1000000,
 			maxRowConsumption:          1,
+			chunkTimeoutSec:            1000000000000,
 			expectedChunksLen:          1,
 			expectedBlocksInFirstChunk: 1,
 		},
@@ -137,7 +158,7 @@ func testChunkProposerLimits(t *testing.T) {
 				MaxL1CommitGasPerChunk:          tt.maxL1CommitGas,
 				MaxL1CommitCalldataSizePerChunk: tt.maxL1CommitCalldataSize,
 				MaxRowConsumptionPerChunk:       tt.maxRowConsumption,
-				ChunkTimeoutSec:                 300,
+				ChunkTimeoutSec:                 tt.chunkTimeoutSec,
 				GasCostIncreaseMultiplier:       1.2,
 			}, db, nil)
 			cp.TryProposeChunk()

--- a/rollup/internal/controller/watcher/chunk_proposer_test.go
+++ b/rollup/internal/controller/watcher/chunk_proposer_test.go
@@ -13,58 +13,154 @@ import (
 	"scroll-tech/rollup/internal/orm"
 )
 
-// TODO: Add unit tests that the limits are enforced correctly.
-func testChunkProposer(t *testing.T) {
-	db := setupDB(t)
-	defer database.CloseDB(db)
-
-	l2BlockOrm := orm.NewL2Block(db)
-	err := l2BlockOrm.InsertL2Blocks(context.Background(), []*types.WrappedBlock{wrappedBlock1, wrappedBlock2})
-	assert.NoError(t, err)
-
-	cp := NewChunkProposer(context.Background(), &config.ChunkProposerConfig{
-		MaxBlockNumPerChunk:             100,
-		MaxTxNumPerChunk:                10000,
-		MaxL1CommitGasPerChunk:          50000000000,
-		MaxL1CommitCalldataSizePerChunk: 1000000,
-		MaxRowConsumptionPerChunk:       1048319,
-		ChunkTimeoutSec:                 300,
-	}, db, nil)
-	cp.TryProposeChunk()
-
-	expectedChunk := &types.Chunk{
-		Blocks: []*types.WrappedBlock{wrappedBlock1, wrappedBlock2},
+func testChunkProposerLimits(t *testing.T) {
+	tests := []struct {
+		name                    string
+		maxBlockNum             uint64
+		maxTxNum                uint64
+		maxL1CommitGas          uint64
+		maxL1CommitCalldataSize uint64
+		maxRowConsumption       uint64
+		expectedChunksLen       int
+		expectedBlocksNum       uint64
+	}{
+		{
+			name:                    "Timeout",
+			maxBlockNum:             100,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       1,
+			expectedBlocksNum:       2,
+		},
+		{
+			name:                    "MaxTxNumPerChunkIs0",
+			maxBlockNum:             10,
+			maxTxNum:                0,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       0,
+		},
+		{
+			name:                    "MaxL1CommitGasPerChunkIs0",
+			maxBlockNum:             10,
+			maxTxNum:                10000,
+			maxL1CommitGas:          0,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       0,
+		},
+		{
+			name:                    "MaxL1CommitCalldataSizePerChunkIs0",
+			maxBlockNum:             10,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 0,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       0,
+		},
+		{
+			name:                    "MaxRowConsumptionPerChunkIs0",
+			maxBlockNum:             100,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       0,
+			expectedChunksLen:       0,
+		},
+		{
+			name:                    "MaxBlockNumPerChunkIs1",
+			maxBlockNum:             1,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       1,
+			expectedBlocksNum:       1,
+		},
+		{
+			name:                    "MaxTxNumPerChunkIsFirstBlock",
+			maxBlockNum:             10,
+			maxTxNum:                2,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       1,
+			expectedBlocksNum:       1,
+		},
+		{
+			name:                    "MaxL1CommitGasPerChunkIsFirstBlock",
+			maxBlockNum:             10,
+			maxTxNum:                10000,
+			maxL1CommitGas:          60,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       1,
+			expectedBlocksNum:       1,
+		},
+		{
+			name:                    "MaxL1CommitCalldataSizePerChunkIsFirstBlock",
+			maxBlockNum:             10,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 298,
+			maxRowConsumption:       1000000,
+			expectedChunksLen:       1,
+			expectedBlocksNum:       1,
+		},
+		{
+			name:                    "MaxRowConsumptionPerChunkIs1",
+			maxBlockNum:             10,
+			maxTxNum:                10000,
+			maxL1CommitGas:          50000000000,
+			maxL1CommitCalldataSize: 1000000,
+			maxRowConsumption:       1,
+			expectedChunksLen:       1,
+			expectedBlocksNum:       1,
+		},
 	}
-	expectedHash, err := expectedChunk.Hash(0)
-	assert.NoError(t, err)
 
-	chunkOrm := orm.NewChunk(db)
-	chunks, err := chunkOrm.GetChunksGEIndex(context.Background(), 0, 0)
-	assert.NoError(t, err)
-	assert.Len(t, chunks, 1)
-	assert.Equal(t, expectedHash.Hex(), chunks[0].Hash)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupDB(t)
+			defer database.CloseDB(db)
 
-func testChunkProposerRowConsumption(t *testing.T) {
-	db := setupDB(t)
-	defer database.CloseDB(db)
+			l2BlockOrm := orm.NewL2Block(db)
+			err := l2BlockOrm.InsertL2Blocks(context.Background(), []*types.WrappedBlock{wrappedBlock1, wrappedBlock2})
+			assert.NoError(t, err)
 
-	l2BlockOrm := orm.NewL2Block(db)
-	err := l2BlockOrm.InsertL2Blocks(context.Background(), []*types.WrappedBlock{wrappedBlock1, wrappedBlock2})
-	assert.NoError(t, err)
+			cp := NewChunkProposer(context.Background(), &config.ChunkProposerConfig{
+				MaxBlockNumPerChunk:             tt.maxBlockNum,
+				MaxTxNumPerChunk:                tt.maxTxNum,
+				MaxL1CommitGasPerChunk:          tt.maxL1CommitGas,
+				MaxL1CommitCalldataSizePerChunk: tt.maxL1CommitCalldataSize,
+				MaxRowConsumptionPerChunk:       tt.maxRowConsumption,
+				ChunkTimeoutSec:                 300,
+				GasCostIncreaseMultiplier:       1.2,
+			}, db, nil)
+			cp.TryProposeChunk()
 
-	cp := NewChunkProposer(context.Background(), &config.ChunkProposerConfig{
-		MaxBlockNumPerChunk:             100,
-		MaxTxNumPerChunk:                10000,
-		MaxL1CommitGasPerChunk:          50000000000,
-		MaxL1CommitCalldataSizePerChunk: 1000000,
-		MaxRowConsumptionPerChunk:       0, // !
-		ChunkTimeoutSec:                 300,
-	}, db, nil)
-	cp.TryProposeChunk()
+			chunkOrm := orm.NewChunk(db)
+			chunks, err := chunkOrm.GetChunksGEIndex(context.Background(), 0, 0)
+			assert.NoError(t, err)
+			assert.Len(t, chunks, tt.expectedChunksLen)
 
-	chunkOrm := orm.NewChunk(db)
-	chunks, err := chunkOrm.GetChunksGEIndex(context.Background(), 0, 0)
-	assert.NoError(t, err)
-	assert.Len(t, chunks, 0)
+			if len(chunks) > 0 {
+				var expectedChunk types.Chunk
+
+				switch tt.expectedBlocksNum {
+				case 1:
+					expectedChunk.Blocks = []*types.WrappedBlock{wrappedBlock1}
+				case 2:
+					expectedChunk.Blocks = []*types.WrappedBlock{wrappedBlock1, wrappedBlock2}
+				}
+
+				expectedHash, err := expectedChunk.Hash(0)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedHash.Hex(), chunks[0].Hash)
+			}
+		})
+	}
 }

--- a/rollup/internal/controller/watcher/watcher_test.go
+++ b/rollup/internal/controller/watcher/watcher_test.go
@@ -110,10 +110,9 @@ func TestFunction(t *testing.T) {
 	t.Run("TestParseBridgeEventLogsL2RelayedMessageEventSignature", testParseBridgeEventLogsL2RelayedMessageEventSignature)
 	t.Run("TestParseBridgeEventLogsL2FailedRelayedMessageEventSignature", testParseBridgeEventLogsL2FailedRelayedMessageEventSignature)
 
-	// Run chunk-proposer test cases.
-	t.Run("TestChunkProposer", testChunkProposer)
-	t.Run("TestChunkProposerRowConsumption", testChunkProposerRowConsumption)
+	// Run chunk proposer test cases.
+	t.Run("TestChunkProposerLimits", testChunkProposerLimits)
 
-	// Run batch-proposer test cases.
-	t.Run("TestBatchProposer", testBatchProposer)
+	// Run chunk proposer test cases.
+	t.Run("TestBatchProposerLimits", testBatchProposerLimits)
 }

--- a/rollup/internal/controller/watcher/watcher_test.go
+++ b/rollup/internal/controller/watcher/watcher_test.go
@@ -115,4 +115,5 @@ func TestFunction(t *testing.T) {
 
 	// Run chunk proposer test cases.
 	t.Run("TestBatchProposerLimits", testBatchProposerLimits)
+	t.Run("TestBatchCommitGasAndCalldataSizeEstimation", testBatchCommitGasAndCalldataSizeEstimation)
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

Add tests, covered cases:
1. Fully pack: triggered by timeout. (i) chunk-proposer: 2 in 2 blocks; (ii) batch-proposer: 2 in 2 chunks.
2. Partially pack: (i) chunk-proposer: 1 in 2 blocks; (ii) batch-proposer: 1 in 2 chunks.
3. No pack: (i) no limit is reached; (ii) the very first block/chunk breaks one of the limits.
4. Equal asserts for l1 commit gas and calldata size estimation, detecting logic changes of batch estimation.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205321339721908
  - https://app.asana.com/0/0/1205321339721910