### PR TITLE
fix(rollup-relayer): better handle commit batch revert

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.30"
+var tag = "v4.3.31"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -380,7 +380,7 @@ func (r *Layer2Relayer) ProcessPendingBatches() {
 		if types.RollupStatus(batch.RollupStatus) == types.RollupCommitFailed {
 			// use eth_estimateGas if this batch has been committed failed.
 			fallbackGasLimit = 0
-			log.Warn("Batch commit previously failed, using eth_estimateGas for next submission", "hash", batch.Hash)
+			log.Warn("Batch commit previously failed, using eth_estimateGas for the re-submission", "hash", batch.Hash)
 		}
 		txHash, err := r.commitSender.SendTransaction(txID, &r.cfg.RollupContractAddress, big.NewInt(0), calldata, fallbackGasLimit)
 		if err != nil {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -378,8 +378,9 @@ func (r *Layer2Relayer) ProcessPendingBatches() {
 		txID := batch.Hash + "-commit"
 		fallbackGasLimit := uint64(float64(batch.TotalL1CommitGas) * r.cfg.L1CommitGasLimitMultiplier)
 		if types.RollupStatus(batch.RollupStatus) == types.RollupCommitFailed {
-			// use estimateGas if this batch has been committed failed.
+			// use eth_estimateGas if this batch has been committed failed.
 			fallbackGasLimit = 0
+			log.Warn("Batch commit previously failed, using eth_estimateGas for next submission", "hash", batch.Hash)
 		}
 		txHash, err := r.commitSender.SendTransaction(txID, &r.cfg.RollupContractAddress, big.NewInt(0), calldata, fallbackGasLimit)
 		if err != nil {

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -192,22 +192,22 @@ func (o *Batch) GetRollupStatusByHashList(ctx context.Context, hashes []string) 
 	return statuses, nil
 }
 
-// GetPendingBatches retrieves pending batches up to the specified limit.
+// GetFailedAndPendingBatches retrieves batches with failed or pending status up to the specified limit.
 // The returned batches are sorted in ascending order by their index.
-func (o *Batch) GetPendingBatches(ctx context.Context, limit int) ([]*Batch, error) {
+func (o *Batch) GetFailedAndPendingBatches(ctx context.Context, limit int) ([]*Batch, error) {
 	if limit <= 0 {
 		return nil, errors.New("limit must be greater than zero")
 	}
 
 	db := o.db.WithContext(ctx)
 	db = db.Model(&Batch{})
-	db = db.Where("rollup_status = ?", types.RollupPending)
+	db = db.Where("rollup_status = ? OR rollup_status = ?", types.RollupCommitFailed, types.RollupPending)
 	db = db.Order("index ASC")
 	db = db.Limit(limit)
 
 	var batches []*Batch
 	if err := db.Find(&batches).Error; err != nil {
-		return nil, fmt.Errorf("Batch.GetPendingBatches error: %w", err)
+		return nil, fmt.Errorf("Batch.GetFailedAndPendingBatches error: %w", err)
 	}
 	return batches, nil
 }

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -258,14 +258,17 @@ func TestBatchOrm(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(2), count)
 
-	pendingBatches, err := batchOrm.GetPendingBatches(context.Background(), 100)
+	err = batchOrm.UpdateRollupStatus(context.Background(), batchHash1, types.RollupCommitFailed)
+	assert.NoError(t, err)
+
+	pendingBatches, err := batchOrm.GetFailedAndPendingBatches(context.Background(), 100)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(pendingBatches))
 
 	rollupStatus, err := batchOrm.GetRollupStatusByHashList(context.Background(), []string{batchHash1, batchHash2})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(rollupStatus))
-	assert.Equal(t, types.RollupPending, rollupStatus[0])
+	assert.Equal(t, types.RollupCommitFailed, rollupStatus[0])
 	assert.Equal(t, types.RollupPending, rollupStatus[1])
 
 	err = batchOrm.UpdateProvingStatus(context.Background(), batchHash2, types.ProvingTaskVerified)


### PR DESCRIPTION
### Purpose or design rationale of this PR

**Problem:**
When `rollup-relayer` encounters a batch commit failure, it continues to commit subsequent batches, which would fail.

**Solutions:**
1. Before committing a new batch, check If the parent batch has failed, if so, stop.
2. Use `estimateGas` for batches that have been committed failed.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
