### PR TITLE
build(ci): make all intermediate images compatible with multi platforms

### DIFF
--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -50,7 +50,6 @@ jobs:
           context: .
           push: true
           file: build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
-          platforms: linux/amd64,linux/arm64
           tags: scrolltech/cuda-go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
           build-args: |
             CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
@@ -79,7 +78,7 @@ jobs:
           push: true
           file: build/dockerfiles/intermediate/go-rust-builder.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: scrolltech/go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/go-rust-builder:go-${{ github.event.inputs.GO_VERSION }}-rust-${{ github.event.inputs.RUST_VERSION }}
           build-args: |
             GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
             RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
@@ -106,7 +105,7 @@ jobs:
           push: true
           file: build/dockerfiles/intermediate/go-alpine-builder.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: scrolltech/go-alpine-builder:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/go-alpine-builder:${{ github.event.inputs.GO_VERSION }}
           build-args: |
             GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
             RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
@@ -133,7 +132,7 @@ jobs:
           push: true
           file: build/dockerfiles/intermediate/rust-builder.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: scrolltech/rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/rust-builder:${{ github.event.inputs.RUST_VERSION }}
           build-args: |
             RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
 
@@ -159,7 +158,7 @@ jobs:
           push: true
           file: build/dockerfiles/intermediate/rust-alpine-builder.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: scrolltech/rust-alpine-builder:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/rust-alpine-builder:${{ github.event.inputs.RUST_VERSION }}
           build-args: |
             RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
 
@@ -185,7 +184,7 @@ jobs:
           push: true
           file: build/dockerfiles/intermediate/go-rust-alpine-builder.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: scrolltech/go-rust-alpine-builder:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/go-rust-alpine-builder:go-${{ github.event.inputs.GO_VERSION }}-rust-${{ github.event.inputs.RUST_VERSION }}
           build-args: |
             GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
             RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
@@ -212,7 +211,7 @@ jobs:
           push: true
           file: build/dockerfiles/intermediate/py-runner.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: scrolltech/py-runner:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/py-runner:${{ github.event.inputs.PYTHON_VERSION }}
           build-args: |
             CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
             GO_VERSION: ${{ github.event.inputs.GO_VERSION }}

--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -29,29 +29,192 @@ defaults:
     working-directory: 'build/dockerfiles/intermediate'
 
 jobs:
-  build-and-push:
+  build-and-publish-cuda-go-rust-builder:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    #cuda-go-rust-builder
-    - name: Build image
-      id: build
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        push: true
-        file: build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
-        platforms: linux/amd64,linux/arm64
-        tags: scrolltech/cuda-go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
-        build-args: |
-          CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
-          GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
-          RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/cuda-go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
+            GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+
+  build-and-publish-go-rust-builder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/go-rust-builder.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+
+  build-and-publish-go-alpine-builder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/go-alpine-builder.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/go-alpine-builder:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+
+  build-and-rust-builder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/rust-builder.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+
+  build-and-publish-rust-alpine-builder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/rust-alpine-builder.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/rust-alpine-builder:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+
+  build-and-publish-go-rust-alpine-builder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/go-rust-alpine-builder.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/go-rust-alpine-builder:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+
+  build-and-publish-py-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: build/dockerfiles/intermediate/py-runner.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: scrolltech/py-runner:${{ github.event.inputs.CUDA_VERSION }}
+          build-args: |
+            CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
+            GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+            RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+

--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -50,7 +50,7 @@ jobs:
           context: .
           push: true
           file: build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
-          tags: scrolltech/cuda-go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+          tags: scrolltech/cuda-go-rust-builder:cuda-${{ github.event.inputs.CUDA_VERSION }}-go-${{ github.event.inputs.GO_VERSION }}-rust-${{ github.event.inputs.RUST_VERSION }}
           build-args: |
             CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
             GO_VERSION: ${{ github.event.inputs.GO_VERSION }}

--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -110,7 +110,7 @@ jobs:
             GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
             RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
 
-  build-and-rust-builder:
+  build-and-publish-rust-builder:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -41,19 +41,17 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build
-      run: |
-        make all
-      env:
-        GO_VERSION: ${{ inputs.GO_VERSION }}
-        RUST_VERSION: ${{ inputs.RUST_VERSION }}
-        PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
-        CUDA_VERSION: ${{ inputs.CUDA_VERSION }}
-    - name: Publish
-      run: |
-        make publish
-      env:
-        GO_VERSION: ${{ inputs.GO_VERSION }}
-        RUST_VERSION: ${{ inputs.RUST_VERSION }}
-        PYTHON_VERSION: ${{ inputs.PYTHON_VERSION }}
-        CUDA_VERSION: ${{ inputs.CUDA_VERSION }}
+    #cuda-go-rust-builder
+    - name: Build image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        file: build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
+        platforms: linux/amd64,linux/arm64
+        tags: scrolltech/cuda-go-rust-builder:${{ github.event.inputs.CUDA_VERSION }}
+        build-args: |
+          CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
+          GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+          RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}

--- a/build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install build-essential curl wget git pkg-config --no-install-recomm
 # Install dev-packages
 RUN apt-get install libclang-dev libssl-dev cmake llvm --no-install-recommends -y
 # Install related libs
-RUN apt install libprocps-dev libboost-all-dev libmpfr-dev libgmp-dev --no-install-recommends -y
+RUN apt install libprocps-dev libmpfr-dev libgmp-dev --no-install-recommends -y
 # Clean installed cache
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install build-essential curl wget git pkg-config --no-install-recomm
 # Install dev-packages
 RUN apt-get install libclang-dev libssl-dev cmake llvm --no-install-recommends -y
 # Install related libs
-RUN apt install libprocps-dev libmpfr-dev libgmp-dev --no-install-recommends -y
+RUN apt install libprocps-dev libboost-all-dev libmpfr-dev libgmp-dev --no-install-recommends -y
 # Clean installed cache
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

Purpose of this change is to ensure all intermediate images, except cuda, are compatible with arm64 architecture.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [X] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes
