### PR TITLE
fix(contracts): OZ-N01 Inconsistent Naming Convention

### DIFF
--- a/contracts/src/libraries/verifier/ZkTrieVerifier.sol
+++ b/contracts/src/libraries/verifier/ZkTrieVerifier.sol
@@ -56,7 +56,7 @@ library ZkTrieVerifier {
                 }
             }
             // compute poseidon hash of two uint256
-            function poseidon_hash(hasher, v0, v1, domain) -> r {
+            function poseidonHash(hasher, v0, v1, domain) -> r {
                 let x := mload(0x40)
                 // keccack256("poseidon(uint256[2],uint256)")
                 mstore(x, 0xa717016c00000000000000000000000000000000000000000000000000000000)
@@ -68,8 +68,8 @@ library ZkTrieVerifier {
                 r := mload(0x20)
             }
             // compute poseidon hash of 1 uint256
-            function hash_uint256(hasher, v) -> r {
-                r := poseidon_hash(hasher, shr(128, v), and(v, 0xffffffffffffffffffffffffffffffff), 512)
+            function hashUint256(hasher, v) -> r {
+                r := poseidonHash(hasher, shr(128, v), and(v, 0xffffffffffffffffffffffffffffffff), 512)
             }
 
             // traverses the tree from the root to the node before the leaf.
@@ -98,7 +98,7 @@ library ZkTrieVerifier {
                     ptr := add(ptr, 0x20)
                     let childHashR := calldataload(ptr)
                     ptr := add(ptr, 0x20)
-                    let hash := poseidon_hash(hasher, childHashL, childHashR, nodeType)
+                    let hash := poseidonHash(hasher, childHashL, childHashR, nodeType)
 
                     // first item is considered the root node.
                     // Otherwise verifies that the hash of the current node
@@ -139,7 +139,7 @@ library ZkTrieVerifier {
                 ptr := _ptr
 
                 let leafHash
-                let key := hash_uint256(hasher, shl(96, _account))
+                let key := hashUint256(hasher, shl(96, _account))
 
                 // `stateRoot` is a return value and must be checked by the caller
                 ptr, _stateRoot, leafHash := walkTree(hasher, key, ptr)
@@ -158,18 +158,18 @@ library ZkTrieVerifier {
                     // [nonce||codesize||0, balance, storage_root, keccak codehash, poseidon codehash]
                     mstore(0x00, calldataload(ptr))
                     ptr := add(ptr, 0x20) // skip nonce||codesize||0
-                    mstore(0x00, poseidon_hash(hasher, mload(0x00), calldataload(ptr), 1280))
+                    mstore(0x00, poseidonHash(hasher, mload(0x00), calldataload(ptr), 1280))
                     ptr := add(ptr, 0x20) // skip balance
                     storageRootHash := calldataload(ptr)
                     ptr := add(ptr, 0x20) // skip StorageRoot
-                    let tmpHash := hash_uint256(hasher, calldataload(ptr))
+                    let tmpHash := hashUint256(hasher, calldataload(ptr))
                     ptr := add(ptr, 0x20) // skip KeccakCodeHash
-                    tmpHash := poseidon_hash(hasher, storageRootHash, tmpHash, 1280)
-                    tmpHash := poseidon_hash(hasher, mload(0x00), tmpHash, 1280)
-                    tmpHash := poseidon_hash(hasher, tmpHash, calldataload(ptr), 1280)
+                    tmpHash := poseidonHash(hasher, storageRootHash, tmpHash, 1280)
+                    tmpHash := poseidonHash(hasher, mload(0x00), tmpHash, 1280)
+                    tmpHash := poseidonHash(hasher, tmpHash, calldataload(ptr), 1280)
                     ptr := add(ptr, 0x20) // skip PoseidonCodeHash
 
-                    tmpHash := poseidon_hash(hasher, key, tmpHash, 4)
+                    tmpHash := poseidonHash(hasher, key, tmpHash, 4)
                     require(eq(leafHash, tmpHash), "InvalidAccountLeafNodeHash")
 
                     require(eq(0x20, byte(0, calldataload(ptr))), "InvalidAccountKeyPreimageLength")
@@ -192,7 +192,7 @@ library ZkTrieVerifier {
                 ptr := _ptr
 
                 let leafHash
-                let key := hash_uint256(hasher, _storageKey)
+                let key := hashUint256(hasher, _storageKey)
                 let rootHash
                 ptr, rootHash, leafHash := walkTree(hasher, key, ptr)
 
@@ -220,8 +220,8 @@ library ZkTrieVerifier {
 
                     // compute leaf node hash and compare, details can be found in
                     // https://github.com/scroll-tech/mpt-circuit/blob/v0.7/spec/mpt-proof.md#storage-segmenttypes
-                    mstore(0x00, hash_uint256(hasher, _storageValue))
-                    mstore(0x00, poseidon_hash(hasher, key, mload(0x00), 4))
+                    mstore(0x00, hashUint256(hasher, _storageValue))
+                    mstore(0x00, poseidonHash(hasher, key, mload(0x00), 4))
                     require(eq(leafHash, mload(0x00)), "InvalidStorageLeafNodeHash")
 
                     require(eq(0x20, byte(0, calldataload(ptr))), "InvalidStorageKeyPreimageLength")


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fix the following issue reported by Openzepplin: https://defender.openzeppelin.com/v2/#/audit/bca59bc7-0ff8-49a2-bcea-09f7cc7a82b8/issues/N-01

> The `ZkTrieVerifier` library uses two naming conventions for the functions' names. In particular, functions associated with the hashing operation ([`poseidon_hash` and the `hash_uint256` functions](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L59-L73)) are written in snake case, whereas other functions such as the [`walkTree` function](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L77) are written in camel case.
>
> Consider using a consistent naming style throughout the codebase.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
