### PR TITLE
refactor: separate test cases for RPC endpoint tests

### DIFF
--- a/common/utils/rpc_test.go
+++ b/common/utils/rpc_test.go
@@ -1,78 +1,92 @@
 package utils
 
 import (
-	"compress/flate"
-	"context"
-	"testing"
+    "compress/flate"
+    "context"
+    "testing"
 
-	"github.com/scroll-tech/go-ethereum/rpc"
-	"github.com/stretchr/testify/assert"
+    "github.com/scroll-tech/go-ethereum/rpc"
+    "github.com/stretchr/testify/assert"
 )
 
 type testService struct{}
 
 type echoArgs struct {
-	S string
+    S string
 }
 
 type echoResult struct {
-	Name string
-	ID   int
-	Args *echoArgs
+    Name string
+    ID   int
+    Args *echoArgs
 }
 
 func (s *testService) NoArgsRets() {}
 
 func (s *testService) Echo(str string, i int, args *echoArgs) echoResult {
-	return echoResult{str, i, args}
+    return echoResult{str, i, args}
 }
 
 func TestStartHTTPEndpoint(t *testing.T) {
-	endpoint := "localhost:18080"
-	handler, _, err := StartHTTPEndpoint(endpoint, []rpc.API{
-		{
-			Public:    true,
-			Namespace: "test",
-			Service:   new(testService),
-		},
-	})
-	assert.NoError(t, err)
-	defer handler.Shutdown(context.Background())
+    endpoint := "localhost:18080"
+    handler, _, err := StartHTTPEndpoint(endpoint, []rpc.API{
+        {
+            Public:     true,
+            Namespace:  "test",
+            Service:    new(testService),
+        },
+    })
+    assert.NoError(t, err)
+    defer handler.Shutdown(context.Background())
 
-	client, err := rpc.Dial("http://" + endpoint)
-	assert.NoError(t, err)
+    t.Run("StartEndpoint", func(t *testing.T) {
+        assert.NotNil(t, handler)
+    })
 
-	assert.NoError(t, client.Call(nil, "test_noArgsRets"))
+    client, err := rpc.Dial("http://" + endpoint)
+    assert.NoError(t, err)
+    defer client.Close()
 
-	result := echoResult{}
-	assert.NoError(t, client.Call(&result, "test_echo", "test", 0, &echoArgs{S: "test"}))
-	assert.Equal(t, 0, result.ID)
-	assert.Equal(t, "test", result.Name)
+    t.Run("NoArgsRets", func(t *testing.T) {
+        assert.NoError(t, client.Call(nil, "test_noArgsRets"))
+    })
 
-	defer client.Close()
+    t.Run("Echo", func(t *testing.T) {
+        result := echoResult{}
+        assert.NoError(t, client.Call(&result, "test_echo", "test", 0, &echoArgs{S: "test"}))
+        assert.Equal(t, 0, result.ID)
+        assert.Equal(t, "test", result.Name)
+    })
 }
 
 func TestStartWSEndpoint(t *testing.T) {
-	endpoint := "localhost:18081"
-	handler, _, err := StartWSEndpoint(endpoint, []rpc.API{
-		{
-			Public:    true,
-			Namespace: "test",
-			Service:   new(testService),
-		},
-	}, flate.NoCompression)
-	assert.NoError(t, err)
-	defer handler.Shutdown(context.Background())
+    endpoint := "localhost:18081"
+    handler, _, err := StartWSEndpoint(endpoint, []rpc.API{
+        {
+            Public:     true,
+            Namespace:  "test",
+            Service:    new(testService),
+        },
+    }, flate.NoCompression)
+    assert.NoError(t, err)
+    defer handler.Shutdown(context.Background())
 
-	client, err := rpc.Dial("ws://" + endpoint)
-	assert.NoError(t, err)
+    t.Run("StartEndpoint", func(t *testing.T) {
+        assert.NotNil(t, handler)
+    })
 
-	assert.NoError(t, client.Call(nil, "test_noArgsRets"))
+    client, err := rpc.Dial("ws://" + endpoint)
+    assert.NoError(t, err)
+    defer client.Close()
 
-	result := echoResult{}
-	assert.NoError(t, client.Call(&result, "test_echo", "test", 0, &echoArgs{S: "test"}))
-	assert.Equal(t, 0, result.ID)
-	assert.Equal(t, "test", result.Name)
+    t.Run("NoArgsRets", func(t *testing.T) {
+        assert.NoError(t, client.Call(nil, "test_noArgsRets"))
+    })
 
-	defer client.Close()
+    t.Run("Echo", func(t *testing.T) {
+        result := echoResult{}
+        assert.NoError(t, client.Call(&result, "test_echo", "test", 0, &echoArgs{S: "test"}))
+        assert.Equal(t, 0, result.ID)
+        assert.Equal(t, "test", result.Name)
+    })
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

_This PR refactors the existing test suite for the RPC endpoint code by separating the test cases into smaller, more focused tests. The changes aim to improve the readability, maintainability, and clarity of the tests.

What does this PR do?
- Separates the test cases for `StartHTTPEndpoint` and `StartWSEndpoint` functions into individual test cases using the `t.Run` function.
- Adds descriptive names for each test case to convey what aspect of the function is being tested.

Why does it do it?
- The previous implementation had multiple test cases combined within a single test function, making it harder to understand and maintain the tests.
- Separating the test cases into smaller, focused tests improves readability and makes it easier to add or modify test cases in the future.

How does it do it?
- By utilizing the `t.Run` function, the code creates individual test cases within the main test function.
- Each test case is named descriptively to convey its purpose (e.g., "StartEndpoint", "NoArgsRets", "Echo").
- The assertions and test logic for each test case are contained within their respective `t.Run` blocks._

### PR title

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Deployment tag versioning

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag

### Breaking change label

- [x] No, this PR is not a breaking change