### PR TITLE
fix(codecv1): out of bound when keccak256 hash's pointBigInt.Bytes() length is less than 32 bytes

### DIFF
--- a/common/types/encoding/codecv1/codecv1.go
+++ b/common/types/encoding/codecv1/codecv1.go
@@ -292,9 +292,6 @@ func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Poi
 	// 1 hash for metadata and 1 for each chunk
 	challengePreimage := make([]byte, (1+MaxNumChunks)*32)
 
-	// the challenge point z
-	var z kzg4844.Point
-
 	// the chunk data hash used for calculating the challenge preimage
 	var chunkDataHash common.Hash
 
@@ -348,9 +345,14 @@ func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Poi
 	}
 
 	// compute z = challenge_digest % BLS_MODULUS
-	challengeDigest := crypto.Keccak256Hash(challengePreimage[:])
-	point := new(big.Int).Mod(new(big.Int).SetBytes(challengeDigest[:]), BLSModulus)
-	copy(z[:], point.Bytes()[0:32])
+	challengeDigest := crypto.Keccak256Hash(challengePreimage)
+	pointBigInt := new(big.Int).Mod(new(big.Int).SetBytes(challengeDigest[:]), BLSModulus)
+	pointBytes := pointBigInt.Bytes()
+
+	// the challenge point z
+	var z kzg4844.Point
+	start := 32 - len(pointBytes)
+	copy(z[start:], pointBytes)
 
 	return blob, &z, nil
 }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.78"
+var tag = "v4.3.79"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Related error logs during testing:
```
2024-04-01 03:08:40 panic: runtime error: slice bounds out of range [:32] with capacity 31
2024-04-01 03:08:40 
2024-04-01 03:08:40 goroutine 148 [running]:
2024-04-01 03:08:40 scroll-tech/common/types/encoding/codecv1.constructBlobPayload({0xc00012c3a8, 0x1, 0x1?})
2024-04-01 03:08:40     /src/common/types/encoding/codecv1/codecv1.go:353 +0x611
2024-04-01 03:08:40 scroll-tech/common/types/encoding/codecv1.NewDABatch(0xc0001a7770)
2024-04-01 03:08:40     /src/common/types/encoding/codecv1/codecv1.go:230 +0x10e
2024-04-01 03:08:40 scroll-tech/rollup/internal/utils.GetBatchMetadata(0xc0001a7770, 0x1)
2024-04-01 03:08:40     /src/rollup/internal/utils/utils.go:241 +0xa5
2024-04-01 03:08:40 scroll-tech/rollup/internal/orm.(*Batch).InsertBatch(0xc000402d80, {0x1611710, 0xc000a77310}, 0xc0001a7770, 0xc0005c79a0?, {0xc0010bf9d0, 0x1, 0x0?})
2024-04-01 03:08:40     /src/rollup/internal/orm/batch.go:250 +0x2f8
2024-04-01 03:08:40 scroll-tech/rollup/internal/controller/watcher.(*BatchProposer).updateDBBatchInfo.func1(0xc000a34930)
2024-04-01 03:08:40     /src/rollup/internal/controller/watcher/batch_proposer.go:136 +0x71
2024-04-01 03:08:40 gorm.io/gorm.(*DB).Transaction(0xc000a94e40, 0xc000f014c0, {0x0, 0x0, 0x0})
2024-04-01 03:08:40     /go/pkg/mod/gorm.io/gorm@v1.25.5/finisher_api.go:647 +0x28b
2024-04-01 03:08:40 scroll-tech/rollup/internal/controller/watcher.(*BatchProposer).updateDBBatchInfo(0xc00055c360, 0xc0001a7770, 0x1)
2024-04-01 03:08:40     /src/rollup/internal/controller/watcher/batch_proposer.go:135 +0xad
2024-04-01 03:08:40 scroll-tech/rollup/internal/controller/watcher.(*BatchProposer).proposeBatch(0xc00055c360)
2024-04-01 03:08:40     /src/rollup/internal/controller/watcher/batch_proposer.go:261 +0xc46
2024-04-01 03:08:40 scroll-tech/rollup/internal/controller/watcher.(*BatchProposer).TryProposeBatch(0xc00055c360)
2024-04-01 03:08:40     /src/rollup/internal/controller/watcher/batch_proposer.go:127 +0x3e
2024-04-01 03:08:40 scroll-tech/common/utils.Loop({0x1611710, 0xc000a77310}, 0x0?, 0xc0001aaab0)
2024-04-01 03:08:40     /src/common/utils/utils.go:52 +0x7c
2024-04-01 03:08:40 created by scroll-tech/rollup/cmd/rollup_relayer/app.action
2024-04-01 03:08:40     /src/rollup/cmd/rollup_relayer/app/app.go:111 +0xc0a
```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
