### PR TITLE
Remove redundant govet linter from golangci-lint configuration

### DIFF
--- a/build/.golangci.yml
+++ b/build/.golangci.yml
@@ -164,7 +164,6 @@ linters-settings:
 linters:
   enable:
     - megacheck
-    - govet
     - gofmt
     - goimports
     - varcheck


### PR DESCRIPTION
### Purpose or design rationale of this PR

- Removed the duplicate 'govet' entry from the 'enable' section of the golangci-lint configuration file to avoid unnecessary duplication.
- **Modified file**: \build\.golangci.yml

### PR title
refactor: remove redundant govet checks from golangci-lint config


### Deployment tag versioning

-  No, this PR doesn't involve a new deployment, git tag, docker image tag



### Breaking change label
- No, this PR is not a breaking change
