### PR TITLE
fix(sender): add gas limit when querying access list

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.64"
+var tag = "v4.3.65"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.63"
+var tag = "v4.3.64"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -84,6 +84,9 @@ func (s *Sender) estimateGasLimit(to *common.Address, data []byte, gasPrice, gas
 		return gasLimitWithoutAccessList, nil, nil
 	}
 
+	// Explicitly set a gas limit to prevent the "insufficient funds for gas * price + value" error.
+	// Because if msg.Gas remains unset, CreateAccessList defaults to using RPCGasCap(), which can be excessively high.
+	msg.Gas = gasLimitWithoutAccessList * 3
 	accessList, gasLimitWithAccessList, errStr, rpcErr := s.gethClient.CreateAccessList(s.ctx, msg)
 	if rpcErr != nil {
 		log.Error("CreateAccessList RPC error", "error", rpcErr)


### PR DESCRIPTION
### Purpose or design rationale of this PR

If gas limit is not assigned when querying access list, the node (geth implementation) will assign `RPCGasCap()` as the default gas limit, and `RPCGasCap()`'s default value is 50,000,000, this would result in returning `"insufficient funds for gas * price + value"` even if the sender's actual balance is sufficient for sending the transaction.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change