### PR TITLE
fix: some var name conflicts

### DIFF
--- a/bridge-history-api/utils/database.go
+++ b/bridge-history-api/utils/database.go
@@ -40,8 +40,8 @@ func (g *gormLogger) Error(_ context.Context, msg string, data ...interface{}) {
 
 func (g *gormLogger) Trace(_ context.Context, begin time.Time, fc func() (string, int64), err error) {
 	elapsed := time.Since(begin)
-	sql, rowsAffected := fc()
-	g.gethLogger.Debug("gorm", "line", utils.FileWithLineNum(), "cost", elapsed, "sql", sql, "rowsAffected", rowsAffected, "err", err)
+	sqlStr, rowsAffected := fc()
+	g.gethLogger.Debug("gorm", "line", utils.FileWithLineNum(), "cost", elapsed, "sqlStr", sqlStr, "rowsAffected", rowsAffected, "err", err)
 }
 
 // InitDB init the db handler

--- a/common/database/db.go
+++ b/common/database/db.go
@@ -40,8 +40,8 @@ func (g *gormLogger) Error(_ context.Context, msg string, data ...interface{}) {
 
 func (g *gormLogger) Trace(_ context.Context, begin time.Time, fc func() (string, int64), err error) {
 	elapsed := time.Since(begin)
-	sql, rowsAffected := fc()
-	g.gethLogger.Debug("gorm", "line", utils.FileWithLineNum(), "cost", elapsed, "sql", sql, "rowsAffected", rowsAffected, "err", err)
+	sqlStr, rowsAffected := fc()
+	g.gethLogger.Debug("gorm", "line", utils.FileWithLineNum(), "cost", elapsed, "sqlStr", sqlStr, "rowsAffected", rowsAffected, "err", err)
 }
 
 // InitDB init the db handler

--- a/common/docker/docker_db.go
+++ b/common/docker/docker_db.go
@@ -89,14 +89,14 @@ func (i *ImgDB) IsRunning() bool {
 }
 
 func (i *ImgDB) prepare() []string {
-	cmd := []string{"run", "--rm", "--name", i.name, "-p", fmt.Sprintf("%d:5432", i.port)}
+	cmdStrs := []string{"run", "--rm", "--name", i.name, "-p", fmt.Sprintf("%d:5432", i.port)}
 	envs := []string{
 		"-e", "POSTGRES_PASSWORD=" + i.password,
 		"-e", fmt.Sprintf("POSTGRES_DB=%s", i.dbName),
 	}
 
-	cmd = append(cmd, envs...)
-	return append(cmd, i.image)
+	cmdStrs = append(cmdStrs, envs...)
+	return append(cmdStrs, i.image)
 }
 
 func (i *ImgDB) isOk() bool {

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -34,13 +34,13 @@ func (crc *chunkRowConsumption) add(rowConsumption *gethTypes.RowConsumption) er
 
 // max finds the maximum row consumption among all sub-circuits
 func (crc *chunkRowConsumption) max() uint64 {
-	var max uint64
+	var _max uint64
 	for _, value := range *crc {
-		if value > max {
-			max = value
+		if value > _max {
+			_max = value
 		}
 	}
-	return max
+	return _max
 }
 
 // ChunkProposer proposes chunks based on available unchunked blocks.

--- a/rollup/internal/controller/watcher/l2_watcher.go
+++ b/rollup/internal/controller/watcher/l2_watcher.go
@@ -293,15 +293,15 @@ func (w *L2WatcherClient) parseBridgeEventLogs(logs []gethTypes.Log) ([]relayedM
 				isSuccessful: true,
 			})
 		case bridgeAbi.L2FailedRelayedMessageEventSignature:
-			event := bridgeAbi.L2FailedRelayedMessageEvent{}
-			err := utils.UnpackLog(w.messengerABI, &event, "FailedRelayedMessage", vLog)
+			msgEvent := bridgeAbi.L2FailedRelayedMessageEvent{}
+			err := utils.UnpackLog(w.messengerABI, &msgEvent, "FailedRelayedMessage", vLog)
 			if err != nil {
 				log.Warn("Failed to unpack layer2 FailedRelayedMessage event", "err", err)
 				return relayedMessages, err
 			}
 
 			relayedMessages = append(relayedMessages, relayedMessage{
-				msgHash:      event.MessageHash,
+				msgHash:      msgEvent.MessageHash,
 				txHash:       vLog.TxHash,
 				isSuccessful: false,
 			})

--- a/rollup/internal/controller/watcher/l2_watcher.go
+++ b/rollup/internal/controller/watcher/l2_watcher.go
@@ -280,15 +280,15 @@ func (w *L2WatcherClient) parseBridgeEventLogs(logs []gethTypes.Log) ([]relayedM
 	for _, vLog := range logs {
 		switch vLog.Topics[0] {
 		case bridgeAbi.L2RelayedMessageEventSignature:
-			event := bridgeAbi.L2RelayedMessageEvent{}
-			err := utils.UnpackLog(w.messengerABI, &event, "RelayedMessage", vLog)
+			msgEvent := bridgeAbi.L2RelayedMessageEvent{}
+			err := utils.UnpackLog(w.messengerABI, &msgEvent, "RelayedMessage", vLog)
 			if err != nil {
 				log.Warn("Failed to unpack layer2 RelayedMessage event", "err", err)
 				return relayedMessages, err
 			}
 
 			relayedMessages = append(relayedMessages, relayedMessage{
-				msgHash:      event.MessageHash,
+				msgHash:      msgEvent.MessageHash,
 				txHash:       vLog.TxHash,
 				isSuccessful: true,
 			})


### PR DESCRIPTION
### Purpose or design rationale of this PR

1. In go1.21, some new built-in functions like `clear`, `min`, and `max` have been added. To avoid conflicts after upgrading, we should rename this variable.
2. Importing a package name as a name identifier, while legal in itself, may render the package's exported identifiers unavailable or cause confusion when reading the code.

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
