### PR TITLE
fix: add connection timeout for db conn pool

### DIFF
--- a/bridge-history-api/utils/database.go
+++ b/bridge-history-api/utils/database.go
@@ -74,6 +74,8 @@ func InitDB(config *config.DBConfig) (*gorm.DB, error) {
 		return nil, pingErr
 	}
 
+	sqlDB.SetConnMaxLifetime(time.Minute * 10)
+	sqlDB.SetConnMaxIdleTime(time.Minute * 5)
 	sqlDB.SetMaxOpenConns(config.MaxOpenNum)
 	sqlDB.SetMaxIdleConns(config.MaxIdleNum)
 

--- a/common/database/db.go
+++ b/common/database/db.go
@@ -70,6 +70,9 @@ func InitDB(config *Config) (*gorm.DB, error) {
 		return nil, pingErr
 	}
 
+	sqlDB.SetConnMaxLifetime(time.Minute * 10)
+	sqlDB.SetConnMaxIdleTime(time.Minute * 5)
+
 	sqlDB.SetMaxOpenConns(config.MaxOpenNum)
 	sqlDB.SetMaxIdleConns(config.MaxIdleNum)
 

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.42"
+var tag = "v4.3.43"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Database conn pool should specify strategy for conn timeout
1. for idle connections, should shrink the pool to save more resources
2. for connections, if network partition or LB switch happened, the original conns will die, but app will not know this until the code runs to reading/writing on this conn. There should be a way to evict the expired conn. if there is a dbproxy between app and mysql, this max lifetime should be less than the proxy config.

These two params should also considered under your db architecture~

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
