### PR TITLE
feat(bridge-history): add GIN metrics and separate /ready and /health endpoints to different ports

### DIFF
--- a/bridge-history-api/cmd/backend_server/app/app.go
+++ b/bridge-history-api/cmd/backend_server/app/app.go
@@ -65,11 +65,12 @@ func action(ctx *cli.Context) error {
 			log.Crit("run http server failure", "error", runServerErr)
 		}
 	}()
+
+	observability.Server(ctx, db)
+
 	// Catch CTRL-C to ensure a graceful shutdown.
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
-
-	observability.Server(ctx, db)
 
 	// Wait until the interrupt signal is received from an OS signal.
 	<-interrupt

--- a/bridge-history-api/cmd/backend_server/app/app.go
+++ b/bridge-history-api/cmd/backend_server/app/app.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli/v2"
 
 	"bridge-history-api/config"
@@ -55,7 +56,9 @@ func action(ctx *cli.Context) error {
 
 	router := gin.Default()
 	controller.InitController(db)
-	route.Route(router, cfg)
+
+	registry := prometheus.DefaultRegisterer
+	route.Route(router, cfg, registry)
 
 	go func() {
 		if runServerErr := router.Run(fmt.Sprintf(":%s", port)); runServerErr != nil {

--- a/bridge-history-api/cmd/backend_server/app/app.go
+++ b/bridge-history-api/cmd/backend_server/app/app.go
@@ -12,6 +12,7 @@ import (
 	"bridge-history-api/config"
 	"bridge-history-api/internal/controller"
 	"bridge-history-api/internal/route"
+	"bridge-history-api/observability"
 	"bridge-history-api/utils"
 )
 
@@ -64,6 +65,8 @@ func action(ctx *cli.Context) error {
 	// Catch CTRL-C to ensure a graceful shutdown.
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
+
+	observability.Server(ctx, db)
 
 	// Wait until the interrupt signal is received from an OS signal.
 	<-interrupt

--- a/bridge-history-api/go.mod
+++ b/bridge-history-api/go.mod
@@ -3,14 +3,17 @@ module bridge-history-api
 go 1.19
 
 require (
+	github.com/bits-and-blooms/bitset v1.7.0
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/gin-contrib/cors v1.4.0
+	github.com/gin-contrib/pprof v1.4.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.19
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pressly/goose/v3 v3.7.0
+	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.8.3
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/sync v0.3.0
@@ -22,7 +25,6 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bits-and-blooms/bitset v1.7.0 // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/bytedance/sonic v1.9.2 // indirect
@@ -96,7 +98,6 @@ require (
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect

--- a/bridge-history-api/go.sum
+++ b/bridge-history-api/go.sum
@@ -119,6 +119,8 @@ github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnR
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0g=
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
+github.com/gin-contrib/pprof v1.4.0 h1:XxiBSf5jWZ5i16lNOPbMTVdgHBdhfGRD5PZ1LWazzvg=
+github.com/gin-contrib/pprof v1.4.0/go.mod h1:RrehPJasUVBPK6yTUwOl8/NP6i0vbUgmxtis+Z5KE90=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=

--- a/bridge-history-api/internal/route/route.go
+++ b/bridge-history-api/internal/route/route.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"bridge-history-api/config"
 	"bridge-history-api/internal/controller"
+	"bridge-history-api/observability"
 )
 
 // Route routes the APIs
-func Route(router *gin.Engine, conf *config.Config) {
+func Route(router *gin.Engine, conf *config.Config, reg prometheus.Registerer) {
 	router.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"*"},
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE"},
@@ -19,6 +21,8 @@ func Route(router *gin.Engine, conf *config.Config) {
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
 	}))
+
+	observability.Use(router, "bridge-history", reg)
 
 	r := router.Group("api/")
 	r.POST("/txsbyhashes", controller.HistoryCtrler.PostQueryTxsByHash)

--- a/bridge-history-api/internal/route/route.go
+++ b/bridge-history-api/internal/route/route.go
@@ -23,6 +23,4 @@ func Route(router *gin.Engine, conf *config.Config) {
 	r := router.Group("api/")
 	r.POST("/txsbyhashes", controller.HistoryCtrler.PostQueryTxsByHash)
 	r.GET("/claimable", controller.HistoryCtrler.GetAllClaimableTxsByAddr)
-	r.GET("/health", controller.HealthCheck.HealthCheck)
-	r.GET("/ready", controller.Ready.Ready)
 }

--- a/bridge-history-api/observability/ginmetrics/bloom.go
+++ b/bridge-history-api/observability/ginmetrics/bloom.go
@@ -1,0 +1,57 @@
+package ginmetrics
+
+import (
+	"github.com/bits-and-blooms/bitset"
+)
+
+const defaultSize = 2 << 24
+
+var seeds = []uint{7, 11, 13, 31, 37, 61}
+
+// BloomFilter a simple bloom filter
+type BloomFilter struct {
+	Set   *bitset.BitSet
+	Funcs [6]simpleHash
+}
+
+// NewBloomFilter new a BloomFilter
+func NewBloomFilter() *BloomFilter {
+	bf := new(BloomFilter)
+	for i := 0; i < len(bf.Funcs); i++ {
+		bf.Funcs[i] = simpleHash{defaultSize, seeds[i]}
+	}
+	bf.Set = bitset.New(defaultSize)
+	return bf
+}
+
+// Add a value to BloomFilter
+func (bf *BloomFilter) Add(value string) {
+	for _, f := range bf.Funcs {
+		bf.Set.Set(f.hash(value))
+	}
+}
+
+// Contains check the value is in bloom filter
+func (bf *BloomFilter) Contains(value string) bool {
+	if value == "" {
+		return false
+	}
+	ret := true
+	for _, f := range bf.Funcs {
+		ret = ret && bf.Set.Test(f.hash(value))
+	}
+	return ret
+}
+
+type simpleHash struct {
+	Cap  uint
+	Seed uint
+}
+
+func (s *simpleHash) hash(value string) uint {
+	var result uint = 0
+	for i := 0; i < len(value); i++ {
+		result = result*s.Seed + uint(value[i])
+	}
+	return (s.Cap - 1) & result
+}

--- a/bridge-history-api/observability/ginmetrics/metric.go
+++ b/bridge-history-api/observability/ginmetrics/metric.go
@@ -1,0 +1,89 @@
+package ginmetrics
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metric defines a metric object. Users can use it to save
+// metric data. Every metric should be globally unique by name.
+type Metric struct {
+	Type        MetricType
+	Name        string
+	Description string
+	Labels      []string
+	Buckets     []float64
+	Objectives  map[float64]float64
+
+	vec prometheus.Collector
+}
+
+// SetGaugeValue set data for Gauge type Metric.
+func (m *Metric) SetGaugeValue(labelValues []string, value float64) error {
+	if m.Type == None {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+
+	if m.Type != Gauge {
+		return fmt.Errorf("metric %s not Gauge type", m.Name)
+	}
+	m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Set(value)
+	return nil
+}
+
+// Inc increases value for Counter/Gauge type metric, increments
+// the counter by 1
+func (m *Metric) Inc(labelValues []string) error {
+	if m.Type == None {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+
+	if m.Type != Gauge && m.Type != Counter {
+		return fmt.Errorf("metric %s not Gauge or Counter type", m.Name)
+	}
+	switch m.Type {
+	case Counter:
+		m.vec.(*prometheus.CounterVec).WithLabelValues(labelValues...).Inc()
+	case Gauge:
+		m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Inc()
+	}
+	return nil
+}
+
+// Add adds the given value to the Metric object. Only
+// for Counter/Gauge type metric.
+func (m *Metric) Add(labelValues []string, value float64) error {
+	if m.Type == None {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+
+	if m.Type != Gauge && m.Type != Counter {
+		return fmt.Errorf("metric %s not Gauge or Counter type", m.Name)
+	}
+	switch m.Type {
+	case Counter:
+		m.vec.(*prometheus.CounterVec).WithLabelValues(labelValues...).Add(value)
+	case Gauge:
+		m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Add(value)
+	}
+	return nil
+}
+
+// Observe is used by Histogram and Summary type metric to
+// add observations.
+func (m *Metric) Observe(labelValues []string, value float64) error {
+	if m.Type == 0 {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+	if m.Type != Histogram && m.Type != Summary {
+		return fmt.Errorf("metric %s not Histogram or Summary type", m.Name)
+	}
+	switch m.Type {
+	case Histogram:
+		m.vec.(*prometheus.HistogramVec).WithLabelValues(labelValues...).Observe(value)
+	case Summary:
+		m.vec.(*prometheus.SummaryVec).WithLabelValues(labelValues...).Observe(value)
+	}
+	return nil
+}

--- a/bridge-history-api/observability/ginmetrics/middleware.go
+++ b/bridge-history-api/observability/ginmetrics/middleware.go
@@ -1,0 +1,155 @@
+package ginmetrics
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	metricRequestTotal    = "request_total"
+	metricRequestUVTotal  = "request_uv_total"
+	metricURIRequestTotal = "uri_request_total"
+	metricRequestBody     = "request_body_total"
+	metricResponseBody    = "response_body_total"
+	metricRequestDuration = "request_duration"
+	metricSlowRequest     = "slow_request_total"
+
+	bloomFilter *BloomFilter
+)
+
+// Use set gin metrics middleware
+func (m *Monitor) Use(r gin.IRoutes) {
+	m.initGinMetrics()
+
+	r.Use(m.monitorInterceptor)
+	r.GET(m.metricPath, func(ctx *gin.Context) {
+		promhttp.Handler().ServeHTTP(ctx.Writer, ctx.Request)
+	})
+}
+
+// UseWithoutExposingEndpoint is used to add monitor interceptor to gin router
+// It can be called multiple times to intercept from multiple gin.IRoutes
+// http path is not set, to do that use Expose function
+func (m *Monitor) UseWithoutExposingEndpoint(r gin.IRoutes) {
+	m.initGinMetrics()
+	r.Use(m.monitorInterceptor)
+}
+
+// Expose adds metric path to a given router.
+// The router can be different with the one passed to UseWithoutExposingEndpoint.
+// This allows to expose metrics on different port.
+func (m *Monitor) Expose(r gin.IRoutes) {
+	r.GET(m.metricPath, func(ctx *gin.Context) {
+		promhttp.Handler().ServeHTTP(ctx.Writer, ctx.Request)
+	})
+}
+
+// initGinMetrics used to init gin metrics
+func (m *Monitor) initGinMetrics() {
+	bloomFilter = NewBloomFilter()
+
+	_ = monitor.AddMetric(&Metric{
+		Type:        Counter,
+		Name:        metricRequestTotal,
+		Description: "all the server received request num.",
+		Labels:      nil,
+	})
+	_ = monitor.AddMetric(&Metric{
+		Type:        Counter,
+		Name:        metricRequestUVTotal,
+		Description: "all the server received ip num.",
+		Labels:      nil,
+	})
+	_ = monitor.AddMetric(&Metric{
+		Type:        Counter,
+		Name:        metricURIRequestTotal,
+		Description: "all the server received request num with every uri.",
+		Labels:      []string{"uri", "method", "code"},
+	})
+	_ = monitor.AddMetric(&Metric{
+		Type:        Counter,
+		Name:        metricRequestBody,
+		Description: "the server received request body size, unit byte",
+		Labels:      nil,
+	})
+	_ = monitor.AddMetric(&Metric{
+		Type:        Counter,
+		Name:        metricResponseBody,
+		Description: "the server send response body size, unit byte",
+		Labels:      nil,
+	})
+	_ = monitor.AddMetric(&Metric{
+		Type:        Histogram,
+		Name:        metricRequestDuration,
+		Description: "the time server took to handle the request.",
+		Labels:      []string{"uri"},
+		Buckets:     m.reqDuration,
+	})
+	_ = monitor.AddMetric(&Metric{
+		Type:        Counter,
+		Name:        metricSlowRequest,
+		Description: fmt.Sprintf("the server handled slow requests counter, t=%d.", m.slowTime),
+		Labels:      []string{"uri", "method", "code"},
+	})
+}
+
+// monitorInterceptor as gin monitor middleware.
+func (m *Monitor) monitorInterceptor(ctx *gin.Context) {
+	if ctx.Request.URL.Path == m.metricPath {
+		ctx.Next()
+		return
+	}
+	startTime := time.Now()
+
+	// execute normal process.
+	ctx.Next()
+
+	// after request
+	m.ginMetricHandle(ctx, startTime)
+}
+
+func (m *Monitor) ginMetricHandle(ctx *gin.Context, start time.Time) {
+	r := ctx.Request
+	w := ctx.Writer
+
+	//set request total
+	_ = m.GetMetric(metricRequestTotal).Inc(nil)
+
+	// set uv
+	if clientIP := ctx.ClientIP(); !bloomFilter.Contains(clientIP) {
+		bloomFilter.Add(clientIP)
+		_ = m.GetMetric(metricRequestUVTotal).Inc(nil)
+	}
+
+	errCode := strconv.Itoa(ctx.GetInt("errcode"))
+	if len(errCode) == 0 {
+		errCode = strconv.Itoa(w.Status())
+	}
+
+	// set uri request total
+	_ = m.GetMetric(metricURIRequestTotal).Inc([]string{ctx.FullPath(), r.Method, errCode})
+
+	// set request body size
+	// since r.ContentLength can be negative (in some occasions) guard the operation
+	if r.ContentLength >= 0 {
+		_ = m.GetMetric(metricRequestBody).Add(nil, float64(r.ContentLength))
+	}
+
+	// set slow request
+	latency := time.Since(start)
+	if int32(latency.Seconds()) > m.slowTime {
+		_ = m.GetMetric(metricSlowRequest).Inc([]string{ctx.FullPath(), r.Method, strconv.Itoa(w.Status())})
+	}
+
+	// set request duration
+	_ = m.GetMetric(metricRequestDuration).Observe([]string{ctx.FullPath()}, latency.Seconds())
+
+	// set response size
+	if w.Size() > 0 {
+		_ = m.GetMetric(metricResponseBody).Add(nil, float64(w.Size()))
+	}
+}

--- a/bridge-history-api/observability/ginmetrics/types.go
+++ b/bridge-history-api/observability/ginmetrics/types.go
@@ -1,0 +1,158 @@
+package ginmetrics
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// MetricType define metric type
+type MetricType int
+
+const (
+	// None unknown metric type
+	None MetricType = iota
+	// Counter MetricType
+	Counter
+	// Gauge MetricType
+	Gauge
+	// Histogram MetricType
+	Histogram
+	// Summary MetricType
+	Summary
+
+	defaultMetricPath = "/debug/metrics"
+	defaultSlowTime   = int32(5)
+)
+
+var (
+	defaultDuration = []float64{0.1, 0.3, 1.2, 5, 10}
+	monitor         *Monitor
+
+	promTypeHandler = map[MetricType]func(metric *Metric, reg prometheus.Registerer){
+		Counter:   counterHandler,
+		Gauge:     gaugeHandler,
+		Histogram: histogramHandler,
+		Summary:   summaryHandler,
+	}
+)
+
+// Monitor is an object that uses to set gin server monitor.
+type Monitor struct {
+	slowTime    int32
+	metricPath  string
+	reqDuration []float64
+	metrics     map[string]*Metric
+	register    prometheus.Registerer
+}
+
+// GetMonitor used to get global Monitor object,
+// this function returns a singleton object.
+func GetMonitor(reg prometheus.Registerer) *Monitor {
+	if monitor == nil {
+		monitor = &Monitor{
+			metricPath:  defaultMetricPath,
+			slowTime:    defaultSlowTime,
+			reqDuration: defaultDuration,
+			metrics:     make(map[string]*Metric),
+			register:    reg,
+		}
+	}
+	return monitor
+}
+
+// GetMetric used to get metric object by metric_name.
+func (m *Monitor) GetMetric(name string) *Metric {
+	if metric, ok := m.metrics[name]; ok {
+		return metric
+	}
+	return &Metric{}
+}
+
+// SetMetricPath set metricPath property. metricPath is used for Prometheus
+// to get gin server monitoring data.
+func (m *Monitor) SetMetricPath(path string) {
+	m.metricPath = path
+}
+
+// SetSlowTime set slowTime property. slowTime is used to determine whether
+// the request is slow. For "gin_slow_request_total" metric.
+func (m *Monitor) SetSlowTime(slowTime int32) {
+	m.slowTime = slowTime
+}
+
+// SetDuration set reqDuration property. reqDuration is used to ginRequestDuration
+// metric buckets.
+func (m *Monitor) SetDuration(duration []float64) {
+	m.reqDuration = duration
+}
+
+// SetMetricPrefix set the metric prefix
+func (m *Monitor) SetMetricPrefix(prefix string) {
+	metricRequestTotal = prefix + metricRequestTotal
+	metricRequestUVTotal = prefix + metricRequestUVTotal
+	metricURIRequestTotal = prefix + metricURIRequestTotal
+	metricRequestBody = prefix + metricRequestBody
+	metricResponseBody = prefix + metricResponseBody
+	metricRequestDuration = prefix + metricRequestDuration
+	metricSlowRequest = prefix + metricSlowRequest
+}
+
+// SetMetricSuffix set the metric suffix
+func (m *Monitor) SetMetricSuffix(suffix string) {
+	metricRequestTotal += suffix
+	metricRequestUVTotal += suffix
+	metricURIRequestTotal += suffix
+	metricRequestBody += suffix
+	metricResponseBody += suffix
+	metricRequestDuration += suffix
+	metricSlowRequest += suffix
+}
+
+// AddMetric add custom monitor metric.
+func (m *Monitor) AddMetric(metric *Metric) error {
+	if _, ok := m.metrics[metric.Name]; ok {
+		return fmt.Errorf("metric %s is existed", metric.Name)
+	}
+
+	if metric.Name == "" {
+		return errors.New("metric name cannot be empty")
+	}
+
+	if f, ok := promTypeHandler[metric.Type]; ok {
+		f(metric, m.register)
+		m.metrics[metric.Name] = metric
+	}
+
+	return nil
+}
+
+func counterHandler(metric *Metric, register prometheus.Registerer) {
+	metric.vec = promauto.With(register).NewCounterVec(
+		prometheus.CounterOpts{Name: metric.Name, Help: metric.Description},
+		metric.Labels,
+	)
+}
+
+func gaugeHandler(metric *Metric, register prometheus.Registerer) {
+	metric.vec = promauto.With(register).NewGaugeVec(
+		prometheus.GaugeOpts{Name: metric.Name, Help: metric.Description},
+		metric.Labels,
+	)
+}
+
+func histogramHandler(metric *Metric, register prometheus.Registerer) {
+	metric.vec = promauto.With(register).NewHistogramVec(
+		prometheus.HistogramOpts{Name: metric.Name, Help: metric.Description, Buckets: metric.Buckets},
+		metric.Labels,
+	)
+}
+
+func summaryHandler(metric *Metric, register prometheus.Registerer) {
+	promauto.With(register).NewSummaryVec(
+		prometheus.SummaryOpts{Name: metric.Name, Help: metric.Description, Objectives: metric.Objectives},
+		metric.Labels,
+	)
+}

--- a/bridge-history-api/observability/middleware.go
+++ b/bridge-history-api/observability/middleware.go
@@ -1,0 +1,18 @@
+package observability
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"scroll-tech/common/observability/ginmetrics"
+)
+
+// Use register the gin metric
+func Use(router *gin.Engine, metricsPrefix string, reg prometheus.Registerer) {
+	m := ginmetrics.GetMonitor(reg)
+	m.SetMetricPath("/metrics")
+	m.SetMetricPrefix(metricsPrefix + "_")
+	m.SetSlowTime(1)
+	m.SetDuration([]float64{0.025, .05, .1, .5, 1, 5, 10})
+	m.UseWithoutExposingEndpoint(router)
+}

--- a/bridge-history-api/observability/probes.go
+++ b/bridge-history-api/observability/probes.go
@@ -1,0 +1,35 @@
+package observability
+
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"scroll-tech/common/database"
+	"scroll-tech/common/types"
+)
+
+// ProbesController probe check controller
+type ProbesController struct {
+	db *gorm.DB
+}
+
+// NewProbesController returns an ProbesController instance
+func NewProbesController(db *gorm.DB) *ProbesController {
+	return &ProbesController{
+		db: db,
+	}
+}
+
+// HealthCheck the api controller for health check
+func (a *ProbesController) HealthCheck(c *gin.Context) {
+	if _, err := database.Ping(a.db); err != nil {
+		types.RenderFatal(c, err)
+		return
+	}
+	types.RenderSuccess(c, nil)
+}
+
+// Ready the api controller for ready check
+func (a *ProbesController) Ready(c *gin.Context) {
+	types.RenderSuccess(c, nil)
+}

--- a/bridge-history-api/observability/server.go
+++ b/bridge-history-api/observability/server.go
@@ -1,0 +1,53 @@
+package observability
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	// enable the pprof
+	_ "net/http/pprof"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/gin-contrib/pprof"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/urfave/cli/v2"
+	"gorm.io/gorm"
+
+	"scroll-tech/common/utils"
+)
+
+// Server starts the metrics server on the given address, will be closed when the given
+// context is canceled.
+func Server(c *cli.Context, db *gorm.DB) {
+	if !c.Bool(utils.MetricsEnabled.Name) {
+		return
+	}
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	pprof.Register(r)
+	r.GET("/metrics", func(context *gin.Context) {
+		promhttp.Handler().ServeHTTP(context.Writer, context.Request)
+	})
+
+	probeController := NewProbesController(db)
+	r.GET("/health", probeController.HealthCheck)
+	r.GET("/ready", probeController.Ready)
+
+	address := fmt.Sprintf(":%s", c.String(utils.MetricsPort.Name))
+	server := &http.Server{
+		Addr:              address,
+		Handler:           r,
+		ReadHeaderTimeout: time.Minute,
+	}
+	log.Info("Starting metrics server", "address", address)
+
+	go func() {
+		if runServerErr := server.ListenAndServe(); runServerErr != nil && !errors.Is(runServerErr, http.ErrServerClosed) {
+			log.Crit("run metrics http server failure", "error", runServerErr)
+		}
+	}()
+}

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.21"
+var tag = "v4.3.22"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

**Changes:**
1. Separate ready and health APIs from business APIs.
2. GIN metrics.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
