### PR TITLE
fix(contracts): allow setting ETH/token limit to zero

### DIFF
--- a/contracts/src/rate-limiter/ETHRateLimiter.sol
+++ b/contracts/src/rate-limiter/ETHRateLimiter.sol
@@ -110,10 +110,6 @@ contract ETHRateLimiter is Ownable, IETHRateLimiter {
     /// @dev Internal function to update the total token amount limit.
     /// @param _newTotalLimit The new total limit.
     function _updateTotalLimit(uint104 _newTotalLimit) private {
-        if (_newTotalLimit == 0) {
-            revert TotalLimitIsZero();
-        }
-
         uint256 _oldTotalLimit = currentPeriod.limit;
         currentPeriod.limit = _newTotalLimit;
 

--- a/contracts/src/rate-limiter/IETHRateLimiter.sol
+++ b/contracts/src/rate-limiter/IETHRateLimiter.sol
@@ -19,9 +19,6 @@ interface IETHRateLimiter {
     /// @dev Thrown when the `periodDuration` is initialized to zero.
     error PeriodIsZero();
 
-    /// @dev Thrown when the `totalAmount` is initialized to zero.
-    error TotalLimitIsZero();
-
     /// @dev Thrown when an amount breaches the total limit in the period.
     error ExceedTotalLimit();
 

--- a/contracts/src/rate-limiter/ITokenRateLimiter.sol
+++ b/contracts/src/rate-limiter/ITokenRateLimiter.sol
@@ -19,10 +19,6 @@ interface ITokenRateLimiter {
     /// @dev Thrown when the `periodDuration` is initialized to zero.
     error PeriodIsZero();
 
-    /// @dev Thrown when the `totalAmount` is initialized to zero.
-    /// @param token The address of the token.
-    error TotalLimitIsZero(address token);
-
     /// @dev Thrown when an amount breaches the total limit in the period.
     /// @param token The address of the token.
     error ExceedTotalLimit(address token);

--- a/contracts/src/rate-limiter/TokenRateLimiter.sol
+++ b/contracts/src/rate-limiter/TokenRateLimiter.sol
@@ -77,7 +77,7 @@ contract TokenRateLimiter is AccessControlEnumerable, ITokenRateLimiter {
         } else {
             _currentTotalAmount = _currentPeriod.amount + _amount;
         }
-        if (_currentPeriod.limit != 0 && _currentTotalAmount > _currentPeriod.limit) {
+        if (_currentTotalAmount > _currentPeriod.limit) {
             revert ExceedTotalLimit(_token);
         }
 
@@ -94,10 +94,6 @@ contract TokenRateLimiter is AccessControlEnumerable, ITokenRateLimiter {
     /// @notice Update the total token amount limit.
     /// @param _newTotalLimit The new total limit.
     function updateTotalLimit(address _token, uint104 _newTotalLimit) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (_newTotalLimit == 0) {
-            revert TotalLimitIsZero(_token);
-        }
-
         uint256 _oldTotalLimit = currentPeriod[_token].limit;
         currentPeriod[_token].limit = _newTotalLimit;
 

--- a/contracts/src/test/ETHRateLimiter.t.sol
+++ b/contracts/src/test/ETHRateLimiter.t.sol
@@ -18,17 +18,11 @@ contract ETHRateLimiterTest is DSTestPlus {
     }
 
     function testUpdateTotalLimit(uint104 _newTotalLimit) external {
-        hevm.assume(_newTotalLimit > 0);
-
         // not owner, revert
         hevm.startPrank(address(1));
         hevm.expectRevert("Ownable: caller is not the owner");
         limiter.updateTotalLimit(_newTotalLimit);
         hevm.stopPrank();
-
-        // zero revert
-        hevm.expectRevert(IETHRateLimiter.TotalLimitIsZero.selector);
-        limiter.updateTotalLimit(0);
 
         // success
         hevm.expectEmit(false, false, false, true);

--- a/contracts/src/test/TokenRateLimiter.t.sol
+++ b/contracts/src/test/TokenRateLimiter.t.sol
@@ -18,8 +18,6 @@ contract TokenRateLimiterTest is DSTestPlus {
     }
 
     function testUpdateTotalLimit(address _token, uint104 _newTotalLimit) external {
-        hevm.assume(_newTotalLimit > 0);
-
         // not admin, revert
         hevm.startPrank(address(1));
         hevm.expectRevert(
@@ -27,10 +25,6 @@ contract TokenRateLimiterTest is DSTestPlus {
         );
         limiter.updateTotalLimit(_token, _newTotalLimit);
         hevm.stopPrank();
-
-        // zero revert
-        hevm.expectRevert(abi.encodeWithSelector(ITokenRateLimiter.TotalLimitIsZero.selector, _token));
-        limiter.updateTotalLimit(_token, 0);
 
         // success
         hevm.expectEmit(true, false, false, true);


### PR DESCRIPTION
Previously, the updateLimit method in Ratelimiter enforced that the new token limit cannot be zero. However, there are scenarios where the admin may need to temporarily halt the process by setting the limit to zero. This commit modifies the updateLimit method to allow setting the token limit to zero when needed.