### PR TITLE
fix(contracts): OZ-L04 Trie Depth Is Not Explicitly Capped

### DIFF
--- a/contracts/integration-test/ZkTrieVerifier.spec.ts
+++ b/contracts/integration-test/ZkTrieVerifier.spec.ts
@@ -308,6 +308,28 @@ describe("ZkTrieVerifier", async () => {
     });
   }
 
+  it("should revert, when InvalidNodeDepth", async () => {
+    const test = testcases[0];
+    {
+      const proof = concat([
+        `0xfa`,
+        ...test.accountProof,
+        `0x${test.storageProof.length.toString(16).padStart(2, "0")}`,
+        ...test.storageProof,
+      ]);
+      await expect(verifier.verifyZkTrieProof(test.account, test.storage, proof)).to.revertedWith("InvalidNodeDepth");
+    }
+    {
+      const proof = concat([
+        `0x${test.accountProof.length.toString(16).padStart(2, "0")}`,
+        ...test.accountProof,
+        `0xfa`,
+        ...test.storageProof,
+      ]);
+      await expect(verifier.verifyZkTrieProof(test.account, test.storage, proof)).to.revertedWith("InvalidNodeDepth");
+    }
+  });
+
   it("should revert, when InvalidBranchNodeType", async () => {
     const test = testcases[0];
     for (const i of [0, 1, test.accountProof.length - 3]) {

--- a/contracts/src/libraries/verifier/ZkTrieVerifier.sol
+++ b/contracts/src/libraries/verifier/ZkTrieVerifier.sol
@@ -79,6 +79,7 @@ library ZkTrieVerifier {
 
                 // the first byte is the number of nodes + 1
                 let nodes := sub(byte(0, calldataload(ptr)), 1)
+                require(lt(nodes, 249), "InvalidNodeDepth")
                 ptr := add(ptr, 1)
 
                 // treat the leaf node with different logic


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fix the following issue reported by Openzepplin: https://defender.openzeppelin.com/v2/#/audit/bca59bc7-0ff8-49a2-bcea-09f7cc7a82b8/issues/L-04

> By using the Poseidon Hash, the node uses a [maximum depth of 248 levels](https://docs.scroll.io/en/technology/sequencer/zktrie/#tree-construction). However, the `ZkTrieVerifier` library does not impose a limit on the [first byte](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L81) that represents the length added to the proofs, making it possible to pass proofs with a length that exceeds the limit and continue with the operation. Even though it is challenging to craft a proof that would allow a user to pass the validations performed when constructing the leaf hash, not asserting the length exposes some un-mitigated attack surface which could be targeted by a malicious user in a different attack.
>
> Consider asserting that the maximum depth is not exceeded by the crafted proof.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
