### PR TITLE
feat(watcher&rollup): add block commit calldata size and commit/finalize batch revert metrics

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.26"
+var tag = "v4.3.27"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -582,6 +582,7 @@ func (r *Layer2Relayer) handleConfirmation(confirmation *sender.Confirmation) {
 			status = types.RollupCommitted
 		} else {
 			status = types.RollupCommitFailed
+			r.metrics.rollupL2BatchesCommittedConfirmedFailedTotal.Inc()
 			log.Warn("transaction confirmed but failed in layer1", "confirmation", confirmation)
 		}
 		// @todo handle db error
@@ -603,6 +604,7 @@ func (r *Layer2Relayer) handleConfirmation(confirmation *sender.Confirmation) {
 			status = types.RollupFinalized
 		} else {
 			status = types.RollupFinalizeFailed
+			r.metrics.rollupL2BatchesFinalizedConfirmedFailedTotal.Inc()
 			log.Warn("transaction confirmed but failed in layer1", "confirmation", confirmation)
 		}
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -583,7 +583,7 @@ func (r *Layer2Relayer) handleConfirmation(confirmation *sender.Confirmation) {
 		} else {
 			status = types.RollupCommitFailed
 			r.metrics.rollupL2BatchesCommittedConfirmedFailedTotal.Inc()
-			log.Warn("transaction confirmed but failed in layer1", "confirmation", confirmation)
+			log.Warn("commitBatch transaction confirmed but failed in layer1", "confirmation", confirmation)
 		}
 		// @todo handle db error
 		err := r.batchOrm.UpdateCommitTxHashAndRollupStatus(r.ctx, batchHash.(string), confirmation.TxHash.String(), status)
@@ -605,7 +605,7 @@ func (r *Layer2Relayer) handleConfirmation(confirmation *sender.Confirmation) {
 		} else {
 			status = types.RollupFinalizeFailed
 			r.metrics.rollupL2BatchesFinalizedConfirmedFailedTotal.Inc()
-			log.Warn("transaction confirmed but failed in layer1", "confirmation", confirmation)
+			log.Warn("finalizeBatchWithProof transaction confirmed but failed in layer1", "confirmation", confirmation)
 		}
 
 		// @todo handle db error

--- a/rollup/internal/controller/relayer/l2_relayer_metrics.go
+++ b/rollup/internal/controller/relayer/l2_relayer_metrics.go
@@ -16,7 +16,9 @@ type l2RelayerMetrics struct {
 	rollupL2RelayerProcessCommittedBatchesFinalizedTotal        prometheus.Counter
 	rollupL2RelayerProcessCommittedBatchesFinalizedSuccessTotal prometheus.Counter
 	rollupL2BatchesCommittedConfirmedTotal                      prometheus.Counter
+	rollupL2BatchesCommittedConfirmedFailedTotal                prometheus.Counter
 	rollupL2BatchesFinalizedConfirmedTotal                      prometheus.Counter
+	rollupL2BatchesFinalizedConfirmedFailedTotal                prometheus.Counter
 	rollupL2BatchesGasOraclerConfirmedTotal                     prometheus.Counter
 	rollupL2ChainMonitorLatestFailedCall                        prometheus.Counter
 	rollupL2ChainMonitorLatestFailedBatchStatus                 prometheus.Counter
@@ -62,9 +64,17 @@ func initL2RelayerMetrics(reg prometheus.Registerer) *l2RelayerMetrics {
 				Name: "rollup_layer2_process_committed_batches_confirmed_total",
 				Help: "The total number of layer2 process committed batches confirmed total",
 			}),
+			rollupL2BatchesCommittedConfirmedFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+				Name: "rollup_layer2_process_committed_batches_confirmed_failed_total",
+				Help: "The total number of layer2 process committed batches confirmed failed total",
+			}),
 			rollupL2BatchesFinalizedConfirmedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 				Name: "rollup_layer2_process_finalized_batches_confirmed_total",
 				Help: "The total number of layer2 process finalized batches confirmed total",
+			}),
+			rollupL2BatchesFinalizedConfirmedFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+				Name: "rollup_layer2_process_finalized_batches_confirmed_failed_total",
+				Help: "The total number of layer2 process finalized batches confirmed failed total",
 			}),
 			rollupL2BatchesGasOraclerConfirmedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 				Name: "rollup_layer2_process_gras_oracler_confirmed_total",

--- a/rollup/internal/controller/watcher/l2_watcher.go
+++ b/rollup/internal/controller/watcher/l2_watcher.go
@@ -180,6 +180,9 @@ func (w *L2WatcherClient) getAndStoreBlockTraces(ctx context.Context, from, to u
 	}
 
 	if len(blocks) > 0 {
+		for _, block := range blocks {
+			w.metrics.rollupL2BlockL1CommitCalldataSize.Set(float64(block.EstimateL1CommitCalldataSize()))
+		}
 		if err := w.l2BlockOrm.InsertL2Blocks(w.ctx, blocks); err != nil {
 			return fmt.Errorf("failed to batch insert BlockTraces: %v", err)
 		}

--- a/rollup/internal/controller/watcher/l2_watcher_metrics.go
+++ b/rollup/internal/controller/watcher/l2_watcher_metrics.go
@@ -8,12 +8,13 @@ import (
 )
 
 type l2WatcherMetrics struct {
-	fetchRunningMissingBlocksTotal  prometheus.Counter
-	fetchRunningMissingBlocksHeight prometheus.Gauge
-	fetchContractEventTotal         prometheus.Counter
-	fetchContractEventHeight        prometheus.Gauge
-	rollupL2MsgsRelayedEventsTotal  prometheus.Counter
-	rollupL2BlocksFetchedGap        prometheus.Gauge
+	fetchRunningMissingBlocksTotal    prometheus.Counter
+	fetchRunningMissingBlocksHeight   prometheus.Gauge
+	fetchContractEventTotal           prometheus.Counter
+	fetchContractEventHeight          prometheus.Gauge
+	rollupL2MsgsRelayedEventsTotal    prometheus.Counter
+	rollupL2BlocksFetchedGap          prometheus.Gauge
+	rollupL2BlockL1CommitCalldataSize prometheus.Gauge
 }
 
 var (
@@ -47,6 +48,10 @@ func initL2WatcherMetrics(reg prometheus.Registerer) *l2WatcherMetrics {
 			rollupL2BlocksFetchedGap: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 				Name: "rollup_l2_watcher_blocks_fetched_gap",
 				Help: "The gap of l2 fetch",
+			}),
+			rollupL2BlockL1CommitCalldataSize: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+				Name: "rollup_l2_block_commit_calldata_size",
+				Help: "The l2 block commit calldata size",
 			}),
 		}
 	})

--- a/rollup/internal/controller/watcher/l2_watcher_metrics.go
+++ b/rollup/internal/controller/watcher/l2_watcher_metrics.go
@@ -50,8 +50,8 @@ func initL2WatcherMetrics(reg prometheus.Registerer) *l2WatcherMetrics {
 				Help: "The gap of l2 fetch",
 			}),
 			rollupL2BlockL1CommitCalldataSize: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-				Name: "rollup_l2_block_commit_calldata_size",
-				Help: "The l2 block commit calldata size",
+				Name: "rollup_l2_block_l1_commit_calldata_size",
+				Help: "The l1 commitBatch calldata size of the l2 block",
 			}),
 		}
 	})


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR adds:
1. A block commit calldata size metric in l2-watcher.
2. Commit/finalize batch revert metrics in rollup-relayer.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
