### PR TITLE
fix(db): change prover_block_list's index on public_key from non-unique to unique

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.0"
+var tag = "v4.4.1"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/database/migrate/migrate_test.go
+++ b/database/migrate/migrate_test.go
@@ -59,20 +59,20 @@ func testResetDB(t *testing.T) {
 	cur, err := Current(pgDB)
 	assert.NoError(t, err)
 	// total number of tables.
-	assert.Equal(t, int64(19), cur)
+	assert.Equal(t, int64(20), cur)
 }
 
 func testMigrate(t *testing.T) {
 	assert.NoError(t, Migrate(pgDB))
 	cur, err := Current(pgDB)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(19), cur)
+	assert.Equal(t, int64(20), cur)
 }
 
 func testRollback(t *testing.T) {
 	version, err := Current(pgDB)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(19), version)
+	assert.Equal(t, int64(20), version)
 
 	assert.NoError(t, Rollback(pgDB, nil))
 

--- a/database/migrate/migrations/00020_alter_publickey_unique_prover_block.sql
+++ b/database/migrate/migrations/00020_alter_publickey_unique_prover_block.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+DROP INDEX if exists idx_prover_block_list_on_public_key;
+
+CREATE UNIQUE INDEX if not exists uniq_prover_block_list_on_public_key ON prover_block_list(public_key) where deleted_at IS NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+CREATE INDEX if not exists idx_prover_block_list_on_public_key ON prover_block_list(public_key);
+
+DROP INDEX if exists uniq_prover_block_list_on_public_key;
+
+-- +goose StatementEnd


### PR DESCRIPTION
### Purpose or design rationale of this PR

Change prover_block_list's index on public_key from non-unique to unique, so the same prover will be added only once.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
