### PR TITLE
ci: add support for arm64 on event-watcher images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,7 @@ jobs:
           aws --region ${{ env.AWS_REGION }} ecr describe-repositories --repository-names ${{ env.REPOSITORY }} && : || aws --region ${{ env.AWS_REGION }} ecr create-repository --repository-name ${{ env.REPOSITORY }}
       - name: Build and push
         uses: docker/build-push-action@v3
+        platforms: linux/amd64,linux/arm64
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: event-watcher


### PR DESCRIPTION
### add support for arm64 on event-watcher images

Change the workflow to create event-watcher image to support arm64 architecture
