### PR TITLE
refactor: add address(0) check for constructors.

### DIFF
--- a/contracts/src/L1/L1ScrollMessenger.sol
+++ b/contracts/src/L1/L1ScrollMessenger.sol
@@ -28,6 +28,11 @@ import {IMessageDropCallback} from "../libraries/callbacks/IMessageDropCallback.
 /// this contract.
 contract L1ScrollMessenger is ScrollMessengerBase, IL1ScrollMessenger {
     /***********
+     * Errors *
+     ***********/
+    error ErrZeroAddress();
+
+    /***********
      * Structs *
      ***********/
 
@@ -95,6 +100,9 @@ contract L1ScrollMessenger is ScrollMessengerBase, IL1ScrollMessenger {
         address _rollup,
         address _messageQueue
     ) public initializer {
+        if (_counterpart == address(0) || _rollup == address(0) || _messageQueue == address(0)) {
+            revert ErrZeroAddress();
+        }
         ScrollMessengerBase.__ScrollMessengerBase_init(_counterpart, _feeVault);
 
         rollup = _rollup;

--- a/contracts/src/L1/L1ScrollMessenger.sol
+++ b/contracts/src/L1/L1ScrollMessenger.sol
@@ -28,11 +28,6 @@ import {IMessageDropCallback} from "../libraries/callbacks/IMessageDropCallback.
 /// this contract.
 contract L1ScrollMessenger is ScrollMessengerBase, IL1ScrollMessenger {
     /***********
-     * Errors *
-     ***********/
-    error ErrZeroAddress();
-
-    /***********
      * Structs *
      ***********/
 

--- a/contracts/src/L2/L2ScrollMessenger.sol
+++ b/contracts/src/L2/L2ScrollMessenger.sol
@@ -24,11 +24,6 @@ import {ScrollMessengerBase} from "../libraries/ScrollMessengerBase.sol";
 /// @dev It should be a predeployed contract on layer 2 and should hold infinite amount
 /// of Ether (Specifically, `uint256(-1)`), which can be initialized in Genesis Block.
 contract L2ScrollMessenger is ScrollMessengerBase, IL2ScrollMessenger {
-    /***********
-     * Errors *
-     ***********/
-    error ErrZeroAddress();
-
     /*************
      * Constants *
      *************/

--- a/contracts/src/L2/L2ScrollMessenger.sol
+++ b/contracts/src/L2/L2ScrollMessenger.sol
@@ -24,6 +24,11 @@ import {ScrollMessengerBase} from "../libraries/ScrollMessengerBase.sol";
 /// @dev It should be a predeployed contract on layer 2 and should hold infinite amount
 /// of Ether (Specifically, `uint256(-1)`), which can be initialized in Genesis Block.
 contract L2ScrollMessenger is ScrollMessengerBase, IL2ScrollMessenger {
+    /***********
+     * Errors *
+     ***********/
+    error ErrZeroAddress();
+
     /*************
      * Constants *
      *************/
@@ -49,12 +54,15 @@ contract L2ScrollMessenger is ScrollMessengerBase, IL2ScrollMessenger {
      ***************/
 
     constructor(address _messageQueue) {
+        if (_messageQueue == address(0)) revert ErrZeroAddress();
+
         _disableInitializers();
 
         messageQueue = _messageQueue;
     }
 
     function initialize(address _counterpart) external initializer {
+        if (_counterpart == address(0)) revert ErrZeroAddress();
         ScrollMessengerBase.__ScrollMessengerBase_init(_counterpart, address(0));
     }
 

--- a/contracts/src/libraries/IScrollMessenger.sol
+++ b/contracts/src/libraries/IScrollMessenger.sol
@@ -3,6 +3,11 @@
 pragma solidity ^0.8.16;
 
 interface IScrollMessenger {
+    /***********
+     * Errors *
+     ***********/
+    error ErrZeroAddress();
+
     /**********
      * Events *
      **********/

--- a/contracts/src/test/L1GatewayTestBase.t.sol
+++ b/contracts/src/test/L1GatewayTestBase.t.sol
@@ -82,7 +82,7 @@ abstract contract L1GatewayTestBase is DSTestPlus {
         verifier = new MockRollupVerifier();
 
         // Deploy L2 contracts
-        l2Messenger = new L2ScrollMessenger(address(0));
+        l2Messenger = new L2ScrollMessenger(address(1));
 
         // Initialize L1 contracts
         l1Messenger.initialize(address(l2Messenger), feeVault, address(rollup), address(messageQueue));


### PR DESCRIPTION
### Purpose or design rationale of this PR
I think it's necessary to add a check for address(0) in the constructors. Initializing a state variable with address(0) can lead to unintended behavior and vulnerabilities in the contract.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
