### PR TITLE
fix(bridge-history): v2 db migrate

### DIFF
--- a/bridge-history-api/internal/orm/migrate/migrate.go
+++ b/bridge-history-api/internal/orm/migrate/migrate.go
@@ -18,7 +18,7 @@ const MigrationsDir string = "migrations"
 func init() {
 	goose.SetBaseFS(embedMigrations)
 	goose.SetSequential(true)
-	goose.SetTableName("bridge_history_migrations")
+	goose.SetTableName("bridge_historyv2_migrations")
 
 	verbose, _ := strconv.ParseBool(os.Getenv("LOG_SQL_MIGRATIONS"))
 	goose.SetVerbose(verbose)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Separating db migration names of bridge-history-api v1 and v2.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
