### PR TITLE
perf(db): add idx for chunk_index and batch_index

### DIFF
--- a/database/migrate/migrate_test.go
+++ b/database/migrate/migrate_test.go
@@ -63,7 +63,7 @@ func testResetDB(t *testing.T) {
 	cur, err := Current(pgDB.DB)
 	assert.NoError(t, err)
 	// total number of tables.
-	assert.Equal(t, 12, int(cur))
+	assert.Equal(t, 13, int(cur))
 }
 
 func testMigrate(t *testing.T) {

--- a/database/migrate/migrations/00013_add_index_index_chunk_bactch.sql
+++ b/database/migrate/migrations/00013_add_index_index_chunk_bactch.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+
+create index if not exists idx_chunk_index on chunk(index) where deleted_at IS NULL;
+
+create index if not exists idx_batch_index on batch(index) where deleted_at IS NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+drop index if exists idx_chunk_index;
+drop index if exists idx_batch_index;
+
+-- +goose StatementEnd


### PR DESCRIPTION
### Purpose or design rationale of this PR

`GetBatchByIndex` & `GetChunksInRange` query the batch table and chunk table by index

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [x] Yes
