### PR TITLE
fix(bridge-history): incorrect status reset

### DIFF
--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -259,18 +259,21 @@ func (c *CrossMessage) UpdateL1MessageQueueEventsInfo(ctx context.Context, l1Mes
 		db := c.db
 		db = db.WithContext(ctx)
 		db = db.Model(&CrossMessage{})
-		// do not over-write terminal statuses.
-		db = db.Where("tx_status != ?", TxStatusTypeRelayed)
-		db = db.Where("tx_status != ?", TxStatusTypeDropped)
 		txStatusUpdateFields := make(map[string]interface{})
 		switch l1MessageQueueEvent.EventType {
 		case MessageQueueEventTypeQueueTransaction:
 			continue
 		case MessageQueueEventTypeDequeueTransaction:
+			// do not over-write terminal statuses.
+			db = db.Where("tx_status != ?", TxStatusTypeRelayed)
+			db = db.Where("tx_status != ?", TxStatusTypeDropped)
 			db = db.Where("message_nonce = ?", l1MessageQueueEvent.QueueIndex)
 			db = db.Where("message_type = ?", MessageTypeL1SentMessage)
 			txStatusUpdateFields["tx_status"] = TxStatusTypeSkipped
 		case MessageQueueEventTypeDropTransaction:
+			// do not over-write terminal statuses.
+			db = db.Where("tx_status != ?", TxStatusTypeRelayed)
+			db = db.Where("tx_status != ?", TxStatusTypeDropped)
 			db = db.Where("message_nonce = ?", l1MessageQueueEvent.QueueIndex)
 			db = db.Where("message_type = ?", MessageTypeL1SentMessage)
 			txStatusUpdateFields["tx_status"] = TxStatusTypeDropped

--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -265,17 +265,7 @@ func (c *CrossMessage) UpdateL1MessageQueueEventsInfo(ctx context.Context, l1Mes
 		txStatusUpdateFields := make(map[string]interface{})
 		switch l1MessageQueueEvent.EventType {
 		case MessageQueueEventTypeQueueTransaction:
-			// only replayMessages or enforced txs (whose message hashes would not be found), sentMessages have been filtered out.
-			// replayMessage case:
-			// First SentMessage in L1: https://sepolia.etherscan.io/tx/0xbee4b631312448fcc2caac86e4dccf0a2ae0a88acd6c5fd8764d39d746e472eb
-			// Transaction reverted in L2: https://sepolia.scrollscan.com/tx/0xde6ef307a7da255888aad7a4c40a6b8c886e46a8a05883070bbf18b736cbfb8c
-			// replayMessage: https://sepolia.etherscan.io/tx/0xa5392891232bb32d98fcdbaca0d91b4d22ef2755380d07d982eebd47b147ce28
-			//
-			// Note: update l1_tx_hash if the user calls replayMessage, cannot use queue index here,
-			// because in replayMessage, queue index != message nonce.
-			// Ref: https://github.com/scroll-tech/scroll/blob/v4.3.44/contracts/src/L1/L1ScrollMessenger.sol#L187-L190
-			db = db.Where("message_hash = ?", l1MessageQueueEvent.MessageHash.String())
-			txStatusUpdateFields["tx_status"] = TxStatusTypeSent // reset status to "sent".
+			continue
 		case MessageQueueEventTypeDequeueTransaction:
 			db = db.Where("message_nonce = ?", l1MessageQueueEvent.QueueIndex)
 			db = db.Where("message_type = ?", MessageTypeL1SentMessage)
@@ -300,7 +290,15 @@ func (c *CrossMessage) UpdateL1MessageQueueEventsInfo(ctx context.Context, l1Mes
 		case MessageQueueEventTypeDequeueTransaction:
 			continue
 		case MessageQueueEventTypeQueueTransaction:
-			// only replayMessages or enforced txs (whose message hashes would not be found), sentMessages have been filtered out.
+			// only replayMessages or enforced txs (whose message hashes would not be found), sendMessages have been filtered out.
+			// replayMessage case:
+			// First SentMessage in L1: https://sepolia.etherscan.io/tx/0xbee4b631312448fcc2caac86e4dccf0a2ae0a88acd6c5fd8764d39d746e472eb
+			// Transaction reverted in L2: https://sepolia.scrollscan.com/tx/0xde6ef307a7da255888aad7a4c40a6b8c886e46a8a05883070bbf18b736cbfb8c
+			// replayMessage: https://sepolia.etherscan.io/tx/0xa5392891232bb32d98fcdbaca0d91b4d22ef2755380d07d982eebd47b147ce28
+			//
+			// Note: update l1_tx_hash if the user calls replayMessage, cannot use queue index here,
+			// because in replayMessage, queue index != message nonce.
+			// Ref: https://github.com/scroll-tech/scroll/blob/v4.3.44/contracts/src/L1/L1ScrollMessenger.sol#L187-L190
 			db = db.Where("message_hash = ?", l1MessageQueueEvent.MessageHash.String())
 			txHashUpdateFields["l1_replay_tx_hash"] = l1MessageQueueEvent.TxHash.String()
 		case MessageQueueEventTypeDropTransaction:

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.57"
+var tag = "v4.3.58"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Previously, bridge-history cannot handle the `replayMessage` case:
1. L1 sendMessage.
2. L2 relay message and failed.
3. L1 replayMessage.
4. L2 relay message and failed (not success, which is a non-terminal status).

if step 4 is updated in L2 fetcher before step 2, the status would be incorrectly set as "sent".

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
