### PR TITLE
fix(contracts): OZ-N02 Inconsistent Integer Base in Inline Assembly

### DIFF
--- a/contracts/src/libraries/verifier/ZkTrieVerifier.sol
+++ b/contracts/src/libraries/verifier/ZkTrieVerifier.sol
@@ -79,7 +79,7 @@ library ZkTrieVerifier {
 
                 // the first byte is the number of nodes + 1
                 let nodes := sub(byte(0, calldataload(ptr)), 1)
-                ptr := add(ptr, 1)
+                ptr := add(ptr, 0x01)
 
                 // treat the leaf node with different logic
                 for {
@@ -91,7 +91,7 @@ library ZkTrieVerifier {
                     let nodeType := byte(0, calldataload(ptr))
                     // 6 <= nodeType && nodeType < 10
                     require(lt(sub(nodeType, 6), 4), "InvalidBranchNodeType")
-                    ptr := add(ptr, 1)
+                    ptr := add(ptr, 0x01)
 
                     // load left/right child hash
                     let childHashL := calldataload(ptr)


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fix the following issue reported by Openzepplin: https://defender.openzeppelin.com/v2/#/audit/bca59bc7-0ff8-49a2-bcea-09f7cc7a82b8/issues/N-02

> The `ZkTrieVerifier` library makes use of inline assembly for multiple features. When performing these calculations, the decimal and hexadecimal integer bases are used interchangeably. For instance, [`1`](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L82) and [`0x1`](https://github.com/scroll-tech/scroll/blob/c68f4283b15e9816427caedf372ed2daac7f2e66/contracts/src/libraries/verifier/ZkTrieVerifier.sol#L150) are used to move the memory pointer.
>
> Consider sticking to one integer base for memory pointer movements and any other operations to improve the readability of the codebase and prevent calculation errors.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
