### PR TITLE
perf(db): add indexes for table prover_task, columns respectively: task_id, created_at

### DIFF
--- a/database/migrate/migrate_test.go
+++ b/database/migrate/migrate_test.go
@@ -59,20 +59,20 @@ func testResetDB(t *testing.T) {
 	cur, err := Current(pgDB)
 	assert.NoError(t, err)
 	// total number of tables.
-	assert.Equal(t, int64(17), cur)
+	assert.Equal(t, int64(18), cur)
 }
 
 func testMigrate(t *testing.T) {
 	assert.NoError(t, Migrate(pgDB))
 	cur, err := Current(pgDB)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(17), cur)
+	assert.Equal(t, int64(18), cur)
 }
 
 func testRollback(t *testing.T) {
 	version, err := Current(pgDB)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(17), version)
+	assert.Equal(t, int64(18), version)
 
 	assert.NoError(t, Rollback(pgDB, nil))
 

--- a/database/migrate/migrations/00018_add_index_taskid_createdat_prover_task.sql
+++ b/database/migrate/migrations/00018_add_index_taskid_createdat_prover_task.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+
+create index if not exists idx_prover_task_created_at on prover_task(created_at) where deleted_at IS NULL;
+
+create index if not exists idx_prover_task_task_id on prover_task(task_id) where deleted_at IS NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+drop index if exists idx_prover_task_created_at;
+
+drop index if exists idx_prover_task_task_id;
+
+
+-- +goose StatementEnd


### PR DESCRIPTION
### Purpose or design rationale of this PR

Add two index for table prover_task
- the `task_id` index is used to find chunk or batch's related prover_task more effiencint
- the `created_at` index is used for calculating statistic data(such as total proved tasks) partitionally ( split by created_at range)


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
