### PR TITLE
fix(bridge-history): update sql

### DIFF
--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -55,7 +55,7 @@ func NewBatchEvent(db *gorm.DB) *BatchEvent {
 	return &BatchEvent{db: db}
 }
 
-// GetBatchEventSyncedHeightInDB returns the maximum l1_block_number from the batch_event table.
+// GetBatchEventSyncedHeightInDB returns the maximum l1_block_number from the batch_event_v2 table.
 func (c *BatchEvent) GetBatchEventSyncedHeightInDB(ctx context.Context) (uint64, error) {
 	var batch BatchEvent
 	db := c.db.WithContext(ctx)

--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -475,9 +475,9 @@ func (c *CrossMessage) InsertOrUpdateL2RelayedMessagesOfL1Deposits(ctx context.C
 			Exprs: []clause.Expression{
 				clause.And(
 					// do not over-write terminal statuses.
-					clause.Neq{Column: "cross_message.tx_status", Value: TxStatusTypeRelayed},
-					clause.Neq{Column: "cross_message.tx_status", Value: TxStatusTypeFailedRelayed},
-					clause.Neq{Column: "cross_message.tx_status", Value: TxStatusTypeDropped},
+					clause.Neq{Column: "cross_message_v2.tx_status", Value: TxStatusTypeRelayed},
+					clause.Neq{Column: "cross_message_v2.tx_status", Value: TxStatusTypeFailedRelayed},
+					clause.Neq{Column: "cross_message_v2.tx_status", Value: TxStatusTypeDropped},
 				),
 			},
 		},
@@ -531,9 +531,9 @@ func (c *CrossMessage) InsertOrUpdateL1RelayedMessagesOfL2Withdrawals(ctx contex
 			Exprs: []clause.Expression{
 				clause.And(
 					// do not over-write terminal statuses.
-					clause.Neq{Column: "cross_message.tx_status", Value: TxStatusTypeRelayed},
-					clause.Neq{Column: "cross_message.tx_status", Value: TxStatusTypeFailedRelayed},
-					clause.Neq{Column: "cross_message.tx_status", Value: TxStatusTypeDropped},
+					clause.Neq{Column: "cross_message_v2.tx_status", Value: TxStatusTypeRelayed},
+					clause.Neq{Column: "cross_message_v2.tx_status", Value: TxStatusTypeFailedRelayed},
+					clause.Neq{Column: "cross_message_v2.tx_status", Value: TxStatusTypeDropped},
 				),
 			},
 		},

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.47"
+var tag = "v4.3.48"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Change `cross_message` to `cross_message_v2`.

Related error message:
`2024-01-03 16:23:52 | ERROR[01-03\|08:23:52.046\|scroll-tech/bridge-history-api/internal/logic/event_update.go:206]            failed to update db of L2 events         err="failed to update L2 reverted relayed message of L1 deposit, error: ERROR: missing FROM-clause entry for table \"cross_message\" (SQLSTATE 42P01)"`

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
