### PR TITLE
fix (libzkp): free Rust CString by `from_raw`

### DIFF
--- a/common/libzkp/impl/src/utils.rs
+++ b/common/libzkp/impl/src/utils.rs
@@ -11,6 +11,19 @@ use std::{
 pub(crate) static OUTPUT_DIR: Lazy<Option<String>> =
     Lazy::new(|| env::var("PROVER_OUTPUT_DIR").ok());
 
+/// # Safety
+#[no_mangle]
+pub extern "C" fn free_c_chars(ptr: *mut c_char) {
+    if ptr.is_null() {
+        log::warn!("Try to free an empty pointer!");
+        return;
+    }
+
+    unsafe {
+        let _ = CString::from_raw(ptr);
+    }
+}
+
 pub(crate) fn c_char_to_str(c: *const c_char) -> &'static str {
     let cstr = unsafe { CStr::from_ptr(c) };
     cstr.to_str().unwrap()

--- a/common/libzkp/interface/libzkp.h
+++ b/common/libzkp/interface/libzkp.h
@@ -12,3 +12,4 @@ char* gen_chunk_proof(char* block_traces);
 char verify_chunk_proof(char* proof);
 
 char* block_traces_to_chunk_info(char* block_traces);
+void free_c_chars(char* ptr);

--- a/prover/core/prover.go
+++ b/prover/core/prover.go
@@ -42,7 +42,6 @@ func NewProverCore(cfg *config.ProverCoreConfig) (*ProverCore, error) {
 
 	var vk string
 	var rawVK *C.char
-	defer C.free(unsafe.Pointer(rawVK))
 	if cfg.ProofType == message.ProofTypeBatch {
 		C.init_batch_prover(paramsPathStr, assetsPathStr)
 		rawVK = C.get_batch_vk()
@@ -50,6 +49,7 @@ func NewProverCore(cfg *config.ProverCoreConfig) (*ProverCore, error) {
 		C.init_chunk_prover(paramsPathStr, assetsPathStr)
 		rawVK = C.get_chunk_vk()
 	}
+	defer C.free_c_chars(rawVK)
 
 	if rawVK != nil {
 		vk = C.GoString(rawVK)
@@ -162,7 +162,7 @@ func (p *ProverCore) checkChunkProofs(chunkProofsByt []byte) (bool, error) {
 
 	log.Info("Start to check chunk proofs ...")
 	cResult := C.check_chunk_proofs(chunkProofsStr)
-	defer C.free(unsafe.Pointer(cResult))
+	defer C.free_c_chars(cResult)
 	log.Info("Finish checking chunk proofs!")
 
 	var result CheckChunkProofsResponse
@@ -189,7 +189,7 @@ func (p *ProverCore) proveBatch(chunkInfosByt []byte, chunkProofsByt []byte) ([]
 
 	log.Info("Start to create batch proof ...")
 	bResult := C.gen_batch_proof(chunkInfosStr, chunkProofsStr)
-	defer C.free(unsafe.Pointer(bResult))
+	defer C.free_c_chars(bResult)
 	log.Info("Finish creating batch proof!")
 
 	var result ProofResult
@@ -211,7 +211,7 @@ func (p *ProverCore) proveChunk(tracesByt []byte) ([]byte, error) {
 
 	log.Info("Start to create chunk proof ...")
 	cProof := C.gen_chunk_proof(tracesStr)
-	defer C.free(unsafe.Pointer(cProof))
+	defer C.free_c_chars(cProof)
 	log.Info("Finish creating chunk proof!")
 
 	var result ProofResult
@@ -246,7 +246,7 @@ func (p *ProverCore) tracesToChunkInfo(tracesByt []byte) []byte {
 	defer C.free(unsafe.Pointer(tracesStr))
 
 	cChunkInfo := C.block_traces_to_chunk_info(tracesStr)
-	defer C.free(unsafe.Pointer(cChunkInfo))
+	defer C.free_c_chars(cChunkInfo)
 
 	chunkInfo := C.GoString(cChunkInfo)
 	return []byte(chunkInfo)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Proof results and VKs are returned by [vec_to_c_char](https://github.com/scroll-tech/scroll/blob/develop/common/libzkp/impl/src/utils.rs#L29C34-L29C42) or [string_to_c_char](https://github.com/scroll-tech/scroll/blob/develop/common/libzkp/impl/src/utils.rs#L25C35-L25C43) as `*const c_char` which calls [CString::into_raw](https://doc.rust-lang.org/stable/std/ffi/struct.CString.html#method.into_raw), reference [its doc](https://doc.rust-lang.org/stable/std/ffi/struct.CString.html#method.into_raw), the C ptr must be freed by `CString::from_raw` (memory leak otherwise).

- adds a new function `free_c_chars`.
- calls it when returns proof result or VK.

### Test

The memory available could restore (`983 -> 983`) when running a loop (50 chunks from yesterday to morning of today).
The chunk-prover and batch-prover are created for each run of loop.

|date|time|total|used|free|shared|buff/cache|available|
|----|----|-----|----|----|------|----------|---------|
|....|....|.....|....|....|......|..........|.........|
2023-10-23|17:47:16|995|5|793|0|197|983|
2023-10-23|17:47:46|995|6|791|0|197|981|
2023-10-23|17:48:16|995|5|793|0|197|983|
2023-10-23|17:48:46|995|7|790|0|198|981|
2023-10-23|17:49:16|995|25|772|0|198|963|
2023-10-23|17:49:46|995|24|773|0|198|964|
2023-10-23|17:50:16|995|24|773|0|198|964|
2023-10-23|17:50:46|995|26|770|0|198|961|
2023-10-23|17:51:16|995|40|757|0|198|948|
2023-10-23|17:51:46|995|76|720|0|198|911|
2023-10-23|17:52:16|995|141|655|0|198|846|
2023-10-23|17:52:46|995|141|655|0|198|846|
|....|....|.....|....|....|......|..........|.........|
2023-10-24|08:23:28|995|4|788|0|202|983|
2023-10-24|08:23:58|995|4|788|0|202|983|
2023-10-24|08:24:28|995|4|788|0|202|983|
2023-10-24|08:24:58|995|4|788|0|202|983|
|....|....|.....|....|....|......|..........|.........|

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
