### PR TITLE
fix(sender): gas price bump corner case when resubmitting tx

### DIFF
--- a/common/cmd/cmd.go
+++ b/common/cmd/cmd.go
@@ -95,8 +95,7 @@ func (c *Cmd) Write(data []byte) (int, error) {
 	if verbose || c.openLog {
 		fmt.Printf("%s:\n\t%v", c.name, out)
 	} else if strings.Contains(strings.ToLower(out), "error") ||
-		strings.Contains(strings.ToLower(out), "warning") ||
-		strings.Contains(strings.ToLower(out), "info") {
+		strings.Contains(strings.ToLower(out), "warning") {
 		fmt.Printf("%s:\n\t%v", c.name, out)
 	}
 	go c.checkFuncs.IterCb(func(_ string, value interface{}) {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.44"
+var tag = "v4.3.45"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -308,7 +308,7 @@ func (s *Sender) createAndSendTx(auth *bind.TransactOpts, feeData *FeeData, targ
 		return nil, err
 	}
 	if err = s.client.SendTransaction(s.ctx, tx); err != nil {
-		log.Error("failed to send tx", "tx hash", tx.Hash().String(), "from", auth.From.String(), "to", tx.To().String(), "nonce", tx.Nonce(), "err", err)
+		log.Error("failed to send tx", "tx hash", tx.Hash().String(), "from", auth.From.String(), "nonce", tx.Nonce(), "err", err)
 		// Check if contain nonce, and reset nonce
 		// only reset nonce when it is not from resubmit
 		if strings.Contains(err.Error(), "nonce") && overrideNonce == nil {
@@ -357,7 +357,6 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 		"tx_hash": tx.Hash().String(),
 		"tx_type": s.config.TxType,
 		"from":    auth.From.String(),
-		"to":      tx.To().String(),
 		"nonce":   tx.Nonce(),
 	}
 
@@ -481,7 +480,6 @@ func (s *Sender) checkPendingTransaction(header *types.Header, confirmed uint64)
 			log.Info("resubmit transaction",
 				"hash", pending.tx.Hash().String(),
 				"from", pending.signer.From.String(),
-				"to", pending.tx.To(),
 				"nonce", pending.tx.Nonce(),
 				"submit block number", pending.submitAt,
 				"current block number", number,

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -372,7 +372,7 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 			gasPrice = maxGasPrice
 		}
 
-		if originalGasPrice.Cmp(gasPrice) <= 0 {
+		if originalGasPrice.Cmp(gasPrice) == 0 {
 			log.Warn("gas price bump corner case, add 1 wei", "original", originalGasPrice.Uint64(), "adjusted", gasPrice.Uint64())
 			gasPrice = new(big.Int).Add(gasPrice, big.NewInt(1))
 		}
@@ -414,12 +414,12 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 			gasFeeCap = maxGasPrice
 		}
 
-		if originalGasTipCap.Cmp(gasTipCap) <= 0 {
+		if originalGasTipCap.Cmp(gasTipCap) == 0 {
 			log.Warn("gas tip cap bump corner case, add 1 wei", "original", originalGasTipCap.Uint64(), "adjusted", gasTipCap.Uint64())
 			gasTipCap = new(big.Int).Add(gasTipCap, big.NewInt(1))
 		}
 
-		if originalGasFeeCap.Cmp(gasFeeCap) <= 0 {
+		if originalGasFeeCap.Cmp(gasFeeCap) == 0 {
 			log.Warn("gas fee cap bump corner case, add 1 wei", "original", originalGasFeeCap.Uint64(), "adjusted", gasFeeCap.Uint64())
 			gasFeeCap = new(big.Int).Add(gasFeeCap, big.NewInt(1))
 		}

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -222,12 +222,13 @@ func (s *Sender) SendTransaction(ID string, target *common.Address, value *big.I
 
 	if feeData, err = s.getFeeData(s.auth, target, value, data, fallbackGasLimit); err != nil {
 		s.metrics.sendTransactionFailureGetFee.WithLabelValues(s.service, s.name).Inc()
-		log.Error("failed to get fee data", "err", err)
+		log.Error("failed to get fee data", "from", s.auth.From.String(), "to", target.String(), "value", value.Uint64(), "fallback gas limit", fallbackGasLimit, "err", err)
 		return common.Hash{}, fmt.Errorf("failed to get fee data, err: %w", err)
 	}
 
 	if tx, err = s.createAndSendTx(s.auth, feeData, target, value, data, nil); err != nil {
 		s.metrics.sendTransactionFailureSendTx.WithLabelValues(s.service, s.name).Inc()
+		log.Error("failed to create and send tx (non-resubmit case)", "from", s.auth.From.String(), "to", target.String(), "nonce", s.auth.Nonce.Uint64(), "value", value.Uint64(), "err", err)
 		return common.Hash{}, fmt.Errorf("failed to create and send transaction, err: %w", err)
 	}
 
@@ -303,11 +304,11 @@ func (s *Sender) createAndSendTx(auth *bind.TransactOpts, feeData *FeeData, targ
 	// sign and send
 	tx, err := auth.Signer(auth.From, types.NewTx(txData))
 	if err != nil {
-		log.Error("failed to sign tx", "err", err)
+		log.Error("failed to sign tx", "address", auth.From.String(), "err", err)
 		return nil, err
 	}
 	if err = s.client.SendTransaction(s.ctx, tx); err != nil {
-		log.Error("failed to send tx", "tx hash", tx.Hash().String(), "err", err)
+		log.Error("failed to send tx", "tx hash", tx.Hash().String(), "from", auth.From.String(), "to", tx.To().String(), "nonce", tx.Nonce(), "err", err)
 		// Check if contain nonce, and reset nonce
 		// only reset nonce when it is not from resubmit
 		if strings.Contains(err.Error(), "nonce") && overrideNonce == nil {
@@ -356,6 +357,8 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 		"tx_hash": tx.Hash().String(),
 		"tx_type": s.config.TxType,
 		"from":    auth.From.String(),
+		"to":      tx.To().String(),
+		"nonce":   tx.Nonce(),
 	}
 
 	switch s.config.TxType {
@@ -369,10 +372,15 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 		if gasPrice.Cmp(maxGasPrice) > 0 {
 			gasPrice = maxGasPrice
 		}
-		feeData.gasPrice = gasPrice
 
-		txInfo["original_gas_price"] = originalGasPrice
-		txInfo["adjusted_gas_price"] = gasPrice
+		if originalGasPrice.Cmp(gasPrice) <= 0 {
+			log.Warn("gas price bump corner case, add 1 wei", "original", originalGasPrice.Uint64(), "adjusted", gasPrice.Uint64())
+			gasPrice = new(big.Int).Add(gasPrice, big.NewInt(1))
+		}
+
+		feeData.gasPrice = gasPrice
+		txInfo["original_gas_price"] = originalGasPrice.Uint64()
+		txInfo["adjusted_gas_price"] = gasPrice.Uint64()
 	default:
 		originalGasTipCap := big.NewInt(feeData.gasTipCap.Int64())
 		originalGasFeeCap := big.NewInt(feeData.gasFeeCap.Int64())
@@ -406,20 +414,35 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 		if gasFeeCap.Cmp(maxGasPrice) > 0 {
 			gasFeeCap = maxGasPrice
 		}
+
+		if originalGasTipCap.Cmp(gasTipCap) <= 0 {
+			log.Warn("gas tip cap bump corner case, add 1 wei", "original", originalGasTipCap.Uint64(), "adjusted", gasTipCap.Uint64())
+			gasTipCap = new(big.Int).Add(gasTipCap, big.NewInt(1))
+		}
+
+		if originalGasFeeCap.Cmp(gasFeeCap) <= 0 {
+			log.Warn("gas fee cap bump corner case, add 1 wei", "original", originalGasFeeCap.Uint64(), "adjusted", gasFeeCap.Uint64())
+			gasFeeCap = new(big.Int).Add(gasFeeCap, big.NewInt(1))
+		}
+
 		feeData.gasFeeCap = gasFeeCap
 		feeData.gasTipCap = gasTipCap
-
-		txInfo["original_gas_tip_cap"] = originalGasTipCap
-		txInfo["adjusted_gas_tip_cap"] = gasTipCap
-		txInfo["original_gas_fee_cap"] = originalGasFeeCap
-		txInfo["adjusted_gas_fee_cap"] = gasFeeCap
+		txInfo["original_gas_tip_cap"] = originalGasTipCap.Uint64()
+		txInfo["adjusted_gas_tip_cap"] = gasTipCap.Uint64()
+		txInfo["original_gas_fee_cap"] = originalGasFeeCap.Uint64()
+		txInfo["adjusted_gas_fee_cap"] = gasFeeCap.Uint64()
 	}
 
-	log.Debug("Transaction gas adjustment details", txInfo)
+	log.Info("Transaction gas adjustment details", txInfo)
 
 	nonce := tx.Nonce()
 	s.metrics.resubmitTransactionTotal.WithLabelValues(s.service, s.name).Inc()
-	return s.createAndSendTx(auth, feeData, tx.To(), tx.Value(), tx.Data(), &nonce)
+	tx, err := s.createAndSendTx(auth, feeData, tx.To(), tx.Value(), tx.Data(), &nonce)
+	if err != nil {
+		log.Error("failed to create and send tx (resubmit case)", "from", s.auth.From.String(), "to", tx.To().String(), "nonce", nonce, "value", tx.Value().Uint64(), "err", err)
+		return nil, err
+	}
+	return tx, nil
 }
 
 // checkPendingTransaction checks the confirmation status of pending transactions against the latest confirmed block number.
@@ -455,15 +478,16 @@ func (s *Sender) checkPendingTransaction(header *types.Header, confirmed uint64)
 				}
 			}
 		} else if s.config.EscalateBlocks+pending.submitAt < number {
-			log.Debug("resubmit transaction",
-				"tx hash", pending.tx.Hash().String(),
+			log.Info("resubmit transaction",
+				"hash", pending.tx.Hash().String(),
+				"from", pending.signer.From.String(),
+				"to", pending.tx.To(),
+				"nonce", pending.tx.Nonce(),
 				"submit block number", pending.submitAt,
 				"current block number", number,
-				"escalateBlocks", s.config.EscalateBlocks)
+				"configured escalateBlocks", s.config.EscalateBlocks)
 
-			var tx *types.Transaction
-			tx, err := s.resubmitTransaction(pending.feeData, pending.signer, pending.tx)
-			if err != nil {
+			if tx, err := s.resubmitTransaction(pending.feeData, pending.signer, pending.tx); err != nil {
 				// If account pool is empty, it will try again in next loop.
 				if !errors.Is(err, ErrNoAvailableAccount) {
 					log.Error("failed to resubmit transaction, reset submitAt", "tx hash", pending.tx.Hash().String(), "err", err)

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -222,13 +222,13 @@ func (s *Sender) SendTransaction(ID string, target *common.Address, value *big.I
 
 	if feeData, err = s.getFeeData(s.auth, target, value, data, fallbackGasLimit); err != nil {
 		s.metrics.sendTransactionFailureGetFee.WithLabelValues(s.service, s.name).Inc()
-		log.Error("failed to get fee data", "from", s.auth.From.String(), "to", target.String(), "value", value.Uint64(), "fallback gas limit", fallbackGasLimit, "err", err)
+		log.Error("failed to get fee data", "from", s.auth.From.String(), "nonce", s.auth.Nonce.Uint64(), "fallback gas limit", fallbackGasLimit, "err", err)
 		return common.Hash{}, fmt.Errorf("failed to get fee data, err: %w", err)
 	}
 
 	if tx, err = s.createAndSendTx(s.auth, feeData, target, value, data, nil); err != nil {
 		s.metrics.sendTransactionFailureSendTx.WithLabelValues(s.service, s.name).Inc()
-		log.Error("failed to create and send tx (non-resubmit case)", "from", s.auth.From.String(), "to", target.String(), "nonce", s.auth.Nonce.Uint64(), "value", value.Uint64(), "err", err)
+		log.Error("failed to create and send tx (non-resubmit case)", "from", s.auth.From.String(), "nonce", s.auth.Nonce.Uint64(), "err", err)
 		return common.Hash{}, fmt.Errorf("failed to create and send transaction, err: %w", err)
 	}
 
@@ -439,7 +439,7 @@ func (s *Sender) resubmitTransaction(feeData *FeeData, auth *bind.TransactOpts, 
 	s.metrics.resubmitTransactionTotal.WithLabelValues(s.service, s.name).Inc()
 	tx, err := s.createAndSendTx(auth, feeData, tx.To(), tx.Value(), tx.Data(), &nonce)
 	if err != nil {
-		log.Error("failed to create and send tx (resubmit case)", "from", s.auth.From.String(), "to", tx.To().String(), "nonce", nonce, "value", tx.Value().Uint64(), "err", err)
+		log.Error("failed to create and send tx (resubmit case)", "from", s.auth.From.String(), "nonce", nonce, "err", err)
 		return nil, err
 	}
 	return tx, nil

--- a/rollup/internal/controller/sender/sender_test.go
+++ b/rollup/internal/controller/sender/sender_test.go
@@ -304,7 +304,7 @@ func testCheckPendingTransaction(t *testing.T) {
 					},
 				)
 
-				pendingTx := &PendingTransaction{id: "abc", tx: tx, submitAt: header.Number.Uint64() - s.config.EscalateBlocks - 1}
+				pendingTx := &PendingTransaction{id: "abc", tx: tx, signer: s.auth, submitAt: header.Number.Uint64() - s.config.EscalateBlocks - 1}
 				s.pendingTxs.Set(pendingTx.id, pendingTx)
 				s.checkPendingTransaction(header, confirmed)
 

--- a/rollup/internal/controller/sender/sender_test.go
+++ b/rollup/internal/controller/sender/sender_test.go
@@ -180,7 +180,6 @@ func testResubmitNonZeroGasPriceTransaction(t *testing.T) {
 		tx, err := s.createAndSendTx(s.auth, feeData, &common.Address{}, big.NewInt(0), nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
-		// Increase at least 1 wei in gas price, gas tip cap and gas fee cap.
 		_, err = s.resubmitTransaction(feeData, s.auth, tx)
 		assert.NoError(t, err)
 		s.Stop()
@@ -205,7 +204,6 @@ func testResubmitUnderpricedTransaction(t *testing.T) {
 		tx, err := s.createAndSendTx(s.auth, feeData, &common.Address{}, big.NewInt(0), nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
-		// Increase at least 1 wei in gas price, gas tip cap and gas fee cap.
 		_, err = s.resubmitTransaction(feeData, s.auth, tx)
 		assert.Error(t, err, "replacement transaction underpriced")
 		s.Stop()


### PR DESCRIPTION
### Purpose or design rationale of this PR

**Issue:** node returns `“replacement transaction underpriced”` when `commit-batch-sender` resubmits tx with a “bumped” gas tip and gas cap of 120% (a configured value), causing a `commitBatch` tx delay.

**Reason:**
1. if `gas cap` or `gas tip` of replacement EIP-1559 tx (`gas price` of pre EIP-1559 tx) is the same as the old one in the tx_pool, the l1-el node will reject this tx, code ref (the version of l1-el node receiving the tx is v1.13.2): https://github.com/ethereum/go-ethereum/blob/v1.13.2/core/txpool/legacypool/list.go#L305-L307
2. the tx’s gas tip is only 3wei, thus floor(3wei * 1.2) = 3wei, thus rejected by the tx_pool. tx: https://sepolia.etherscan.io/tx/0xcd41a23a90b1f22e106b1c1f224575ca6afa68e1e140e3b03d72db16574d2dbd

**Mainnet Impact:** I think this error would rarely happen in mainnet, because the gas tip is very unlikely to be <= 4 wei to trigger the same issue.

**Fixes:**
1. Add a fix when gas tip and gas cap are the same before and after the bump.
2. Add more logs in resubmitting tx (hard to know the context when submitting currently).

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
