### PR TITLE
test: add test case for initializeV2 function

### DIFF
--- a/contracts/src/test/L1MessageQueueWithGasPriceOracle.t.sol
+++ b/contracts/src/test/L1MessageQueueWithGasPriceOracle.t.sol
@@ -97,4 +97,9 @@ contract L1MessageQueueWithGasPriceOracleTest is ScrollTestBase {
     function testCalculateIntrinsicGasFee(bytes memory data) external {
         assertEq(queue.calculateIntrinsicGasFee(data), 21000 + data.length * 16);
     }
+
+    function testInitializeV2() external {
+        // Call initializeV2 again, should not revert
+        queue.initializeV2();
+    }
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR addresses the lack of test coverage for the `initializeV2` function in the `L1MessageQueueWithGasPriceOracle` contract. It adds a new test case `testInitializeV2` to ensure that the `initializeV2` function can be called without reverting.

The purpose of this change is to improve the test coverage and ensure that the `initializeV2` function behaves as expected. By adding this test case, we can catch any potential issues or regressions related to the `initializeV2` function during future development or refactoring.

To achieve this, a new test function `testInitializeV2` has been added to the `L1MessageQueueWithGasPriceOracleTest` contract. This function simply calls the `initializeV2` function and checks that it does not revert. By explicitly testing this function, we can ensure that it remains functional and does not introduce any unintended behavior.

### PR title

test: add test case for initializeV2 function

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes