### PR TITLE
docs: fix typos

### DIFF
--- a/bridge-history-api/crossmsg/messageproof/withdraw_trie.go
+++ b/bridge-history-api/crossmsg/messageproof/withdraw_trie.go
@@ -6,7 +6,7 @@ import (
 	"bridge-history-api/utils"
 )
 
-// MaxHeight is the maixium possible height of withdraw trie
+// MaxHeight is the maximum possible height of withdraw trie
 const MaxHeight = 40
 
 // WithdrawTrie is an append only merkle trie


### PR DESCRIPTION
Fix typo in  withdraw_trie.go