### PR TITLE
fix start testcontainers fail bug

### DIFF
--- a/common/testcontainers/testcontainers.go
+++ b/common/testcontainers/testcontainers.go
@@ -31,6 +31,9 @@ type TestcontainerApps struct {
 // NewTestcontainerApps returns new instance of TestcontainerApps struct
 func NewTestcontainerApps() *TestcontainerApps {
 	timestamp := time.Now().Nanosecond()
+	// In order to solve the problem of "creating reaper failed: failed to create container"
+	// refer to https://github.com/testcontainers/testcontainers-go/issues/2172
+	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 	return &TestcontainerApps{
 		Timestamp: timestamp,
 	}

--- a/common/testcontainers/testcontainers.go
+++ b/common/testcontainers/testcontainers.go
@@ -33,7 +33,10 @@ func NewTestcontainerApps() *TestcontainerApps {
 	timestamp := time.Now().Nanosecond()
 	// In order to solve the problem of "creating reaper failed: failed to create container"
 	// refer to https://github.com/testcontainers/testcontainers-go/issues/2172
-	os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+	err := os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+	if err != nil {
+		panic("set env failed: " + err.Error())
+	}
 	return &TestcontainerApps{
 		Timestamp: timestamp,
 	}

--- a/common/testcontainers/testcontainers.go
+++ b/common/testcontainers/testcontainers.go
@@ -33,8 +33,7 @@ func NewTestcontainerApps() *TestcontainerApps {
 	timestamp := time.Now().Nanosecond()
 	// In order to solve the problem of "creating reaper failed: failed to create container"
 	// refer to https://github.com/testcontainers/testcontainers-go/issues/2172
-	err := os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
-	if err != nil {
+	if err := os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true"); err != nil {
 		panic("set env failed: " + err.Error())
 	}
 	return &TestcontainerApps{


### PR DESCRIPTION
### Purpose or design rationale of this PR

When starting the testcontainer container, sometimes the error "creating reaper failed: failed to create container
" will be reported, which may be caused by CI/CD compatibility. According to the official issue discussion of testcontainer-go, disabling TESTCONTAINERS_RYUK_DISABLED can solve this problem.

refer to：https://github.com/testcontainers/testcontainers-go/issues/2172

![image](https://github.com/scroll-tech/scroll/assets/38887641/7256557a-edbf-4072-8bc9-5a608ed47130)


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [*] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [*] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [*] No, this PR is not a breaking change
- [ ] Yes
