### PR TITLE
Grammatic Update of "our pledge" part from CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,15 +2,9 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+As members, contributors, and leaders, we pledge to ensure that everyone's participation in our community is a harassment-free experience, regardless of their age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to contribute to a welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 


### PR DESCRIPTION


Grammatically updated the "our pledge" part  in CODE_OF_CONDUCT.md
1. before: " We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone,"
1. after: "As members, contributors, and leaders, we pledge to ensure that everyone's participation in our community is a harassment-free experience"
2. before: "We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community" 
2. after:" we pledge to contribute to a welcoming, diverse, inclusive, and healthy community"

