### PR TITLE
fix(libzkp): try to convert to string for panic errors

### DIFF
--- a/common/libzkp/impl/src/batch.rs
+++ b/common/libzkp/impl/src/batch.rs
@@ -1,7 +1,8 @@
 use crate::{
     types::{CheckChunkProofsResponse, ProofResult},
     utils::{
-        c_char_to_str, c_char_to_vec, file_exists, string_to_c_char, vec_to_c_char, OUTPUT_DIR,
+        c_char_to_str, c_char_to_vec, file_exists, panic_catch, string_to_c_char, vec_to_c_char,
+        OUTPUT_DIR,
     },
 };
 use libc::c_char;
@@ -11,7 +12,7 @@ use prover::{
     utils::{chunk_trace_to_witness_block, init_env_and_log},
     BatchProof, BlockTrace, ChunkHash, ChunkProof,
 };
-use std::{cell::OnceCell, env, panic, ptr::null};
+use std::{cell::OnceCell, env, ptr::null};
 
 static mut PROVER: OnceCell<Prover> = OnceCell::new();
 static mut VERIFIER: OnceCell<Verifier> = OnceCell::new();
@@ -55,7 +56,7 @@ pub unsafe extern "C" fn init_batch_verifier(params_dir: *const c_char, assets_d
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn get_batch_vk() -> *const c_char {
-    let vk_result = panic::catch_unwind(|| PROVER.get_mut().unwrap().get_vk());
+    let vk_result = panic_catch(|| PROVER.get_mut().unwrap().get_vk());
 
     vk_result
         .ok()
@@ -66,7 +67,7 @@ pub unsafe extern "C" fn get_batch_vk() -> *const c_char {
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn check_chunk_proofs(chunk_proofs: *const c_char) -> *const c_char {
-    let check_result: Result<bool, String> = panic::catch_unwind(|| {
+    let check_result: Result<bool, String> = panic_catch(|| {
         let chunk_proofs = c_char_to_vec(chunk_proofs);
         let chunk_proofs = serde_json::from_slice::<Vec<ChunkProof>>(&chunk_proofs)
             .map_err(|e| format!("failed to deserialize chunk proofs: {e:?}"))?;
@@ -102,7 +103,7 @@ pub unsafe extern "C" fn gen_batch_proof(
     chunk_hashes: *const c_char,
     chunk_proofs: *const c_char,
 ) -> *const c_char {
-    let proof_result: Result<Vec<u8>, String> = panic::catch_unwind(|| {
+    let proof_result: Result<Vec<u8>, String> = panic_catch(|| {
         let chunk_hashes = c_char_to_vec(chunk_hashes);
         let chunk_proofs = c_char_to_vec(chunk_proofs);
 
@@ -151,7 +152,7 @@ pub unsafe extern "C" fn verify_batch_proof(proof: *const c_char) -> c_char {
     let proof = c_char_to_vec(proof);
     let proof = serde_json::from_slice::<BatchProof>(proof.as_slice()).unwrap();
 
-    let verified = panic::catch_unwind(|| VERIFIER.get().unwrap().verify_agg_evm_proof(proof));
+    let verified = panic_catch(|| VERIFIER.get().unwrap().verify_agg_evm_proof(proof));
     verified.unwrap_or(false) as c_char
 }
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

Reference [this panic-handling code of zkevm-circuits testool](https://github.com/scroll-tech/zkevm-circuits/blob/develop/testool/src/statetest/suite.rs#L127), fix to the similar logic in libzkp (to avoid returning error as `Any {...}`).

Suppose to test again and release in next version.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
