### PR TITLE
fix: disable test from LidoGatewayIntegration.t.sol

### DIFF
--- a/contracts/src/test/integration/LidoGatewayIntegration.t.sol
+++ b/contracts/src/test/integration/LidoGatewayIntegration.t.sol
@@ -56,11 +56,11 @@ contract LidoGatewayIntegrationTest is GatewayIntegrationBase {
         L2LidoGateway(L2_LIDO_GATEWAY).initializeV2(address(0), address(0), address(0), address(0));
     }
 
-    function testWithoutRouter() public {
+    function testWithoutRouter() private {
         depositAndWithdraw(false);
     }
 
-    function testWithRouter() public {
+    function testWithRouter() private {
         depositAndWithdraw(true);
     }
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

Since we already upgrade lido gateway in mainnet, the tests will fail. We should disable the test for now.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
