### PR TITLE
docs(contracts): OZ-M01 Malicious User Can Increase the Gas Cost of Verification

### DIFF
--- a/contracts/src/libraries/verifier/ZkTrieVerifier.sol
+++ b/contracts/src/libraries/verifier/ZkTrieVerifier.sol
@@ -22,6 +22,16 @@ library ZkTrieVerifier {
     /// |        1 byte        |      ...      |        1 byte        |      ...      |
     /// | account proof length | account proof | storage proof length | storage proof |
     /// ```
+    ///
+    /// Possible attack vector:
+    ///   + Malicious users can influence how many levels the proof must go through by predicting addresses
+    ///     (or storage slots) that would branch the Trie until a certain depth. Even though artificially 
+    ///     increasing the proof's depth of a certain account or storage will not cause a DoS scenario, since
+    ///     the depth can still reach the maximum depth size in the worst-case scenario, artificially increasing
+    ///     the proof's depth will increase the number of iterations the `walkTree` method has to perform in order
+    ///     to reach the respective leaf. If protocols that use this verifier limit the gas used on-chain to perform
+    ///     such a verification (to a reasonable value), then a malicious user might be able to increase it for a
+    ///     particular transaction by reaching a similar hashed key to a certain depth in the Trie.
     function verifyZkTrieProof(
         address poseidon,
         address account,


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fix the following issue reported by Openzepplin: https://defender.openzeppelin.com/v2/#/audit/bca59bc7-0ff8-49a2-bcea-09f7cc7a82b8/issues/M-01

> The `ZkTrieVerifier` library verifies proofs that come from the Scroll L2 node which uses a sparse binary Trie as the data structure. For the verification process, the proofs have the necessary node hashes to reconstruct the root hash based on the queried leaf. The [`walkTree` method](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L77) used for going through all the levels of the Trie uses the [bits of the key provided](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L115-L121) to define where the path should continue (left or right). However, a malicious user can influence how many levels the proof must go through by predicting addresses (or storage slots) that would branch the Trie until a certain depth.
>
> Even though artificially increasing the proof's depth of a certain account or storage will not cause a DoS scenario, since the depth can still reach the maximum depth size in the worst-case scenario, artificially increasing the proof's depth will increase the number of iterations the `walkTree` method has to perform in order to reach the respective leaf. If protocols that use this verifier limit the gas used on-chain to perform such a verification (to a reasonable value), then a malicious user might be able to increase it for a particular transaction by reaching a similar hashed key to a certain depth in the Trie.
>
> As such, consider letting users and developers know about this possible attack vector so as to not limit the gas used in such scenarios. Otherwise, the verification might fail.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] docs: Documentation-only changes

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
