### PR TITLE
refactor(bridge-history): refactor API field naming and improve ERC721/ERC1155 batch-transfer support

### DIFF
--- a/bridge-history-api/internal/controller/api/history_controller.go
+++ b/bridge-history-api/internal/controller/api/history_controller.go
@@ -35,7 +35,7 @@ func (c *HistoryController) GetL2UnclaimedWithdrawalsByAddress(ctx *gin.Context)
 		return
 	}
 
-	resultData := &types.ResultData{Result: pagedTxs, Total: total}
+	resultData := &types.ResultData{Results: pagedTxs, Total: total}
 	types.RenderSuccess(ctx, resultData)
 }
 
@@ -53,7 +53,7 @@ func (c *HistoryController) GetL2WithdrawalsByAddress(ctx *gin.Context) {
 		return
 	}
 
-	resultData := &types.ResultData{Result: pagedTxs, Total: total}
+	resultData := &types.ResultData{Results: pagedTxs, Total: total}
 	types.RenderSuccess(ctx, resultData)
 }
 
@@ -71,7 +71,7 @@ func (c *HistoryController) GetTxsByAddress(ctx *gin.Context) {
 		return
 	}
 
-	resultData := &types.ResultData{Result: pagedTxs, Total: total}
+	resultData := &types.ResultData{Results: pagedTxs, Total: total}
 	types.RenderSuccess(ctx, resultData)
 }
 
@@ -89,6 +89,6 @@ func (c *HistoryController) PostQueryTxsByHashes(ctx *gin.Context) {
 		return
 	}
 
-	resultData := &types.ResultData{Result: results, Total: uint64(len(results))}
+	resultData := &types.ResultData{Results: results, Total: uint64(len(results))}
 	types.RenderSuccess(ctx, resultData)
 }

--- a/bridge-history-api/internal/logic/history_logic.go
+++ b/bridge-history-api/internal/logic/history_logic.go
@@ -16,6 +16,7 @@ import (
 
 	"scroll-tech/bridge-history-api/internal/orm"
 	"scroll-tech/bridge-history-api/internal/types"
+	"scroll-tech/bridge-history-api/internal/utils"
 )
 
 const (
@@ -261,40 +262,44 @@ func (h *HistoryLogic) GetTxsByHashes(ctx context.Context, txHashes []string) ([
 
 func getTxHistoryInfo(message *orm.CrossMessage) *types.TxHistoryInfo {
 	txHistory := &types.TxHistoryInfo{
-		MsgHash:        message.MessageHash,
-		Amount:         message.TokenAmounts,
-		L1Token:        message.L1TokenAddress,
-		L2Token:        message.L2TokenAddress,
-		IsL1:           orm.MessageType(message.MessageType) == orm.MessageTypeL1SentMessage,
-		TxStatus:       message.TxStatus,
+		MessageHash:    message.MessageHash,
+		TokenType:      orm.TokenType(message.TokenType),
+		TokenIDs:       utils.ConvertStringToStringArray(message.TokenIDs),
+		TokenAmounts:   utils.ConvertStringToStringArray(message.TokenAmounts),
+		L1TokenAddress: message.L1TokenAddress,
+		L2TokenAddress: message.L2TokenAddress,
+		MessageType:    orm.MessageType(message.MessageType),
+		TxStatus:       orm.TxStatusType(message.TxStatus),
 		BlockTimestamp: message.BlockTimestamp,
 	}
-	if txHistory.IsL1 {
+	if txHistory.MessageType == orm.MessageTypeL1SentMessage {
 		txHistory.Hash = message.L1TxHash
 		txHistory.ReplayTxHash = message.L1ReplayTxHash
 		txHistory.RefundTxHash = message.L1RefundTxHash
 		txHistory.BlockNumber = message.L1BlockNumber
-		txHistory.FinalizeTx = &types.Finalized{
+		txHistory.CounterpartChainTx = &types.CounterpartChainTx{
 			Hash:        message.L2TxHash,
 			BlockNumber: message.L2BlockNumber,
 		}
 	} else {
 		txHistory.Hash = message.L2TxHash
 		txHistory.BlockNumber = message.L2BlockNumber
-		txHistory.FinalizeTx = &types.Finalized{
+		txHistory.CounterpartChainTx = &types.CounterpartChainTx{
 			Hash:        message.L1TxHash,
 			BlockNumber: message.L1BlockNumber,
 		}
 		if orm.RollupStatusType(message.RollupStatus) == orm.RollupStatusTypeFinalized {
-			txHistory.ClaimInfo = &types.UserClaimInfo{
-				From:       message.MessageFrom,
-				To:         message.MessageTo,
-				Value:      message.MessageValue,
-				Nonce:      strconv.FormatUint(message.MessageNonce, 10),
-				Message:    message.MessageData,
-				Proof:      "0x" + common.Bytes2Hex(message.MerkleProof),
-				BatchIndex: strconv.FormatUint(message.BatchIndex, 10),
-				Claimable:  true,
+			txHistory.ClaimInfo = &types.ClaimInfo{
+				From:    message.MessageFrom,
+				To:      message.MessageTo,
+				Value:   message.MessageValue,
+				Nonce:   strconv.FormatUint(message.MessageNonce, 10),
+				Message: message.MessageData,
+				Proof: types.L2MessageProof{
+					BatchIndex:  strconv.FormatUint(message.BatchIndex, 10),
+					MerkleProof: "0x" + common.Bytes2Hex(message.MerkleProof),
+				},
+				Claimable: true,
 			}
 		}
 	}

--- a/bridge-history-api/internal/utils/utils.go
+++ b/bridge-history-api/internal/utils/utils.go
@@ -191,6 +191,18 @@ func ConvertBigIntArrayToString(array []*big.Int) string {
 	return result
 }
 
+// ConvertStringToStringArray takes a string with values separated by commas and returns a slice of strings
+func ConvertStringToStringArray(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	stringParts := strings.Split(s, ",")
+	for i, part := range stringParts {
+		stringParts[i] = strings.TrimSpace(part)
+	}
+	return stringParts
+}
+
 // GetSkippedQueueIndices get the skipped queue indices
 func GetSkippedQueueIndices(startIndex uint64, skippedBitmap *big.Int) []uint64 {
 	var indices []uint64

--- a/bridge-history-api/internal/utils/utils.go
+++ b/bridge-history-api/internal/utils/utils.go
@@ -203,7 +203,7 @@ func ConvertStringToStringArray(s string) []string {
 	return stringParts
 }
 
-// GetSkippedQueueIndices get the skipped queue indices
+// GetSkippedQueueIndices gets the skipped queue indices
 func GetSkippedQueueIndices(startIndex uint64, skippedBitmap *big.Int) []uint64 {
 	var indices []uint64
 	for i := 0; i < 256; i++ {

--- a/bridge-history-api/internal/utils/utils_test.go
+++ b/bridge-history-api/internal/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/scroll-tech/go-ethereum/common"
@@ -35,4 +36,56 @@ func TestGetBatchRangeFromCalldata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, start, uint64(0))
 	assert.Equal(t, finish, uint64(0))
+}
+
+// TestConvertBigIntArrayToString tests the ConvertBigIntArrayToString function
+func TestConvertBigIntArrayToString(t *testing.T) {
+	tests := []struct {
+		array    []*big.Int
+		expected string
+	}{
+		{[]*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)}, "1, 2, 3"},
+		{[]*big.Int{big.NewInt(0), big.NewInt(-1)}, "0, -1"},
+		{[]*big.Int{}, ""},
+	}
+
+	for _, test := range tests {
+		got := ConvertBigIntArrayToString(test.array)
+		assert.Equal(t, test.expected, got)
+	}
+}
+
+// TestConvertStringToStringArray tests the ConvertStringToStringArray function
+func TestConvertStringToStringArray(t *testing.T) {
+	tests := []struct {
+		s        string
+		expected []string
+	}{
+		{"1, 2, 3", []string{"1", "2", "3"}},
+		{" 4 , 5 , 6 ", []string{"4", "5", "6"}},
+		{"", []string{}},
+	}
+
+	for _, test := range tests {
+		got := ConvertStringToStringArray(test.s)
+		assert.Equal(t, test.expected, got)
+	}
+}
+
+// TestGetSkippedQueueIndices tests the GetSkippedQueueIndices function
+func TestGetSkippedQueueIndices(t *testing.T) {
+	tests := []struct {
+		startIndex uint64
+		bitmap     *big.Int
+		expected   []uint64
+	}{
+		{0, big.NewInt(0b101), []uint64{0, 2}},
+		{10, big.NewInt(0b110), []uint64{11, 12}},
+		{0, big.NewInt(0), nil}, // No bits set
+	}
+
+	for _, test := range tests {
+		got := GetSkippedQueueIndices(test.startIndex, test.bitmap)
+		assert.Equal(t, test.expected, got)
+	}
 }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.51"
+var tag = "v4.3.52"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

While adding the API documentation, I found some areas that could be improved. Key changes in this PR include:

1. Unified JSON field naming to snake_case format, such as `xxx_yyy`.
2. Enhanced support for batch transfers of ERC721 and ERC1155 tokens, with the addition of `token_ids` and `token_type` fields.
3. Renamed various fields for clarity, such as changing `result` to `results` for array types, `finalizeTx` to `counterpartChainTx` since "finalized" is often used to indicate an L2 block's rollup status now, and `IsL1` to `MessageType` since `IsL1` is usually used for function naming.
4. Restructured the `ClaimInfo` struct to more closely align with the contract interfaces.

Current doc: https://www.notion.so/scrollzkp/Bridge-History-APIs-Doc-7623d5c6210c4c3a83006d8d9d871476

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] Yes
