### PR TITLE
feat(gas-oracle): relay blob base fee after Bernoulli block

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.3.95"
+var tag = "v4.4.0"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/database/migrate/migrate_test.go
+++ b/database/migrate/migrate_test.go
@@ -59,20 +59,20 @@ func testResetDB(t *testing.T) {
 	cur, err := Current(pgDB)
 	assert.NoError(t, err)
 	// total number of tables.
-	assert.Equal(t, int64(18), cur)
+	assert.Equal(t, int64(19), cur)
 }
 
 func testMigrate(t *testing.T) {
 	assert.NoError(t, Migrate(pgDB))
 	cur, err := Current(pgDB)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(18), cur)
+	assert.Equal(t, int64(19), cur)
 }
 
 func testRollback(t *testing.T) {
 	version, err := Current(pgDB)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(18), version)
+	assert.Equal(t, int64(19), version)
 
 	assert.NoError(t, Rollback(pgDB, nil))
 

--- a/database/migrate/migrations/00019_add_blob_base_fee.sql
+++ b/database/migrate/migrations/00019_add_blob_base_fee.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE l1_block
+ADD COLUMN blob_base_fee BIGINT DEFAULT 0;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE IF EXISTS l1_block
+DROP COLUMN blob_base_fee;
+
+-- +goose StatementEnd

--- a/rollup/cmd/gas_oracle/app/app.go
+++ b/rollup/cmd/gas_oracle/app/app.go
@@ -78,9 +78,15 @@ func action(ctx *cli.Context) error {
 		log.Crit("failed to connect l2 geth", "config file", cfgFile, "error", err)
 	}
 
+	genesisPath := ctx.String(utils.Genesis.Name)
+	genesis, err := utils.ReadGenesis(genesisPath)
+	if err != nil {
+		log.Crit("failed to read genesis", "genesis file", genesisPath, "error", err)
+	}
+
 	l1watcher := watcher.NewL1WatcherClient(ctx.Context, l1client, cfg.L1Config.StartHeight, cfg.L1Config.Confirmations, cfg.L1Config.L1MessageQueueAddress, cfg.L1Config.ScrollChainContractAddress, db, registry)
 
-	l1relayer, err := relayer.NewLayer1Relayer(ctx.Context, db, cfg.L1Config.RelayerConfig, relayer.ServiceTypeL1GasOracle, registry)
+	l1relayer, err := relayer.NewLayer1Relayer(ctx.Context, db, cfg.L1Config.RelayerConfig, genesis.Config, relayer.ServiceTypeL1GasOracle, registry)
 	if err != nil {
 		log.Crit("failed to create new l1 relayer", "config file", cfgFile, "error", err)
 	}

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/accounts/abi"
 	"github.com/scroll-tech/go-ethereum/crypto"
 	"github.com/scroll-tech/go-ethereum/log"
+	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
 
 	"scroll-tech/common/types"
@@ -28,7 +29,8 @@ import (
 type Layer1Relayer struct {
 	ctx context.Context
 
-	cfg *config.RelayerConfig
+	cfg      *config.RelayerConfig
+	chainCfg *params.ChainConfig
 
 	gasOracleSender *sender.Sender
 	l1GasOracleABI  *abi.ABI
@@ -38,11 +40,13 @@ type Layer1Relayer struct {
 	gasPriceDiff uint64
 
 	l1BlockOrm *orm.L1Block
-	metrics    *l1RelayerMetrics
+	l2BlockOrm *orm.L2Block
+
+	metrics *l1RelayerMetrics
 }
 
 // NewLayer1Relayer will return a new instance of Layer1RelayerClient
-func NewLayer1Relayer(ctx context.Context, db *gorm.DB, cfg *config.RelayerConfig, serviceType ServiceType, reg prometheus.Registerer) (*Layer1Relayer, error) {
+func NewLayer1Relayer(ctx context.Context, db *gorm.DB, cfg *config.RelayerConfig, chainCfg *params.ChainConfig, serviceType ServiceType, reg prometheus.Registerer) (*Layer1Relayer, error) {
 	var gasOracleSender *sender.Sender
 	var err error
 
@@ -74,8 +78,10 @@ func NewLayer1Relayer(ctx context.Context, db *gorm.DB, cfg *config.RelayerConfi
 
 	l1Relayer := &Layer1Relayer{
 		cfg:        cfg,
+		chainCfg:   chainCfg,
 		ctx:        ctx,
 		l1BlockOrm: orm.NewL1Block(db),
+		l2BlockOrm: orm.NewL2Block(db),
 
 		gasOracleSender: gasOracleSender,
 		l1GasOracleABI:  bridgeAbi.L1GasPriceOracleABI,
@@ -123,12 +129,27 @@ func (r *Layer1Relayer) ProcessGasPriceOracle() {
 		if r.lastGasPrice > 0 && expectedDelta == 0 {
 			expectedDelta = 1
 		}
-		// last is undefine or (block.BaseFee >= minGasPrice && exceed diff)
-		if r.lastGasPrice == 0 || (block.BaseFee >= r.minGasPrice && (block.BaseFee >= r.lastGasPrice+expectedDelta || block.BaseFee <= r.lastGasPrice-expectedDelta)) {
-			baseFee := big.NewInt(int64(block.BaseFee))
-			data, err := r.l1GasOracleABI.Pack("setL1BaseFee", baseFee)
+
+		latestL2Height, err := r.l2BlockOrm.GetL2BlocksLatestHeight(r.ctx)
+		if err != nil {
+			log.Warn("Failed to fetch latest L2 block height from db", "err", err)
+			return
+		}
+
+		var isBernoulli = r.chainCfg.IsBernoulli(new(big.Int).SetUint64(latestL2Height))
+
+		var baseFee uint64
+		if isBernoulli && block.BlobBaseFee != 0 {
+			baseFee = block.BlobBaseFee
+		} else {
+			baseFee = block.BaseFee
+		}
+
+		// last is undefined or (baseFee >= minGasPrice && exceed diff)
+		if r.lastGasPrice == 0 || (baseFee >= r.minGasPrice && (baseFee >= r.lastGasPrice+expectedDelta || baseFee <= r.lastGasPrice-expectedDelta)) {
+			data, err := r.l1GasOracleABI.Pack("setL1BaseFee", new(big.Int).SetUint64(baseFee))
 			if err != nil {
-				log.Error("Failed to pack setL1BaseFee", "block.Hash", block.Hash, "block.Height", block.Number, "block.BaseFee", block.BaseFee, "err", err)
+				log.Error("Failed to pack setL1BaseFee", "block.Hash", block.Hash, "block.Height", block.Number, "block.BaseFee", baseFee, "isBernoulli", isBernoulli, "err", err)
 				return
 			}
 
@@ -143,9 +164,9 @@ func (r *Layer1Relayer) ProcessGasPriceOracle() {
 				log.Error("UpdateGasOracleStatusAndOracleTxHash failed", "block.Hash", block.Hash, "block.Height", block.Number, "err", err)
 				return
 			}
-			r.lastGasPrice = block.BaseFee
+			r.lastGasPrice = baseFee
 			r.metrics.rollupL1RelayerLastGasPrice.Set(float64(r.lastGasPrice))
-			log.Info("Update l1 base fee", "txHash", hash.String(), "baseFee", baseFee)
+			log.Info("Update l1 base fee", "txHash", hash.String(), "baseFee", baseFee, "isBernoulli", isBernoulli)
 		}
 	}
 }

--- a/rollup/internal/controller/relayer/l1_relayer_test.go
+++ b/rollup/internal/controller/relayer/l1_relayer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
+	"github.com/scroll-tech/go-ethereum/params"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
@@ -35,7 +36,7 @@ func setupL1RelayerDB(t *testing.T) *gorm.DB {
 func testCreateNewL1Relayer(t *testing.T) {
 	db := setupL1RelayerDB(t)
 	defer database.CloseDB(db)
-	relayer, err := NewLayer1Relayer(context.Background(), db, cfg.L2Config.RelayerConfig, ServiceTypeL1GasOracle, nil)
+	relayer, err := NewLayer1Relayer(context.Background(), db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, relayer)
 	defer relayer.StopSenders()
@@ -57,7 +58,7 @@ func testL1RelayerGasOracleConfirm(t *testing.T) {
 	l1Cfg := cfg.L1Config
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, &params.ChainConfig{}, ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	defer l1Relayer.StopSenders()
 
@@ -90,7 +91,7 @@ func testL1RelayerProcessGasPriceOracle(t *testing.T) {
 	l1Cfg := cfg.L1Config
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, &params.ChainConfig{}, ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, l1Relayer)
 	defer l1Relayer.StopSenders()

--- a/rollup/internal/controller/watcher/l1_watcher.go
+++ b/rollup/internal/controller/watcher/l1_watcher.go
@@ -9,6 +9,7 @@ import (
 	geth "github.com/scroll-tech/go-ethereum"
 	"github.com/scroll-tech/go-ethereum/accounts/abi"
 	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto"
 	"github.com/scroll-tech/go-ethereum/ethclient"
@@ -135,10 +136,16 @@ func (w *L1WatcherClient) FetchBlockHeader(blockHeight uint64) error {
 		baseFee = block.BaseFee.Uint64()
 	}
 
+	var blobBaseFee uint64
+	if excess := block.ExcessBlobGas; excess != nil {
+		blobBaseFee = misc.CalcBlobFee(*excess).Uint64()
+	}
+
 	l1Block := orm.L1Block{
 		Number:          blockHeight,
 		Hash:            block.Hash().String(),
 		BaseFee:         baseFee,
+		BlobBaseFee:     blobBaseFee,
 		GasOracleStatus: int16(types.GasOraclePending),
 	}
 

--- a/rollup/internal/orm/l1_block.go
+++ b/rollup/internal/orm/l1_block.go
@@ -15,9 +15,10 @@ type L1Block struct {
 	db *gorm.DB `gorm:"column:-"`
 
 	// block
-	Number  uint64 `json:"number" gorm:"column:number"`
-	Hash    string `json:"hash" gorm:"column:hash"`
-	BaseFee uint64 `json:"base_fee" gorm:"column:base_fee"`
+	Number      uint64 `json:"number" gorm:"column:number"`
+	Hash        string `json:"hash" gorm:"column:hash"`
+	BaseFee     uint64 `json:"base_fee" gorm:"column:base_fee"`
+	BlobBaseFee uint64 `json:"blob_base_fee" gorm:"column:blob_base_fee"`
 
 	// oracle
 	GasOracleStatus int16  `json:"oracle_status" gorm:"column:oracle_status;default:1"`

--- a/rollup/tests/gas_oracle_test.go
+++ b/rollup/tests/gas_oracle_test.go
@@ -28,7 +28,7 @@ func testImportL1GasPrice(t *testing.T) {
 	l1Cfg := rollupApp.Config.L1Config
 
 	// Create L1Relayer
-	l1Relayer, err := relayer.NewLayer1Relayer(context.Background(), db, l1Cfg.RelayerConfig, relayer.ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := relayer.NewLayer1Relayer(context.Background(), db, l1Cfg.RelayerConfig, &params.ChainConfig{}, relayer.ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	defer l1Relayer.StopSenders()
 

--- a/rollup/tests/process_start_test.go
+++ b/rollup/tests/process_start_test.go
@@ -21,7 +21,7 @@ func testProcessStart(t *testing.T) {
 	defer database.CloseDB(db)
 
 	rollupApp.RunApp(t, cutils.EventWatcherApp)
-	rollupApp.RunApp(t, cutils.GasOracleApp)
+	rollupApp.RunApp(t, cutils.GasOracleApp, "--genesis", "../conf/genesis.json")
 	rollupApp.RunApp(t, cutils.RollupRelayerApp, "--genesis", "../conf/genesis.json")
 
 	rollupApp.WaitExit()
@@ -39,7 +39,7 @@ func testProcessStartEnableMetrics(t *testing.T) {
 	port, err = rand.Int(rand.Reader, big.NewInt(10000))
 	assert.NoError(t, err)
 	svrPort = strconv.FormatInt(port.Int64()+20000, 10)
-	rollupApp.RunApp(t, cutils.GasOracleApp, "--metrics", "--metrics.addr", "localhost", "--metrics.port", svrPort)
+	rollupApp.RunApp(t, cutils.GasOracleApp, "--metrics", "--metrics.addr", "localhost", "--metrics.port", svrPort, "--genesis", "../conf/genesis.json")
 
 	port, err = rand.Int(rand.Reader, big.NewInt(10000))
 	assert.NoError(t, err)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Once Bernoulli is activated on L2, we relay L1 `blobBaseFee` (instead of `baseFee`) to `L1GaspriceOracle`.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes
