### PR TITLE
perf(bridge-history): optimize get claimable l2 sent msg query

### DIFF
--- a/bridge-history-api/internal/logic/history_logic.go
+++ b/bridge-history-api/internal/logic/history_logic.go
@@ -78,12 +78,8 @@ func (h *HistoryLogic) GetClaimableTxsByAddress(ctx context.Context, address com
 	var txHistories []*types.TxHistoryInfo
 	l2SentMsgOrm := orm.NewL2SentMsg(h.db)
 	l2CrossMsgOrm := orm.NewCrossMsg(h.db)
-	total, err := l2SentMsgOrm.GetClaimableL2SentMsgByAddressTotalNum(ctx, address.Hex())
-	if err != nil || total == 0 {
-		return txHistories, 0, err
-	}
-	results, err := l2SentMsgOrm.GetClaimableL2SentMsgByAddressWithOffset(ctx, address.Hex(), offset, limit)
-	if err != nil || len(results) == 0 {
+	total, results, err := l2SentMsgOrm.GetClaimableL2SentMsgByAddressWithOffset(ctx, address.Hex(), offset, limit)
+	if err != nil || total == 0 || len(results) == 0 {
 		return txHistories, 0, err
 	}
 	var msgHashList []string

--- a/bridge-history-api/orm/l2_sent_msg.go
+++ b/bridge-history-api/orm/l2_sent_msg.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -87,16 +86,15 @@ func (l *L2SentMsg) GetClaimableL2SentMsgByAddressWithOffset(ctx context.Context
 		return 0, nil, err
 	}
 
-	var valuesStr string
+	msgHashes := []string{}
 	for _, msg := range totalMsgs {
-		valuesStr += fmt.Sprintf("(\"%s\"),", msg.MsgHash)
+		msgHashes = append(msgHashes, msg.MsgHash)
 	}
-	valuesStr = strings.TrimSuffix(valuesStr, ",")
 
 	var claimedMsgHashes []string
 	db = l.db.WithContext(ctx)
 	db = db.Table("relayed_msg")
-	db = db.Where(fmt.Sprintf("msg_hash IN (VALUES %s)", valuesStr))
+	db = db.Where("msg_hash IN (?)", msgHashes)
 	db = db.Where("deleted_at IS NULL")
 	if err := db.Pluck("msg_hash", &claimedMsgHashes).Error; err != nil {
 		return 0, nil, err

--- a/bridge-history-api/orm/l2_sent_msg.go
+++ b/bridge-history-api/orm/l2_sent_msg.go
@@ -88,6 +88,19 @@ func (l *L2SentMsg) GetClaimableL2SentMsgByAddressWithOffset(ctx context.Context
 		return 0, nil, tx.Error
 	}
 
+	// Note on the use of IN vs VALUES in SQL Queries:
+	// ------------------------------------------------
+	// When using the IN predicate with a large list (>100) of values, performance may suffer.
+	// An alternative approach is to use constant subqueries with the VALUES construct.
+	// For more details and optimization tips, visit:
+	// https://postgres.cz/wiki/PostgreSQL_SQL_Tricks_I#Predicate_IN_optimalization
+	//
+	// Example using IN:
+	// SELECT * FROM tab WHERE x IN (1,2,3,...,n);  -- where n > 70
+	//
+	// Optimized example using VALUES:
+	// SELECT * FROM tab WHERE x IN (VALUES(10), (20));
+	//
 	var valuesStr string
 	for _, msg := range totalMsgs {
 		valuesStr += fmt.Sprintf("('%s'),", msg.MsgHash)

--- a/bridge-history-api/orm/l2_sent_msg.go
+++ b/bridge-history-api/orm/l2_sent_msg.go
@@ -80,6 +80,7 @@ func (l *L2SentMsg) GetClaimableL2SentMsgByAddressWithOffset(ctx context.Context
 	db = db.Where("original_sender = ? OR sender = ?", address, address)
 	db = db.Where("msg_proof != ''")
 	db = db.Where("deleted_at IS NULL")
+	db = db.Order("id DESC")
 	if err := db.Find(&totalMsgs).Error; err != nil {
 		return 0, nil, err
 	}

--- a/bridge-history-api/orm/l2_sent_msg_test.go
+++ b/bridge-history-api/orm/l2_sent_msg_test.go
@@ -32,12 +32,16 @@ func TestGetClaimableL2SentMsgByAddressWithOffset(t *testing.T) {
 	l2SentMsgOrm := NewL2SentMsg(db)
 	relayedMsgOrm := NewRelayedMsg(db)
 
+	count, msgs, err := l2SentMsgOrm.GetClaimableL2SentMsgByAddressWithOffset(context.Background(), "sender1", 0, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), count)
+
 	l2SentMsgs := []*L2SentMsg{
 		{
-			OriginalSender: "sender1",
-			MsgHash:        "hash1",
-			MsgProof:       "proof1",
-			Nonce:          0,
+			Sender:   "sender1",
+			MsgHash:  "hash1",
+			MsgProof: "proof1",
+			Nonce:    0,
 		},
 		{
 			OriginalSender: "sender1",
@@ -65,7 +69,7 @@ func TestGetClaimableL2SentMsgByAddressWithOffset(t *testing.T) {
 	err = relayedMsgOrm.InsertRelayedMsg(context.Background(), relayedMsgs)
 	assert.NoError(t, err)
 
-	count, msgs, err := l2SentMsgOrm.GetClaimableL2SentMsgByAddressWithOffset(context.Background(), "sender1", 0, 10)
+	count, msgs, err = l2SentMsgOrm.GetClaimableL2SentMsgByAddressWithOffset(context.Background(), "sender1", 0, 10)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), count)
 	assert.Equal(t, "hash1", msgs[0].MsgHash)

--- a/bridge-history-api/orm/l2_sent_msg_test.go
+++ b/bridge-history-api/orm/l2_sent_msg_test.go
@@ -1,0 +1,72 @@
+package orm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"bridge-history-api/orm/migrate"
+	"scroll-tech/common/database"
+	"scroll-tech/common/docker"
+)
+
+func TestGetClaimableL2SentMsgByAddressWithOffset(t *testing.T) {
+	base := docker.NewDockerApp()
+	base.RunDBImage(t)
+
+	db, err := database.InitDB(
+		&database.Config{
+			DSN:        base.DBConfig.DSN,
+			DriverName: base.DBConfig.DriverName,
+			MaxOpenNum: base.DBConfig.MaxOpenNum,
+			MaxIdleNum: base.DBConfig.MaxIdleNum,
+		},
+	)
+	assert.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	assert.NoError(t, err)
+	assert.NoError(t, migrate.ResetDB(sqlDB))
+
+	l2SentMsgOrm := NewL2SentMsg(db)
+	relayedMsgOrm := NewRelayedMsg(db)
+
+	l2SentMsgs := []*L2SentMsg{
+		{
+			OriginalSender: "sender1",
+			MsgHash:        "hash1",
+			MsgProof:       "proof1",
+			Nonce:          0,
+		},
+		{
+			OriginalSender: "sender1",
+			MsgHash:        "hash2",
+			MsgProof:       "proof2",
+			Nonce:          1,
+		},
+		{
+			OriginalSender: "sender1",
+			MsgHash:        "hash3",
+			MsgProof:       "",
+			Nonce:          2,
+		},
+	}
+	relayedMsgs := []*RelayedMsg{
+		{
+			MsgHash: "hash2",
+		},
+		{
+			MsgHash: "hash3",
+		},
+	}
+	err = l2SentMsgOrm.InsertL2SentMsg(context.Background(), l2SentMsgs)
+	assert.NoError(t, err)
+	err = relayedMsgOrm.InsertRelayedMsg(context.Background(), relayedMsgs)
+	assert.NoError(t, err)
+
+	count, msgs, err := l2SentMsgOrm.GetClaimableL2SentMsgByAddressWithOffset(context.Background(), "sender1", 0, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), count)
+	assert.Equal(t, "hash1", msgs[0].MsgHash)
+}

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.15"
+var tag = "v4.3.16"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.14"
+var tag = "v4.3.15"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.13"
+var tag = "v4.3.14"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.16"
+var tag = "v4.3.17"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR boosts the speed of `GetClaimableL2SentMsgByAddressWithOffset` and `GetClaimableL2SentMsgByAddressTotalNum`. Key changes:

Combine Functions: Merges both functions into one that returns total unclaimed transactions and a paginated list.

Simplify Queries: Adapts query logic assuming fewer transactions per address. The new approach:

i. Fetches all transactions for the address.
ii. Identifies claimed transactions.
iii. Derives unclaimed transactions.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] perf: A code change that improves performance


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
