### PR TITLE
fix(bridge-history): address validation

### DIFF
--- a/bridge-history-api/conf/config.json
+++ b/bridge-history-api/conf/config.json
@@ -34,8 +34,7 @@
 		"USDCGatewayAddr": "0x33B60d5Dd260d453cAC3782b0bDC01ce84672142",
 		"LIDOGatewayAddr": "0x8aE8f22226B9d789A36AC81474e633f8bE2856c9",
 		"DAIGatewayAddr": "0xaC78dff3A87b5b534e366A93E785a0ce8fA6Cc62",
-		"GatewayRouterAddr": "0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79",
-		"MessageQueueAddr": "0x5300000000000000000000000000000000000000"
+		"GatewayRouterAddr": "0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79"
 	},
 	"db": {
 		"dsn": "postgres://postgres:123456@localhost:5444/test?sslmode=disable",

--- a/bridge-history-api/internal/logic/l1_fetcher.go
+++ b/bridge-history-api/internal/logic/l1_fetcher.go
@@ -66,13 +66,15 @@ func NewL1FetcherLogic(cfg *config.LayerConfig, db *gorm.DB, client *ethclient.C
 	}
 
 	// Optional erc20 gateways.
-	if cfg.USDCGatewayAddr != "" {
+	if common.HexToAddress(cfg.USDCGatewayAddr) != (common.Address{}) {
 		addressList = append(addressList, common.HexToAddress(cfg.USDCGatewayAddr))
 	}
 
-	if cfg.LIDOGatewayAddr != "" {
+	if common.HexToAddress(cfg.LIDOGatewayAddr) != (common.Address{}) {
 		addressList = append(addressList, common.HexToAddress(cfg.LIDOGatewayAddr))
 	}
+
+	log.Info("L1 Fetcher configured with the following address list", "addresses", addressList)
 
 	f := &L1FetcherLogic{
 		db:              db,

--- a/bridge-history-api/internal/logic/l2_fetcher.go
+++ b/bridge-history-api/internal/logic/l2_fetcher.go
@@ -61,13 +61,15 @@ func NewL2FetcherLogic(cfg *config.LayerConfig, db *gorm.DB, client *ethclient.C
 	}
 
 	// Optional erc20 gateways.
-	if cfg.USDCGatewayAddr != "" {
+	if common.HexToAddress(cfg.USDCGatewayAddr) != (common.Address{}) {
 		addressList = append(addressList, common.HexToAddress(cfg.USDCGatewayAddr))
 	}
 
-	if cfg.LIDOGatewayAddr != "" {
+	if common.HexToAddress(cfg.LIDOGatewayAddr) != (common.Address{}) {
 		addressList = append(addressList, common.HexToAddress(cfg.LIDOGatewayAddr))
 	}
+
+	log.Info("L2 Fetcher configured with the following address list", "addresses", addressList)
 
 	f := &L2FetcherLogic{
 		db:              db,

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.46"
+var tag = "v4.3.47"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Streamline address validation to ensure compatibility with other apps (e.g., chain-monitor), so that they can share the same env when deploying, ensuring detection of empty values and formats like "0x0" or extended zero sequences.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
