### PR TITLE
perf(coordinator): optimize get task's optimistic lock

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.13"
+var tag = "v4.3.14"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -80,6 +81,7 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 		}
 
 		if rowsAffected == 0 {
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -84,6 +85,7 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 		}
 
 		if rowsAffected == 0 {
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -79,7 +79,6 @@ func (o *Batch) GetUnassignedBatch(ctx context.Context, maxActiveAttempts, maxTo
 	db = db.Where("total_attempts < ?", maxTotalAttempts)
 	db = db.Where("active_attempts < ?", maxActiveAttempts)
 	db = db.Where("chunk_proofs_status = ?", int(types.ChunkProofsStatusReady))
-	db = db.Order("index ASC")
 
 	var batch Batch
 	err := db.First(&batch).Error

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -72,6 +72,7 @@ func (*Batch) TableName() string {
 }
 
 // GetUnassignedBatch retrieves unassigned batch based on the specified limit.
+// The returned batch are sorted in ascending order by their index.
 func (o *Batch) GetUnassignedBatch(ctx context.Context, maxActiveAttempts, maxTotalAttempts uint8) (*Batch, error) {
 	db := o.db.WithContext(ctx)
 	db = db.Where("proving_status not in (?)", []int{int(types.ProvingTaskVerified), int(types.ProvingTaskFailed)})

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -72,7 +72,6 @@ func (*Batch) TableName() string {
 }
 
 // GetUnassignedBatch retrieves unassigned batch based on the specified limit.
-// The returned batch are sorted in ascending order by their index.
 func (o *Batch) GetUnassignedBatch(ctx context.Context, maxActiveAttempts, maxTotalAttempts uint8) (*Batch, error) {
 	db := o.db.WithContext(ctx)
 	db = db.Where("proving_status not in (?)", []int{int(types.ProvingTaskVerified), int(types.ProvingTaskFailed)})

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -75,7 +75,6 @@ func (o *Chunk) GetUnassignedChunk(ctx context.Context, height int, maxActiveAtt
 	db = db.Where("total_attempts < ?", maxTotalAttempts)
 	db = db.Where("active_attempts < ?", maxActiveAttempts)
 	db = db.Where("end_block_number <= ?", height)
-	db = db.Order("index ASC")
 
 	var chunk Chunk
 	err := db.First(&chunk).Error

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -67,7 +67,6 @@ func (*Chunk) TableName() string {
 }
 
 // GetUnassignedChunk retrieves unassigned chunk based on the specified limit.
-// The returned chunks are sorted in ascending order by their index.
 func (o *Chunk) GetUnassignedChunk(ctx context.Context, height int, maxActiveAttempts, maxTotalAttempts uint8) (*Chunk, error) {
 	db := o.db.WithContext(ctx)
 	db = db.Model(&Chunk{})

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -67,6 +67,7 @@ func (*Chunk) TableName() string {
 }
 
 // GetUnassignedChunk retrieves unassigned chunk based on the specified limit.
+// The returned chunks are sorted in ascending order by their index.
 func (o *Chunk) GetUnassignedChunk(ctx context.Context, height int, maxActiveAttempts, maxTotalAttempts uint8) (*Chunk, error) {
 	db := o.db.WithContext(ctx)
 	db = db.Model(&Chunk{})


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

fix get_task use too many cpu

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
