### PR TITLE
feat(sender): optimize access list tx

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.54"
+var tag = "v4.3.55"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -6,22 +6,21 @@ import (
 	"sync/atomic"
 
 	"github.com/scroll-tech/go-ethereum"
-	"github.com/scroll-tech/go-ethereum/accounts/abi/bind"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/log"
 )
 
-func (s *Sender) estimateLegacyGas(auth *bind.TransactOpts, contract *common.Address, value *big.Int, input []byte, fallbackGasLimit uint64) (*FeeData, error) {
+func (s *Sender) estimateLegacyGas(contract *common.Address, value *big.Int, data []byte, fallbackGasLimit uint64) (*FeeData, error) {
 	gasPrice, err := s.client.SuggestGasPrice(s.ctx)
 	if err != nil {
 		log.Error("estimateLegacyGas SuggestGasPrice failure", "error", err)
 		return nil, err
 	}
-	gasLimit, _, err := s.estimateGasLimit(auth, contract, input, gasPrice, nil, nil, value, false)
+	gasLimit, _, err := s.estimateGasLimit(contract, data, gasPrice, nil, nil, value, false)
 	if err != nil {
-		log.Error("estimateLegacyGas estimateGasLimit failure", "gas price", gasPrice, "from", auth.From.Hex(),
-			"nonce", auth.Nonce.Uint64(), "contract address", contract.Hex(), "fallback gas limit", fallbackGasLimit, "error", err)
+		log.Error("estimateLegacyGas estimateGasLimit failure", "gas price", gasPrice, "from", s.auth.From.Hex(),
+			"nonce", s.auth.Nonce.Uint64(), "contract address", contract.Hex(), "fallback gas limit", fallbackGasLimit, "error", err)
 		if fallbackGasLimit == 0 {
 			return nil, err
 		}
@@ -35,7 +34,7 @@ func (s *Sender) estimateLegacyGas(auth *bind.TransactOpts, contract *common.Add
 	}, nil
 }
 
-func (s *Sender) estimateDynamicGas(auth *bind.TransactOpts, contract *common.Address, value *big.Int, input []byte, fallbackGasLimit uint64) (*FeeData, error) {
+func (s *Sender) estimateDynamicGas(contract *common.Address, value *big.Int, data []byte, fallbackGasLimit uint64) (*FeeData, error) {
 	gasTipCap, err := s.client.SuggestGasTipCap(s.ctx)
 	if err != nil {
 		log.Error("estimateDynamicGas SuggestGasTipCap failure", "error", err)
@@ -50,10 +49,10 @@ func (s *Sender) estimateDynamicGas(auth *bind.TransactOpts, contract *common.Ad
 		gasTipCap,
 		new(big.Int).Mul(baseFee, big.NewInt(2)),
 	)
-	gasLimit, accessList, err := s.estimateGasLimit(auth, contract, input, nil, gasTipCap, gasFeeCap, value, true)
+	gasLimit, accessList, err := s.estimateGasLimit(contract, data, nil, gasTipCap, gasFeeCap, value, true)
 	if err != nil {
 		log.Error("estimateDynamicGas estimateGasLimit failure",
-			"from", auth.From.Hex(), "nonce", auth.Nonce.Uint64(), "contract address", contract.Hex(),
+			"from", s.auth.From.Hex(), "nonce", s.auth.Nonce.Uint64(), "contract address", contract.Hex(),
 			"fallback gas limit", fallbackGasLimit, "error", err)
 		if fallbackGasLimit == 0 {
 			return nil, err
@@ -73,15 +72,15 @@ func (s *Sender) estimateDynamicGas(auth *bind.TransactOpts, contract *common.Ad
 	return feeData, nil
 }
 
-func (s *Sender) estimateGasLimit(opts *bind.TransactOpts, contract *common.Address, input []byte, gasPrice, gasTipCap, gasFeeCap, value *big.Int, useAccessList bool) (uint64, *types.AccessList, error) {
+func (s *Sender) estimateGasLimit(contract *common.Address, data []byte, gasPrice, gasTipCap, gasFeeCap, value *big.Int, useAccessList bool) (uint64, *types.AccessList, error) {
 	msg := ethereum.CallMsg{
-		From:      opts.From,
+		From:      s.auth.From,
 		To:        contract,
 		GasPrice:  gasPrice,
 		GasTipCap: gasTipCap,
 		GasFeeCap: gasFeeCap,
 		Value:     value,
-		Data:      input,
+		Data:      data,
 	}
 	gasLimitWithoutAccessList, err := s.client.EstimateGas(s.ctx, msg)
 	if err != nil {
@@ -93,8 +92,7 @@ func (s *Sender) estimateGasLimit(opts *bind.TransactOpts, contract *common.Addr
 		return gasLimitWithoutAccessList, nil, nil
 	}
 
-	var gasLimitWithAccessList uint64
-	accessList, _, errStr, rpcErr := s.gethClient.CreateAccessList(s.ctx, msg)
+	accessList, gasLimitWithAccessList, errStr, rpcErr := s.gethClient.CreateAccessList(s.ctx, msg)
 	if rpcErr != nil {
 		log.Error("CreateAccessList RPC error", "error", rpcErr)
 		return gasLimitWithoutAccessList, nil, rpcErr
@@ -104,17 +102,35 @@ func (s *Sender) estimateGasLimit(opts *bind.TransactOpts, contract *common.Addr
 		return gasLimitWithoutAccessList, nil, fmt.Errorf(errStr)
 	}
 
-	msg.AccessList = *accessList
-	gasLimitWithAccessList, err = s.client.EstimateGas(s.ctx, msg)
-	if err != nil {
-		log.Error("estimateGasLimit EstimateGas failure with access list", "error", err)
-		return gasLimitWithoutAccessList, nil, err
-	}
+	// Heuristically fine-tune accessList because 'to' address is automatically included in the access list by the Ethereum protocol: https://github.com/ethereum/go-ethereum/blob/v1.13.10/core/state/statedb.go#L1322
+	// This function returns a gas estimation because GO SDK does not support access list: https://github.com/ethereum/go-ethereum/blob/v1.13.10/ethclient/ethclient.go#L642
+	accessList, gasLimitWithAccessList = finetuneAccessList(accessList, gasLimitWithAccessList, msg.To)
 
-	log.Info("gas", "gasLimitWithAccessList", gasLimitWithAccessList, "gasLimitWithoutAccessList", gasLimitWithoutAccessList)
+	log.Info("gas", "senderName", s.name, "senderService", s.service, "gasLimitWithAccessList", gasLimitWithAccessList, "gasLimitWithoutAccessList", gasLimitWithoutAccessList, "accessList", accessList)
 
 	if gasLimitWithAccessList < gasLimitWithoutAccessList {
 		return gasLimitWithAccessList, accessList, nil
 	}
 	return gasLimitWithoutAccessList, nil, nil
+}
+
+func finetuneAccessList(accessList *types.AccessList, gasLimitWithAccessList uint64, to *common.Address) (*types.AccessList, uint64) {
+	if accessList == nil || to == nil {
+		return accessList, gasLimitWithAccessList
+	}
+
+	var newAccessList types.AccessList
+	for _, entry := range *accessList {
+		if entry.Address == *to && len(entry.StorageKeys) < 24 {
+			// This is a heuristic method, we check if number of slots is < 24.
+			// If so, we remove it and adjust the gas limit estimate accordingly.
+			// This removal helps in preventing double-counting of the 'to' address in access list calculations.
+			gasLimitWithAccessList -= 2400
+			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys)) // Assuming these slots can save 100 gas compared with len(entry.StorageKeys times cold sload.
+		} else {
+			// Otherwise, keep the entry in the new access list.
+			newAccessList = append(newAccessList, entry)
+		}
+	}
+	return &newAccessList, gasLimitWithAccessList
 }

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -126,7 +126,8 @@ func finetuneAccessList(accessList *types.AccessList, gasLimitWithAccessList uin
 			// If so, we remove it and adjust the gas limit estimate accordingly.
 			// This removal helps in preventing double-counting of the 'to' address in access list calculations.
 			gasLimitWithAccessList -= 2400
-			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys)) // Assuming that these slots can save 100 gas units compared to the product of len(entry.StorageKeys) and cold sload operations
+			// Assuming each slot saves 100 gas units as access list storage key cost (1900 gas) plus warm sload (100 gas) is cheaper than cold sload (2100 gas).
+			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys))
 		} else {
 			// Otherwise, keep the entry in the new access list.
 			newAccessList = append(newAccessList, entry)

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -126,7 +126,7 @@ func finetuneAccessList(accessList *types.AccessList, gasLimitWithAccessList uin
 			// If so, we remove it and adjust the gas limit estimate accordingly.
 			// This removal helps in preventing double-counting of the 'to' address in access list calculations.
 			gasLimitWithAccessList -= 2400
-			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys)) // Assuming these slots can save 100 gas compared with len(entry.StorageKeys times cold sload.
+			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys)) // Assuming that these slots can save 100 gas units compared to the product of len(entry.StorageKeys) and cold sload operations
 		} else {
 			// Otherwise, keep the entry in the new access list.
 			newAccessList = append(newAccessList, entry)

--- a/rollup/internal/controller/sender/sender_test.go
+++ b/rollup/internal/controller/sender/sender_test.go
@@ -19,16 +19,20 @@ import (
 
 	"scroll-tech/common/docker"
 
+	bridgeAbi "scroll-tech/rollup/abi"
+	"scroll-tech/rollup/mock_bridge"
+
 	"scroll-tech/rollup/internal/config"
 )
 
 const TXBatch = 50
 
 var (
-	privateKey *ecdsa.PrivateKey
-	cfg        *config.Config
-	base       *docker.App
-	txTypes    = []string{"LegacyTx", "AccessListTx", "DynamicFeeTx"}
+	privateKey         *ecdsa.PrivateKey
+	cfg                *config.Config
+	base               *docker.App
+	txTypes            = []string{"LegacyTx", "AccessListTx", "DynamicFeeTx"}
+	scrollChainAddress common.Address
 )
 
 func TestMain(m *testing.M) {
@@ -51,6 +55,18 @@ func setupEnv(t *testing.T) {
 
 	cfg.L1Config.RelayerConfig.SenderConfig.Endpoint = base.L1gethImg.Endpoint()
 	cfg.L1Config.RelayerConfig.SenderConfig.CheckBalanceTime = 1
+
+	auth, err := bind.NewKeyedTransactorWithChainID(privateKey, base.L1gethImg.ChainID())
+	assert.NoError(t, err)
+
+	l1Client, err := base.L1Client()
+	assert.NoError(t, err)
+
+	_, tx, _, err := mock_bridge.DeployMockBridgeL1(auth, l1Client)
+	assert.NoError(t, err)
+
+	scrollChainAddress, err = bind.WaitDeployed(context.Background(), l1Client, tx)
+	assert.NoError(t, err)
 }
 
 func TestSender(t *testing.T) {
@@ -60,6 +76,7 @@ func TestSender(t *testing.T) {
 	t.Run("test new sender", testNewSender)
 	t.Run("test pending limit", testPendLimit)
 	t.Run("test fallback gas limit", testFallbackGasLimit)
+	t.Run("test access list transaction gas limit", testAccessListTransactionGasLimit)
 	t.Run("test resubmit zero gas price transaction", testResubmitZeroGasPriceTransaction)
 	t.Run("test resubmit non-zero gas price transaction", testResubmitNonZeroGasPriceTransaction)
 	t.Run("test resubmit under priced transaction", testResubmitUnderpricedTransaction)
@@ -124,7 +141,7 @@ func testFallbackGasLimit(t *testing.T) {
 
 		// FallbackGasLimit = 100000
 		patchGuard := gomonkey.ApplyPrivateMethod(s, "estimateGasLimit",
-			func(opts *bind.TransactOpts, contract *common.Address, input []byte, gasPrice, gasTipCap, gasFeeCap, value *big.Int) (uint64, *types.AccessList, error) {
+			func(contract *common.Address, input []byte, gasPrice, gasTipCap, gasFeeCap, value *big.Int) (uint64, *types.AccessList, error) {
 				return 0, nil, errors.New("estimateGasLimit error")
 			},
 		)
@@ -152,12 +169,39 @@ func testResubmitZeroGasPriceTransaction(t *testing.T) {
 			gasFeeCap: big.NewInt(0),
 			gasLimit:  50000,
 		}
-		tx, err := s.createAndSendTx(s.auth, feeData, &common.Address{}, big.NewInt(0), nil, nil)
+		tx, err := s.createAndSendTx(feeData, &common.Address{}, big.NewInt(0), nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
 		// Increase at least 1 wei in gas price, gas tip cap and gas fee cap.
 		_, err = s.resubmitTransaction(feeData, s.auth, tx)
 		assert.NoError(t, err)
+		s.Stop()
+	}
+}
+
+func testAccessListTransactionGasLimit(t *testing.T) {
+	for _, txType := range txTypes {
+		cfgCopy := *cfg.L1Config.RelayerConfig.SenderConfig
+		cfgCopy.TxType = txType
+		s, err := NewSender(context.Background(), &cfgCopy, privateKey, "test", "test", nil)
+		assert.NoError(t, err)
+
+		l2GasOracleABI, err := bridgeAbi.L2GasPriceOracleMetaData.GetAbi()
+		assert.NoError(t, err)
+
+		data, err := l2GasOracleABI.Pack("setL2BaseFee", big.NewInt(2333))
+		assert.NoError(t, err)
+
+		gasLimit, accessList, err := s.estimateGasLimit(&scrollChainAddress, data, big.NewInt(100000000000), big.NewInt(100000000000), big.NewInt(100000000000), big.NewInt(0), true)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(43450), gasLimit)
+		assert.NotNil(t, accessList)
+
+		gasLimit, accessList, err = s.estimateGasLimit(&scrollChainAddress, data, big.NewInt(100000000000), big.NewInt(100000000000), big.NewInt(100000000000), big.NewInt(0), false)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(43927), gasLimit)
+		assert.Nil(t, accessList)
+
 		s.Stop()
 	}
 }
@@ -177,7 +221,7 @@ func testResubmitNonZeroGasPriceTransaction(t *testing.T) {
 			gasFeeCap: big.NewInt(100000),
 			gasLimit:  50000,
 		}
-		tx, err := s.createAndSendTx(s.auth, feeData, &common.Address{}, big.NewInt(0), nil, nil)
+		tx, err := s.createAndSendTx(feeData, &common.Address{}, big.NewInt(0), nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
 		_, err = s.resubmitTransaction(feeData, s.auth, tx)
@@ -201,7 +245,7 @@ func testResubmitUnderpricedTransaction(t *testing.T) {
 			gasFeeCap: big.NewInt(100000),
 			gasLimit:  50000,
 		}
-		tx, err := s.createAndSendTx(s.auth, feeData, &common.Address{}, big.NewInt(0), nil, nil)
+		tx, err := s.createAndSendTx(feeData, &common.Address{}, big.NewInt(0), nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
 		_, err = s.resubmitTransaction(feeData, s.auth, tx)
@@ -219,7 +263,7 @@ func testResubmitTransactionWithRisingBaseFee(t *testing.T) {
 	assert.NoError(t, err)
 	tx := types.NewTransaction(s.auth.Nonce.Uint64(), common.Address{}, big.NewInt(0), 0, big.NewInt(0), nil)
 	s.baseFeePerGas = 1000
-	feeData, err := s.getFeeData(s.auth, &common.Address{}, big.NewInt(0), nil, 0)
+	feeData, err := s.getFeeData(&common.Address{}, big.NewInt(0), nil, 0)
 	assert.NoError(t, err)
 	// bump the basefee by 10x
 	s.baseFeePerGas *= 10

--- a/rollup/mock_bridge/MockBridgeL1.sol
+++ b/rollup/mock_bridge/MockBridgeL1.sol
@@ -79,16 +79,16 @@ contract MockBridgeL1 {
    * Variables *
    *************/
 
-  /// @notice Message nonce, used to avoid relay attack.
   uint256 public messageNonce;
-
   mapping(uint256 => bytes32) public committedBatches;
+  uint256 public l2BaseFee;
 
   /***********************************
    * Functions from L2GasPriceOracle *
    ***********************************/
 
-  function setL2BaseFee(uint256) external {
+  function setL2BaseFee(uint256 _newL2BaseFee) external {
+    l2BaseFee = _newL2BaseFee;
   }
 
   /************************************


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR optimizes sender sending access list transactions. Due to the following reasons:
1. `EstimateGas` in go SDK does not support access list: https://github.com/ethereum/go-ethereum/blob/v1.13.10/ethclient/ethclient.go#L642
2. The transaction's `to` address is automatically included in the access list by the Ethereum protocol: https://github.com/ethereum/go-ethereum/blob/v1.13.10/core/state/statedb.go#L1322, the gas (2400 for `ACCESS_LIST_ADDRESS_COST`) would be reduced twice.

Testing scripts (need to tweak `toCallArg` and launch a local node):
```
package main

import (
	"context"
	"fmt"
	"math/big"

	"github.com/scroll-tech/go-ethereum"
	"github.com/scroll-tech/go-ethereum/accounts/abi/bind"
	"github.com/scroll-tech/go-ethereum/common"
	"github.com/scroll-tech/go-ethereum/core/types"
	"github.com/scroll-tech/go-ethereum/ethclient"
	"github.com/scroll-tech/go-ethereum/ethclient/gethclient"
	"github.com/scroll-tech/go-ethereum/rpc"
)

var l1GasPriceOracleMetaData = &bind.MetaData{
	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_owner\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"l1BaseFee\",\"type\":\"uint256\"}],\"name\":\"L1BaseFeeUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"overhead\",\"type\":\"uint256\"}],\"name\":\"OverheadUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"_oldOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"_newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"scalar\",\"type\":\"uint256\"}],\"name\":\"ScalarUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"_oldWhitelist\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"_newWhitelist\",\"type\":\"address\"}],\"name\":\"UpdateWhitelist\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"getL1Fee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"getL1GasUsed\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"l1BaseFee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"overhead\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"scalar\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_l1BaseFee\",\"type\":\"uint256\"}],\"name\":\"setL1BaseFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_overhead\",\"type\":\"uint256\"}],\"name\":\"setOverhead\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_scalar\",\"type\":\"uint256\"}],\"name\":\"setScalar\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_newWhitelist\",\"type\":\"address\"}],\"name\":\"updateWhitelist\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"whitelist\",\"outputs\":[{\"internalType\":\"contract IWhitelist\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]\n",
}

func main() {
	rpcClient, err := rpc.Dial("http://localhost:8545")
	if err != nil {
		fmt.Println("Failed to connect to the Ethereum client", "error", err)
		return
	}

	ethClient := ethclient.NewClient(rpcClient)
	gethClient := gethclient.New(rpcClient)

	fromAddress := common.HexToAddress("0xbe27c3acB9C61AfDfd99b653c3f13fc7Ce7c6F69")
	contractAddress := common.HexToAddress("0x5300000000000000000000000000000000000002")

	l1GasOracleABI, err := l1GasPriceOracleMetaData.GetAbi()
	if err != nil {
		fmt.Println("Failed to get l2GasPriceOracleMetaData abi", "err", err)
		return
	}

	data, err := l1GasOracleABI.Pack("setL1BaseFee", big.NewInt(2333))
	if err != nil {
		fmt.Println("Failed to pack setL1BaseFee", "err", err)
		return
	}

	msg := ethereum.CallMsg{
		From:     fromAddress,
		To:       &contractAddress,
		Gas:      3000000,
		GasPrice: big.NewInt(1e9),
		Value:    big.NewInt(0),
		Data:     data,
	}

	gasWithoutAccessList, err := ethClient.EstimateGas(context.Background(), msg)
	if err != nil {
		fmt.Println("Failed to estimate gas without access list", "error", err)
		return
	}

	accessList, gasWithAccessList, errStr, rpcErr := gethClient.CreateAccessList(context.Background(), msg)
	if rpcErr != nil {
		fmt.Println("CreateAccessList RPC error", "error", rpcErr)
		return
	}
	if errStr != "" {
		fmt.Println("CreateAccessList reported error", "error", errStr)
		return
	}

	// Heuristically fine-tune accessList because 'to' address is automatically included in the access list by the Ethereum protocol: https://github.com/ethereum/go-ethereum/blob/v1.13.10/core/state/statedb.go#L1322
	// This function returns a gas estimation because GO SDK does not support access list: https://github.com/ethereum/go-ethereum/blob/v1.13.10/ethclient/ethclient.go#L642
	accessList, estimateGasAfterFinetune := finetuneAccessList(accessList, gasWithAccessList, &contractAddress)
	msg.AccessList = *accessList
	gasAfterFinetune, err := ethClient.EstimateGas(context.Background(), msg)
	if err != nil {
		fmt.Println("Failed to estimate gas with access list", "error", err)
		return
	}
	fmt.Println("Gas estimate differs", "gasWithAccessList", gasWithAccessList, "gasWithoutAccessList", gasWithoutAccessList, "estimateGasAfterFinetune", estimateGasAfterFinetune, "gasAfterFinetune", gasAfterFinetune, "accessList", accessList)
}

func finetuneAccessList(accessList *types.AccessList, gasLimitWithAccessList uint64, to *common.Address) (*types.AccessList, uint64) {
	if accessList == nil || to == nil {
		return accessList, gasLimitWithAccessList
	}

	var newAccessList types.AccessList
	for _, entry := range *accessList {
		if entry.Address == *to && len(entry.StorageKeys) < 24 {
			// This is a heuristic method, we check if number of slots is < 24.
			// If so, we remove it and adjust the gas limit estimate accordingly.
			// This removal helps in preventing double-counting of the 'to' address in access list calculations.
			gasLimitWithAccessList -= 2400
			// Assuming each slot saves 100 gas units as access list storage key cost (1900 gas) plus warm sload (100 gas) is cheaper than cold sload (2100 gas).
			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys))
		} else {
			// Otherwise, keep the entry in the new access list.
			newAccessList = append(newAccessList, entry)
		}
	}
	return &newAccessList, gasLimitWithAccessList
}
```
tweaked `toCallArg`:
```
func toCallArg(msg ethereum.CallMsg) interface{} {
	arg := map[string]interface{}{
		"from": msg.From,
		"to":   msg.To,
	}
	if len(msg.Data) > 0 {
		arg["data"] = hexutil.Bytes(msg.Data)
	}
	if msg.Value != nil {
		arg["value"] = (*hexutil.Big)(msg.Value)
	}
	if msg.Gas != 0 {
		arg["gas"] = hexutil.Uint64(msg.Gas)
	}
	if msg.GasPrice != nil {
		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
	}
	if msg.AccessList != nil {
		arg["accessList"] = msg.AccessList
	}
	return arg
}
```
Output:
```
Gas estimate differs gasWithAccessList 37053 gasWithoutAccessList 35153 estimateGasAfterFinetune 34853 gasAfterFientune 34953 accessList &[{0x5300000000000000000000000000000000000003 [0x3ab2bc2f5b413df4fb4bd4e53d27bb60acca4431614f365edb18df28a0ee0876]}]
```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature
- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
