### PR TITLE
fix(rollup-relayer): tweak logs

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.92"
+var tag = "v4.3.93"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -578,7 +578,7 @@ func (r *Layer2Relayer) finalizeBatch(dbBatch *orm.Batch, withProof bool) error 
 		return err
 	}
 
-	log.Info("finalizeBatch in layer1", "with proof", withProof, "index", dbBatch.Index, "batch hash", dbBatch.Hash, "tx hash", txHash)
+	log.Info("finalizeBatch in layer1", "with proof", withProof, "index", dbBatch.Index, "batch hash", dbBatch.Hash, "tx hash", txHash.String())
 
 	// record and sync with db, @todo handle db error
 	if err := r.batchOrm.UpdateFinalizeTxHashAndRollupStatus(r.ctx, dbBatch.Hash, txHash.String(), types.RollupFinalizing); err != nil {


### PR DESCRIPTION
### Purpose or design rationale of this PR

To print the full finalization transaction hash. Current logs: `tx hash=0a197f..cc2a03`.
```
INFO [04-14|14:54:20.456|scroll-tech/rollup/internal/controller/sender/estimategas.go:144] gas                                      senderName=finalize_sender senderService=l2_relayer gasLimitWithAccessList=111,948   gasLimitWithoutAccessList=114,810   accessList="&[{Address:0x3d7C30ad0AeE6Ba71a7B37E57fc27F82E67003b8 StorageKeys:[]} {Address:0xE644d72dB4a929b5bf76B06eE7d8a30F2E78B83a StorageKeys:[]} {Address:0xF0B2293F5D834eAe920c6974D50957A1732de763 StorageKeys:[0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc 0x000000000000000000000000000000000000000000000000000000000000006a 0x3b551e8cc07a0fd564046d3100376a171a004874208aa2b1f72b5375d598daea]}]"
INFO [04-14|14:54:20.558|scroll-tech/rollup/internal/controller/relayer/l2_relayer.go:581] finalizeBatch in layer1                  with proof=false index=69630 batch hash=0xb7ccab645e949e2ae4c790ac052555115380c4572553138fe25ff98ed5dafc99 tx hash=0a197f..cc2a03
```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
