### PR TITLE
chore: correct duplicated words and phrasing issues

### DIFF
--- a/bridge-history-api/README.md
+++ b/bridge-history-api/README.md
@@ -1,6 +1,6 @@
 # bridge-history-api
 
-This directory contains the `bridge-history-api` service that provides REST APIs to query txs interact with Scroll official bridge contracts
+This directory contains the `bridge-history-api` service that provides REST APIs to query txs to interact with Scroll official bridge contracts
 
 ## Instructions
 The bridge-history-api contains three distinct components

--- a/common/version/prover_version.go
+++ b/common/version/prover_version.go
@@ -9,7 +9,7 @@ import (
 
 // CheckScrollProverVersion check the "scroll-prover" version, if it's different from the local one, return false
 func CheckScrollProverVersion(proverVersion string) bool {
-	// note the the version is in fact in the format of "tag-commit-scroll_prover-halo2",
+	// note the version is in fact in the format of "tag-commit-scroll_prover-halo2",
 	// so split-by-'-' length should be 4
 	remote := strings.Split(proverVersion, "-")
 	if len(remote) != 4 {

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -25,7 +25,7 @@ This directory contains the solidity code for Scroll L1 bridge and rollup contra
 │   ├── <a href="./src/libraries/">libraries</a>: Shared contract libraries
 │   ├── <a href="./src/misc/">misc</a>: Miscellaneous contracts
 │   ├── <a href="./src/mocks/">mocks</a>: Mock contracts used in the testing
-│   ├── <a href="./src/rate-limiter/">rate-limiter</a>: Rater limiter contract
+│   ├── <a href="./src/rate-limiter/">rate-limiter</a>: Rate limiter contract
 │   └── <a href="./src/test/">test</a>: Unit tests in solidity
 ├── <a href="./foundry.toml">foundry.toml</a>: Foundry configuration
 ├── <a href="./hardhat.config.ts">hardhat.config.ts</a>: Hardhat configuration
@@ -74,5 +74,5 @@ yarn install
 - Run `yarn prepare` to install the precommit linting hook.
 - Run `forge build` to compile contracts with foundry.
 - Run `npx hardhat compile` to compile with hardhat.
-- Run `forge test -vvv` to run foundry units tests. It will compile all contracts before running the unit tests.
+- Run `forge test -vvv` to run foundry unit tests. It will compile all contracts before running the unit tests.
 - Run `npx hardhat test` to run integration tests. It may not compile all contracts before running, it's better to run `npx hardhat compile` first.

--- a/contracts/src/libraries/codec/BatchHeaderV0Codec.sol
+++ b/contracts/src/libraries/codec/BatchHeaderV0Codec.sol
@@ -79,7 +79,7 @@ library BatchHeaderV0Codec {
 
     /// @notice Get the number of L1 messages popped before this batch.
     /// @param batchPtr The start memory offset of the batch header in memory.
-    /// @return _totalL1MessagePopped The the number of L1 messages popped before this batch.
+    /// @return _totalL1MessagePopped The number of L1 messages popped before this batch.
     function getTotalL1MessagePopped(uint256 batchPtr) internal pure returns (uint256 _totalL1MessagePopped) {
         assembly {
             _totalL1MessagePopped := shr(192, mload(add(batchPtr, 17)))

--- a/contracts/src/libraries/codec/BatchHeaderV1Codec.sol
+++ b/contracts/src/libraries/codec/BatchHeaderV1Codec.sol
@@ -79,7 +79,7 @@ library BatchHeaderV1Codec {
 
     /// @notice Get the number of L1 messages popped before this batch.
     /// @param batchPtr The start memory offset of the batch header in memory.
-    /// @return _totalL1MessagePopped The the number of L1 messages popped before this batch.
+    /// @return _totalL1MessagePopped The number of L1 messages popped before this batch.
     function getTotalL1MessagePopped(uint256 batchPtr) internal pure returns (uint256 _totalL1MessagePopped) {
         assembly {
             _totalL1MessagePopped := shr(192, mload(add(batchPtr, 17)))

--- a/contracts/src/lido/README.md
+++ b/contracts/src/lido/README.md
@@ -98,7 +98,7 @@ According to the Scroll documentation, `L1ScrollMessenger`:
 
 This contract is central in the L2-to-L1 communication process since all messages from L2 that verified by the zkevm proof are executed on behalf of this contract.
 
-In case of a vulnerability in the `L1ScrollMessenger`, which allows the attacker to send arbitrary messages bypassing the the zkevm proof, an attacker can immediately drain tokens from the L1 bridge.
+In case of a vulnerability in the `L1ScrollMessenger`, which allows the attacker to send arbitrary messages bypassing the zkevm proof, an attacker can immediately drain tokens from the L1 bridge.
 
 Additional risk creates the upgradeability of the `L1ScrollMessenger`. Exist a risk of an attack with the replacement of the implementation with some malicious functionality. Such an attack might be reduced to the above vulnerability and steal all locked tokens on the L1 bridge.
 


### PR DESCRIPTION
This PR fixes repeated words and straightens out some of the wording in various documents. The changes should make everything a bit clearer and easier to read.
