### PR TITLE
feat(contracts): make sure prover and sequencer is EOA

### DIFF
--- a/contracts/src/L1/rollup/ScrollChain.sol
+++ b/contracts/src/L1/rollup/ScrollChain.sol
@@ -360,6 +360,10 @@ contract ScrollChain is OwnableUpgradeable, PausableUpgradeable, IScrollChain {
     /// @notice Add an account to the sequencer list.
     /// @param _account The address of account to add.
     function addSequencer(address _account) external onlyOwner {
+        // @note Currently many external services rely on EOA sequencer to decode metadata directly from tx.calldata.
+        // So we explicitly make sure the account is EOA.
+        require(_account.code.length == 0, "not EOA");
+
         isSequencer[_account] = true;
 
         emit UpdateSequencer(_account, true);
@@ -376,6 +380,9 @@ contract ScrollChain is OwnableUpgradeable, PausableUpgradeable, IScrollChain {
     /// @notice Add an account to the prover list.
     /// @param _account The address of account to add.
     function addProver(address _account) external onlyOwner {
+        // @note Currently many external services rely on EOA prover to decode metadata directly from tx.calldata.
+        // So we explicitly make sure the account is EOA.
+        require(_account.code.length == 0, "not EOA");
         isProver[_account] = true;
 
         emit UpdateProver(_account, true);

--- a/contracts/src/test/L1GatewayTestBase.t.sol
+++ b/contracts/src/test/L1GatewayTestBase.t.sol
@@ -106,8 +106,8 @@ abstract contract L1GatewayTestBase is DSTestPlus {
     }
 
     function prepareL2MessageRoot(bytes32 messageHash) internal {
-        rollup.addSequencer(address(this));
-        rollup.addProver(address(this));
+        rollup.addSequencer(address(0));
+        rollup.addProver(address(0));
 
         // import genesis batch
         bytes memory batchHeader0 = new bytes(89);
@@ -122,7 +122,9 @@ abstract contract L1GatewayTestBase is DSTestPlus {
         bytes memory chunk0 = new bytes(1 + 60);
         chunk0[0] = bytes1(uint8(1)); // one block in this chunk
         chunks[0] = chunk0;
+        hevm.startPrank(address(0));
         rollup.commitBatch(0, batchHeader0, chunks, new bytes(0));
+        hevm.stopPrank();
 
         bytes memory batchHeader1 = new bytes(89);
         assembly {
@@ -134,6 +136,7 @@ abstract contract L1GatewayTestBase is DSTestPlus {
             mstore(add(batchHeader1, add(0x20, 57)), batchHash0) // parentBatchHash
         }
 
+        hevm.startPrank(address(0));
         rollup.finalizeBatchWithProof(
             batchHeader1,
             bytes32(uint256(1)),
@@ -141,5 +144,6 @@ abstract contract L1GatewayTestBase is DSTestPlus {
             messageHash,
             new bytes(0)
         );
+        hevm.stopPrank();
     }
 }

--- a/contracts/src/test/ScrollChain.t.sol
+++ b/contracts/src/test/ScrollChain.t.sol
@@ -617,24 +617,22 @@ contract ScrollChainTest is DSTestPlus {
         rollup.removeSequencer(_sequencer);
         hevm.stopPrank();
 
-        // revert when account is not EOA
-        if (_sequencer.code.length > 0) {
-            hevm.expectRevert("not EOA");
-            rollup.addSequencer(_sequencer);
-        } else {
-            // change to random operator
-            hevm.expectEmit(true, false, false, true);
-            emit UpdateSequencer(_sequencer, true);
+        hevm.expectRevert("not EOA");
+        rollup.addSequencer(address(this));
+        hevm.assume(_sequencer.code.length == 0);
 
-            assertBoolEq(rollup.isSequencer(_sequencer), false);
-            rollup.addSequencer(_sequencer);
-            assertBoolEq(rollup.isSequencer(_sequencer), true);
+        // change to random EOA operator
+        hevm.expectEmit(true, false, false, true);
+        emit UpdateSequencer(_sequencer, true);
 
-            hevm.expectEmit(true, false, false, true);
-            emit UpdateSequencer(_sequencer, false);
-            rollup.removeSequencer(_sequencer);
-            assertBoolEq(rollup.isSequencer(_sequencer), false);
-        }
+        assertBoolEq(rollup.isSequencer(_sequencer), false);
+        rollup.addSequencer(_sequencer);
+        assertBoolEq(rollup.isSequencer(_sequencer), true);
+
+        hevm.expectEmit(true, false, false, true);
+        emit UpdateSequencer(_sequencer, false);
+        rollup.removeSequencer(_sequencer);
+        assertBoolEq(rollup.isSequencer(_sequencer), false);
     }
 
     function testAddAndRemoveProver(address _prover) public {
@@ -646,23 +644,22 @@ contract ScrollChainTest is DSTestPlus {
         rollup.removeProver(_prover);
         hevm.stopPrank();
 
-        if (_prover.code.length > 0) {
-            hevm.expectRevert("not EOA");
-            rollup.addProver(_prover);
-        } else {
-            // change to random operator
-            hevm.expectEmit(true, false, false, true);
-            emit UpdateProver(_prover, true);
+        hevm.expectRevert("not EOA");
+        rollup.addProver(address(this));
+        hevm.assume(_prover.code.length == 0);
 
-            assertBoolEq(rollup.isProver(_prover), false);
-            rollup.addProver(_prover);
-            assertBoolEq(rollup.isProver(_prover), true);
+        // change to random EOA operator
+        hevm.expectEmit(true, false, false, true);
+        emit UpdateProver(_prover, true);
 
-            hevm.expectEmit(true, false, false, true);
-            emit UpdateProver(_prover, false);
-            rollup.removeProver(_prover);
-            assertBoolEq(rollup.isProver(_prover), false);
-        }
+        assertBoolEq(rollup.isProver(_prover), false);
+        rollup.addProver(_prover);
+        assertBoolEq(rollup.isProver(_prover), true);
+
+        hevm.expectEmit(true, false, false, true);
+        emit UpdateProver(_prover, false);
+        rollup.removeProver(_prover);
+        assertBoolEq(rollup.isProver(_prover), false);
     }
 
     function testSetPause() external {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Many external services use `tx.calldata` to decode metadata for batches/proof, which may cause problem if we use some smart contract account to submit the batches or proof.

This PR add EOA check when add prover and sequencer in `ScrollChain` contract. This check will make sure we only use EOA to submit batch and proof.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
