### PR TITLE
fix: mark used storage slots in L2ScrollMessenger

### DIFF
--- a/contracts/src/L2/L2ScrollMessenger.sol
+++ b/contracts/src/L2/L2ScrollMessenger.sol
@@ -40,6 +40,9 @@ contract L2ScrollMessenger is ScrollMessengerBase, IL2ScrollMessenger {
     /// @notice Mapping from L1 message hash to a boolean value indicating if the message has been successfully executed.
     mapping(bytes32 => bool) public isL1MessageExecuted;
 
+    /// @dev The storage slots used by previous versions of this contract.
+    uint256[2] private __used;
+
     /***************
      * Constructor *
      ***************/


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

https://github.com/scroll-tech/scroll/pull/850 removed some storage variables from `L2ScrollMessenger`. If we add some new storage variables in a future upgrade, they might use the same slots and might end up with unexpected initial values. This PR marks these two slots as `used`.

Layout of old version (4a3056667eadae1e6e13a82ceb97e11ccc6583d7):
```
> forge inspect L2ScrollMessenger storage-layout --pretty
| Name                    | Type                        | Slot | Offset | Bytes | Contract                                       |
|-------------------------|-----------------------------|------|--------|-------|------------------------------------------------|
| _initialized            | uint8                       | 0    | 0      | 1     | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _initializing           | bool                        | 0    | 1      | 1     | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                   | uint256[50]                 | 1    | 0      | 1600  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _owner                  | address                     | 51   | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                   | uint256[49]                 | 52   | 0      | 1568  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _paused                 | bool                        | 101  | 0      | 1     | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                   | uint256[49]                 | 102  | 0      | 1568  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _status                 | uint256                     | 151  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                   | uint256[49]                 | 152  | 0      | 1568  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| xDomainMessageSender    | address                     | 201  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| counterpart             | address                     | 202  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| feeVault                | address                     | 203  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                   | uint256[47]                 | 204  | 0      | 1504  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| isL2MessageSent         | mapping(bytes32 => bool)    | 251  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| isL1MessageExecuted     | mapping(bytes32 => bool)    | 252  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| l1MessageFailedTimes    | mapping(bytes32 => uint256) | 253  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| maxFailedExecutionTimes | uint256                     | 254  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
```

Layout of new version (c543d6fd0d0dd31799d64c47b3b7f7fb305e702f):
```
> forge inspect L2ScrollMessenger storage-layout --pretty
| Name                 | Type                     | Slot | Offset | Bytes | Contract                                       |
|----------------------|--------------------------|------|--------|-------|------------------------------------------------|
| _initialized         | uint8                    | 0    | 0      | 1     | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _initializing        | bool                     | 0    | 1      | 1     | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                | uint256[50]              | 1    | 0      | 1600  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _owner               | address                  | 51   | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                | uint256[49]              | 52   | 0      | 1568  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _paused              | bool                     | 101  | 0      | 1     | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                | uint256[49]              | 102  | 0      | 1568  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| _status              | uint256                  | 151  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                | uint256[49]              | 152  | 0      | 1568  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| xDomainMessageSender | address                  | 201  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| counterpart          | address                  | 202  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| feeVault             | address                  | 203  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| rateLimiter          | address                  | 204  | 0      | 20    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __gap                | uint256[46]              | 205  | 0      | 1472  | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| isL2MessageSent      | mapping(bytes32 => bool) | 251  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| isL1MessageExecuted  | mapping(bytes32 => bool) | 252  | 0      | 32    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
| __used               | uint256[2]               | 253  | 0      | 64    | src/L2/L2ScrollMessenger.sol:L2ScrollMessenger |
```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [X] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes
