### PR TITLE
perf(coordinator): use optimistic lock during batch/chunk assignment

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.12"
+var tag = "v4.3.13"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -88,7 +88,7 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}
 
 	if batchTask == nil {
-		log.Debug("get empty unassigned batch for retry 100 times", "height", getTaskParameter.ProverHeight)
+		log.Debug("get empty unassigned batch after retry 100 times", "height", getTaskParameter.ProverHeight)
 		return nil, nil
 	}
 

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -69,6 +69,7 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 			return nil, ErrCoordinatorInternalFailure
 		}
 		if unassignedBatch == nil {
+			log.Debug("get empty unassigned batch", "height", getTaskParameter.ProverHeight)
 			return nil, nil
 		}
 
@@ -87,6 +88,7 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}
 
 	if batchTask == nil {
+		log.Debug("get empty unassigned batch for retry 100 times", "height", getTaskParameter.ProverHeight)
 		return nil, nil
 	}
 

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -73,6 +73,7 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 		}
 
 		if unassignedChunk == nil {
+			log.Debug("get empty unassigned chunk", "height", getTaskParameter.ProverHeight)
 			return nil, nil
 		}
 
@@ -91,6 +92,7 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}
 
 	if chunkTask == nil {
+		log.Debug("get empty unassigned chunk for retry 100 times", "height", getTaskParameter.ProverHeight)
 		return nil, nil
 	}
 

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -92,7 +92,7 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}
 
 	if chunkTask == nil {
-		log.Debug("get empty unassigned chunk for retry 100 times", "height", getTaskParameter.ProverHeight)
+		log.Debug("get empty unassigned chunk after retry 100 times", "height", getTaskParameter.ProverHeight)
 		return nil, nil
 	}
 

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/log"
 	"gorm.io/gorm"
+
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
 	"scroll-tech/common/utils"

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -80,10 +80,9 @@ func (o *Batch) GetUnassignedBatch(ctx context.Context, maxActiveAttempts, maxTo
 	db = db.Where("active_attempts < ?", maxActiveAttempts)
 	db = db.Where("chunk_proofs_status = ?", int(types.ChunkProofsStatusReady))
 	db = db.Order("index ASC")
-	db = db.Limit(1)
 
 	var batch Batch
-	err := db.Find(&batch).Error
+	err := db.First(&batch).Error
 	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil
 	}

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -10,8 +10,6 @@ import (
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/log"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
-
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
 	"scroll-tech/common/utils"
@@ -72,26 +70,27 @@ func (*Batch) TableName() string {
 	return "batch"
 }
 
-// GetUnassignedBatches retrieves unassigned batches based on the specified limit.
-// The returned batches are sorted in ascending order by their index.
-func (o *Batch) GetUnassignedBatches(ctx context.Context, limit int) ([]*Batch, error) {
-	if limit < 0 {
-		return nil, errors.New("limit must not be smaller than zero")
-	}
-	if limit == 0 {
+// GetUnassignedBatch retrieves unassigned batch based on the specified limit.
+// The returned batch are sorted in ascending order by their index.
+func (o *Batch) GetUnassignedBatch(ctx context.Context, maxActiveAttempts, maxTotalAttempts uint8) (*Batch, error) {
+	db := o.db.WithContext(ctx)
+	db = db.Where("proving_status not in (?)", []int{int(types.ProvingTaskVerified), int(types.ProvingTaskFailed)})
+	db = db.Where("total_attempts < ?", maxTotalAttempts)
+	db = db.Where("active_attempts < ?", maxActiveAttempts)
+	db = db.Where("chunk_proofs_status = ?", int(types.ChunkProofsStatusReady))
+	db = db.Order("index ASC")
+	db = db.Limit(1)
+
+	var batch Batch
+	err := db.Find(&batch).Error
+	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil
 	}
 
-	db := o.db.WithContext(ctx)
-	db = db.Where("proving_status = ? AND chunk_proofs_status = ?", types.ProvingTaskUnassigned, types.ChunkProofsStatusReady)
-	db = db.Order("index ASC")
-	db = db.Limit(limit)
-
-	var batches []*Batch
-	if err := db.Find(&batches).Error; err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("Batch.GetUnassignedBatches error: %w", err)
 	}
-	return batches, nil
+	return &batch, nil
 }
 
 // GetUnassignedAndChunksUnreadyBatches get the batches which is unassigned and chunks is not ready
@@ -303,22 +302,13 @@ func (o *Batch) UpdateProofAndProvingStatusByHash(ctx context.Context, hash stri
 	return nil
 }
 
-// UpdateBatchAttemptsReturning atomically increments the attempts count for the earliest available batch that meets the conditions.
-func (o *Batch) UpdateBatchAttemptsReturning(ctx context.Context, maxActiveAttempts, maxTotalAttempts uint8) (*Batch, error) {
+// UpdateBatchAttempts atomically increments the attempts count for the earliest available batch that meets the conditions.
+func (o *Batch) UpdateBatchAttempts(ctx context.Context, index uint64, curActiveAttempts, curTotalAttempts int16) (int64, error) {
 	db := o.db.WithContext(ctx)
-
-	subQueryDB := db.Model(&Batch{}).Select("index")
-	subQueryDB = subQueryDB.Clauses(clause.Locking{Strength: "UPDATE"})
-	subQueryDB = subQueryDB.Where("proving_status not in (?)", []int{int(types.ProvingTaskVerified), int(types.ProvingTaskFailed)})
-	subQueryDB = subQueryDB.Where("total_attempts < ?", maxTotalAttempts)
-	subQueryDB = subQueryDB.Where("active_attempts < ?", maxActiveAttempts)
-	subQueryDB = subQueryDB.Where("chunk_proofs_status = ?", int(types.ChunkProofsStatusReady))
-	subQueryDB = subQueryDB.Order("index ASC")
-	subQueryDB = subQueryDB.Limit(1)
-
-	var updatedBatch Batch
-	db = db.Model(&updatedBatch).Clauses(clause.Returning{})
-	db = db.Where("index = (?)", subQueryDB)
+	db = db.Model(&Batch{})
+	db = db.Where("index = ?", index)
+	db = db.Where("active_attempts = ?", curActiveAttempts)
+	db = db.Where("total_attempts = ?", curTotalAttempts)
 	result := db.Updates(map[string]interface{}{
 		"proving_status":  types.ProvingTaskAssigned,
 		"total_attempts":  gorm.Expr("total_attempts + 1"),
@@ -326,13 +316,9 @@ func (o *Batch) UpdateBatchAttemptsReturning(ctx context.Context, maxActiveAttem
 	})
 
 	if result.Error != nil {
-		return nil, fmt.Errorf("failed to select and update batch, max active attempts: %v, max total attempts: %v, err: %w",
-			maxActiveAttempts, maxTotalAttempts, result.Error)
+		return 0, fmt.Errorf("failed to update batch, err:%v", result.Error)
 	}
-	if result.RowsAffected == 0 {
-		return nil, nil
-	}
-	return &updatedBatch, nil
+	return result.RowsAffected, nil
 }
 
 // DecreaseActiveAttemptsByHash decrements the active_attempts of a batch given its hash.

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -317,7 +317,7 @@ func (o *Batch) UpdateBatchAttempts(ctx context.Context, index uint64, curActive
 	})
 
 	if result.Error != nil {
-		return 0, fmt.Errorf("failed to update batch, err:%v", result.Error)
+		return 0, fmt.Errorf("failed to update batch, err:%w", result.Error)
 	}
 	return result.RowsAffected, nil
 }

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/scroll-tech/go-ethereum/log"
 	"gorm.io/gorm"
+
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
 	"scroll-tech/common/utils"

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -351,7 +351,7 @@ func (o *Chunk) UpdateChunkAttempts(ctx context.Context, index uint64, curActive
 	})
 
 	if result.Error != nil {
-		return 0, fmt.Errorf("failed to update chunk, err:%v", result.Error)
+		return 0, fmt.Errorf("failed to update chunk, err:%w", result.Error)
 	}
 	return result.RowsAffected, nil
 }

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -76,7 +76,6 @@ func (o *Chunk) GetUnassignedChunk(ctx context.Context, height int, maxActiveAtt
 	db = db.Where("active_attempts < ?", maxActiveAttempts)
 	db = db.Where("end_block_number <= ?", height)
 	db = db.Order("index ASC")
-	db = db.Limit(1)
 
 	var chunk Chunk
 	err := db.First(&chunk).Error


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

<img width="1128" alt="image" src="https://github.com/scroll-tech/scroll/assets/6947653/cc7b4d42-0bea-437c-b93e-7966fcf0c6d2">

The coordinator get_task will lock the table, this make the db performance down. This use  optimistic lock optimize this problem
  
### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
