### PR TITLE
fix(bridge-history-api): change table names

### DIFF
--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -47,7 +47,7 @@ type BatchEvent struct {
 
 // TableName returns the table name for the BatchEvent model.
 func (*BatchEvent) TableName() string {
-	return "batch_event"
+	return "batch_event_v2"
 }
 
 // NewBatchEvent returns a new instance of BatchEvent.

--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -124,7 +124,7 @@ type CrossMessage struct {
 
 // TableName returns the table name for the CrossMessage model.
 func (*CrossMessage) TableName() string {
-	return "cross_message"
+	return "cross_message_v2"
 }
 
 // NewCrossMessage returns a new instance of CrossMessage.

--- a/bridge-history-api/internal/orm/migrate/migrations/00001_cross_message_v2.sql
+++ b/bridge-history-api/internal/orm/migrate/migrations/00001_cross_message_v2.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE cross_message
+CREATE TABLE cross_message_v2
 (
     id                  BIGSERIAL    PRIMARY KEY,
     message_type        SMALLINT     NOT NULL,
@@ -38,20 +38,20 @@ CREATE TABLE cross_message
     deleted_at          TIMESTAMP(0) DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_cm_message_hash ON cross_message (message_hash);
-CREATE INDEX IF NOT EXISTS idx_cm_message_type_l1_block_number ON cross_message (message_type, l1_block_number DESC);
-CREATE INDEX IF NOT EXISTS idx_cm_message_type_l2_block_number ON cross_message (message_type, l2_block_number DESC);
-CREATE INDEX IF NOT EXISTS idx_cm_message_type_rollup_status_message_nonce ON cross_message (message_type, rollup_status, message_nonce DESC);
-CREATE INDEX IF NOT EXISTS idx_cm_message_type_message_nonce_tx_status_l2_block_number ON cross_message (message_type, message_nonce, tx_status, l2_block_number);
-CREATE INDEX IF NOT EXISTS idx_cm_l1_tx_hash ON cross_message (l1_tx_hash);
-CREATE INDEX IF NOT EXISTS idx_cm_l2_tx_hash ON cross_message (l2_tx_hash);
-CREATE INDEX IF NOT EXISTS idx_cm_message_type_tx_status_sender_block_timestamp ON cross_message (message_type, tx_status, sender, block_timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_cm_message_type_sender_block_timestamp ON cross_message (message_type, sender, block_timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_cm_sender_block_timestamp ON cross_message (sender, block_timestamp DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cm_message_hash ON cross_message_v2 (message_hash);
+CREATE INDEX IF NOT EXISTS idx_cm_message_type_l1_block_number ON cross_message_v2 (message_type, l1_block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_cm_message_type_l2_block_number ON cross_message_v2 (message_type, l2_block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_cm_message_type_rollup_status_message_nonce ON cross_message_v2 (message_type, rollup_status, message_nonce DESC);
+CREATE INDEX IF NOT EXISTS idx_cm_message_type_message_nonce_tx_status_l2_block_number ON cross_message_v2 (message_type, message_nonce, tx_status, l2_block_number);
+CREATE INDEX IF NOT EXISTS idx_cm_l1_tx_hash ON cross_message_v2 (l1_tx_hash);
+CREATE INDEX IF NOT EXISTS idx_cm_l2_tx_hash ON cross_message_v2 (l2_tx_hash);
+CREATE INDEX IF NOT EXISTS idx_cm_message_type_tx_status_sender_block_timestamp ON cross_message_v2 (message_type, tx_status, sender, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_cm_message_type_sender_block_timestamp ON cross_message_v2 (message_type, sender, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_cm_sender_block_timestamp ON cross_message_v2 (sender, block_timestamp DESC);
 
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE IF EXISTS cross_message;
+DROP TABLE IF EXISTS cross_message_v2;
 -- +goose StatementEnd

--- a/bridge-history-api/internal/orm/migrate/migrations/00002_batch_event_v2.sql
+++ b/bridge-history-api/internal/orm/migrate/migrations/00002_batch_event_v2.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- +goose StatementBegin
-CREATE TABLE batch_event
+CREATE TABLE batch_event_v2
 (
     id                  BIGSERIAL     PRIMARY KEY,
     l1_block_number     BIGINT        NOT NULL,
@@ -15,14 +15,14 @@ CREATE TABLE batch_event
     deleted_at          TIMESTAMP(0)  DEFAULT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_be_l1_block_number ON batch_event (l1_block_number);
-CREATE INDEX IF NOT EXISTS idx_be_batch_index ON batch_event (batch_index);
-CREATE INDEX IF NOT EXISTS idx_be_batch_index_batch_hash ON batch_event (batch_index, batch_hash);
-CREATE INDEX IF NOT EXISTS idx_be_end_block_number_update_status_batch_status_batch_index ON batch_event (end_block_number, update_status, batch_status, batch_index);
+CREATE INDEX IF NOT EXISTS idx_be_l1_block_number ON batch_event_v2 (l1_block_number);
+CREATE INDEX IF NOT EXISTS idx_be_batch_index ON batch_event_v2 (batch_index);
+CREATE INDEX IF NOT EXISTS idx_be_batch_index_batch_hash ON batch_event_v2 (batch_index, batch_hash);
+CREATE INDEX IF NOT EXISTS idx_be_end_block_number_update_status_batch_status_batch_index ON batch_event_v2 (end_block_number, update_status, batch_status, batch_index);
 
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP TABLE IF EXISTS batch_event;
+DROP TABLE IF EXISTS batch_event_v2;
 -- +goose StatementEnd


### PR DESCRIPTION
### Purpose or design rationale of this PR

Tables now are created successfully:
```
List of relations
 Schema |                Name                |   Type   |  Owner   
--------+------------------------------------+----------+----------
 public | batch_event_v2                     | table    | postgres
 public | batch_event_v2_id_seq              | sequence | postgres
 public | bridge_history_migrations          | table    | postgres
 public | bridge_history_migrations_id_seq   | sequence | postgres
 public | bridge_historyv2_migrations        | table    | postgres
 public | bridge_historyv2_migrations_id_seq | sequence | postgres
 public | cross_message                      | table    | postgres
 public | cross_message_id_seq               | sequence | postgres
 public | cross_message_v2                   | table    | postgres
 public | cross_message_v2_id_seq            | sequence | postgres
 public | l2_sent_msg                        | table    | postgres
 public | l2_sent_msg_id_seq                 | sequence | postgres
 public | relayed_msg                        | table    | postgres
 public | relayed_msg_id_seq                 | sequence | postgres
 public | rollup_batch                       | table    | postgres
 public | rollup_batch_id_seq                | sequence | postgres
(16 rows)
```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
