### PR TITLE
Fix(Rollup): Simplified fmt.Sprintf string

### DIFF
--- a/rollup/cmd/mock_app.go
+++ b/rollup/cmd/mock_app.go
@@ -27,7 +27,7 @@ type MockApp struct {
 	args []string
 }
 
-// NewRollupApp return a new rollupApp manager, name mush be one them.
+// NewRollupApp return a new rollupApp manager, name must be one of them.
 func NewRollupApp(base *docker.App, file string) *MockApp {
 
 	rollupFile := fmt.Sprintf("/tmp/%d_rollup-config.json", base.Timestamp)
@@ -50,12 +50,12 @@ func (b *MockApp) RunApp(t *testing.T, name utils.MockAppName, args ...string) {
 		name == utils.GasOracleApp ||
 		name == utils.MessageRelayerApp ||
 		name == utils.RollupRelayerApp) {
-		t.Errorf(fmt.Sprintf("Don't support the mock app, name: %s", name))
+		t.Errorf("Don't support the mock app, name: %s", name) // Corrected here
 		return
 	}
 
 	if app, ok := b.mockApps[name]; ok {
-		t.Logf(fmt.Sprintf("%s already exist, free the current and recreate again", string(name)))
+		t.Logf("%s already exist, free the current and recreate again", name) // Corrected for consistency
 		app.WaitExit()
 	}
 	appAPI := cmd.NewCmd(string(name), append(b.args, args...)...)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Corrections:
In the t.Errorf call, I removed the unnecessary fmt.Sprintf since t.Errorf (and t.Logf) can format the string by itself. This simplifies the code and makes it more readable. For consistency in messaging and to demonstrate simplification, I also suggested simplifying the t.Logf call by directly using name instead of converting it to a string and back.

//

// RunApp run rollup-test child process by multi parameters.
func (b *MockApp) RunApp(t *testing.T, name utils.MockAppName, args ...string) {
	if !(name == utils.EventWatcherApp ||
		name == utils.GasOracleApp ||
		name == utils.MessageRelayerApp ||
		name == utils.RollupRelayerApp) {
		t.Errorf("Don't support the mock app, name: %s", name) // Corrected here
		return
	}

	if app, ok := b.mockApps[name]; ok {
		t.Logf("%s already exist, free the current and recreate again", name) // Simplified for consistency
		app.WaitExit()
	}
	appAPI := cmd.NewCmd(string(name), append(b.args, args...)...)
	keyword := fmt.Sprintf("Start %s successfully", string(name)[:len(string(name))-len("-test")])
	appAPI.RunApp(func() bool { return appAPI.WaitResult(t, time.Second*20, keyword) })
	b.mockApps[name] = appAPI
}

- [x] perf: A code change that improves performance
- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [x] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag



### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change

