### PR TITLE
refactor(bridge-history): rename metrics

### DIFF
--- a/bridge-history-api/internal/controller/metrics.go
+++ b/bridge-history-api/internal/controller/metrics.go
@@ -22,14 +22,14 @@ func initCacheMetrics() *cacheMetrics {
 		cm = &cacheMetrics{
 			cacheHits: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Name: "cache_hits_total",
+					Name: "bridge_history_api_cache_hits_total",
 					Help: "The total number of cache hits",
 				},
 				[]string{"api"},
 			),
 			cacheMisses: promauto.NewCounterVec(
 				prometheus.CounterOpts{
-					Name: "cache_misses_total",
+					Name: "bridge_history_api_cache_misses_total",
 					Help: "The total number of cache misses",
 				},
 				[]string{"api"},

--- a/bridge-history-api/internal/route/route.go
+++ b/bridge-history-api/internal/route/route.go
@@ -22,7 +22,7 @@ func Route(router *gin.Engine, conf *config.Config, reg prometheus.Registerer) {
 		MaxAge:           12 * time.Hour,
 	}))
 
-	observability.Use(router, "bridge_history", reg)
+	observability.Use(router, "bridge_history_api", reg)
 
 	r := router.Group("api/")
 	r.POST("/txsbyhashes", controller.HistoryCtrler.PostQueryTxsByHash)

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.24"
+var tag = "v4.3.25"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Add `bridge_history_api` prefix in `bridge-history-api` metrics.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
