### PR TITLE
fix(contracts): OZ-L02 Implicit Limitation of Withdrawal

### DIFF
--- a/contracts/src/L2/predeploys/L2TxFeeVault.sol
+++ b/contracts/src/L2/predeploys/L2TxFeeVault.sol
@@ -110,6 +110,9 @@ contract L2TxFeeVault is OwnableBase {
             "FeeVault: withdrawal amount must be greater than minimum withdrawal amount"
         );
 
+        uint256 _balance = address(this).balance;
+        require(_value <= _balance, "FeeVault: insufficient balance to withdraw");
+
         unchecked {
             totalProcessed += _value;
         }

--- a/contracts/src/test/L2TxFeeVault.t.sol
+++ b/contracts/src/test/L2TxFeeVault.t.sol
@@ -33,7 +33,7 @@ contract L2TxFeeVaultTest is DSTestPlus {
     function testCantWithdrawMoreThanBalance(uint256 amount) public {
         hevm.assume(amount >= 10 ether);
         hevm.deal(address(vault), amount - 1);
-        hevm.expectRevert(new bytes(0));
+        hevm.expectRevert("FeeVault: insufficient balance to withdraw");
         vault.withdraw(amount);
     }
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fixed the issue reported by Openzepplin ([**L-02 Implicit Limitation of Withdrawal**](https://defender.openzeppelin.com/v2/#/audit/94bad907-ab2a-490a-bfa9-8dc972fd1930/issues/L-02)) during **Scroll Diff Audit**. The following are the details:

> On [pull request 912](https://github.com/scroll-tech/scroll/pull/912/commits/03f3a0e7a068e0327ff6533bd07c654d0acd6714), the FeeVault contract introduced the possibility to [pass a parameter](https://github.com/scroll-tech/scroll/pull/912/commits/03f3a0e7a068e0327ff6533bd07c654d0acd6714#diff-59b7fd0ed38ccb8a8dc9d3f3a2929a4532f2868a89b7839e3d09a4e267c9c5b3R107) of the value to withdraw. However, this value is implicitly limited to the contract's current balance by the [sendMessage function call](https://github.com/scroll-tech/scroll/pull/912/commits/03f3a0e7a068e0327ff6533bd07c654d0acd6714#diff-59b7fd0ed38ccb8a8dc9d3f3a2929a4532f2868a89b7839e3d09a4e267c9c5b3R120).
>
> In order to fail early and return a clear error message (which would help when debugging a reverted transaction), consider adding a requirement that asserts that the value passed is equal to or less than the contract's balance.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
