### PR TITLE
feat(coordinator): optimize get_task sql

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.82"
+var tag = "v4.3.83"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.80"
+var tag = "v4.3.81"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -73,22 +73,16 @@ func (*Batch) TableName() string {
 // GetUnassignedBatch retrieves unassigned batch based on the specified limit.
 // The returned batch are sorted in ascending order by their index.
 func (o *Batch) GetUnassignedBatch(ctx context.Context, startChunkIndex, endChunkIndex uint64, maxActiveAttempts, maxTotalAttempts uint8) (*Batch, error) {
-	db := o.db.WithContext(ctx)
-	db = db.Where("proving_status = ?", int(types.ProvingTaskUnassigned))
-	db = db.Where("total_attempts < ?", maxTotalAttempts)
-	db = db.Where("active_attempts < ?", maxActiveAttempts)
-	db = db.Where("chunk_proofs_status = ?", int(types.ChunkProofsStatusReady))
-	db = db.Where("start_chunk_index >= ?", startChunkIndex)
-	db = db.Where("end_chunk_index < ?", endChunkIndex)
-
 	var batch Batch
-	err := db.First(&batch).Error
-	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, nil
-	}
-
+	db := o.db.WithContext(ctx)
+	sql := fmt.Sprintf("SELECT * FROM batch WHERE proving_status = %d AND total_attempts < %d AND active_attempts < %d AND chunk_proofs_status = %d AND start_chunk_index >= %d AND end_chunk_index < %d AND batch.deleted_at IS NULL ORDER BY batch.index LIMIT 1;",
+		int(types.ProvingTaskUnassigned), maxTotalAttempts, maxActiveAttempts, int(types.ChunkProofsStatusReady), startChunkIndex, endChunkIndex)
+	err := db.Raw(sql).Scan(&batch).Error
 	if err != nil {
-		return nil, fmt.Errorf("Batch.GetUnassignedBatches error: %w", err)
+		return nil, fmt.Errorf("Batch.GetUnassignedBatch error: %w", err)
+	}
+	if batch.Hash == "" {
+		return nil, nil
 	}
 	return &batch, nil
 }
@@ -96,22 +90,16 @@ func (o *Batch) GetUnassignedBatch(ctx context.Context, startChunkIndex, endChun
 // GetAssignedBatch retrieves assigned batch based on the specified limit.
 // The returned batch are sorted in ascending order by their index.
 func (o *Batch) GetAssignedBatch(ctx context.Context, startChunkIndex, endChunkIndex uint64, maxActiveAttempts, maxTotalAttempts uint8) (*Batch, error) {
-	db := o.db.WithContext(ctx)
-	db = db.Where("proving_status = ?", int(types.ProvingTaskAssigned))
-	db = db.Where("total_attempts < ?", maxTotalAttempts)
-	db = db.Where("active_attempts < ?", maxActiveAttempts)
-	db = db.Where("chunk_proofs_status = ?", int(types.ChunkProofsStatusReady))
-	db = db.Where("start_chunk_index >= ?", startChunkIndex)
-	db = db.Where("end_chunk_index < ?", endChunkIndex)
-
 	var batch Batch
-	err := db.First(&batch).Error
-	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, nil
-	}
-
+	db := o.db.WithContext(ctx)
+	sql := fmt.Sprintf("SELECT * FROM batch WHERE proving_status = %d AND total_attempts < %d AND active_attempts < %d AND chunk_proofs_status = %d AND start_chunk_index >= %d AND end_chunk_index < %d AND batch.deleted_at IS NULL ORDER BY batch.index LIMIT 1;",
+		int(types.ProvingTaskAssigned), maxTotalAttempts, maxActiveAttempts, int(types.ChunkProofsStatusReady), startChunkIndex, endChunkIndex)
+	err := db.Raw(sql).Scan(&batch).Error
 	if err != nil {
-		return nil, fmt.Errorf("Batch.GetAssignedBatches error: %w", err)
+		return nil, fmt.Errorf("Batch.GetAssignedBatch error: %w", err)
+	}
+	if batch.Hash == "" {
+		return nil, nil
 	}
 	return &batch, nil
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*
Currently days, the mainnet-rollup rds’s cpu && load alert occasionally

<img width="843" alt="image" src="https://github.com/scroll-tech/scroll/assets/6947653/8200a32a-5393-4926-8907-eae837402514">

The detail refers https://www.notion.so/scrollzkp/e62383d15b904143be67c80d056210f4?v=dfd060b5777a4321bf99ac02c7e6277a&p=518b34ae1cfa48a28fa2cc2d88152e38&pm=s


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes
