### PR TITLE
docs: update README.md to specify solc version and correct config paths

### DIFF
--- a/rollup/README.md
+++ b/rollup/README.md
@@ -16,7 +16,7 @@ go install -v github.com/scroll-tech/go-ethereum/cmd/abigen
 
 2. `solc`
 
-Ensure you install the version of solc required by [MockBridge.sol](./rollup/mock_bridge/MockBridge.sol) (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
+Ensure you install the version of solc required by [MockBridge.sol](./mock_bridge/MockBridge.sol) (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
 
 ## Build
 

--- a/rollup/README.md
+++ b/rollup/README.md
@@ -16,7 +16,7 @@ go install -v github.com/scroll-tech/go-ethereum/cmd/abigen
 
 2. `solc`
 
-See https://docs.soliditylang.org/en/latest/installing-solidity.html
+Ensure you install the version of solc required by `scroll/rollup/mock_bridge/MockBridge.sol` (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
 
 ## Build
 
@@ -31,7 +31,7 @@ make rollup_bins
 (Note: make sure you use different private keys for different senders in config.json.)
 
 ```bash
-./build/bin/event_watcher --config ./config.json
-./build/bin/gas_oracle --config ./config.json
-./build/bin/rollup_relayer --config ./config.json
+./build/bin/event_watcher --config ./conf/config.json
+./build/bin/gas_oracle --config ./conf/config.json
+./build/bin/rollup_relayer --config ./conf/config.json
 ```

--- a/rollup/README.md
+++ b/rollup/README.md
@@ -16,7 +16,7 @@ go install -v github.com/scroll-tech/go-ethereum/cmd/abigen
 
 2. `solc`
 
-Ensure you install the version of solc required by [MockBridge.sol](./mock_bridge/MockBridge.sol) (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
+Ensure you install the version of solc required by [MockBridge.sol](./mock_bridge/MockBridge.sol#L2) (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
 
 ## Build
 

--- a/rollup/README.md
+++ b/rollup/README.md
@@ -16,7 +16,7 @@ go install -v github.com/scroll-tech/go-ethereum/cmd/abigen
 
 2. `solc`
 
-Ensure you install the version of solc required by `scroll/rollup/mock_bridge/MockBridge.sol` (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
+Ensure you install the version of solc required by [MockBridge.sol](./rollup/mock_bridge/MockBridge.sol) (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
 
 ## Build
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR updates the README.md to clarify the required Solidity compiler version (0.8.24) and correct the configuration file paths to `./conf/config.json`. 

### Issues Addressed
1. **Compiler version**:
   - when running `make mock_abi`, a version mismatch error occurred because the `solc` version used did not match the version specified in `MockBridge.sol`. The error was:
     ```
     Error: Source file requires different compiler version (current compiler is 0.8.25+commit.b61c2a91.Linux.g++) - note that nightly builds are considered to be strictly less than the released version
     --> rollup/mock_bridge/MockBridge.sol:2:1:
      |
     2 | pragma solidity =0.8.24;
      | ^^^^^^^^^^^^^^^^^^^^^^^^
      
     make: *** [Makefile:7: mock_abi] Error 1
     ```
   - this PR updates the README.md to explicitly mention the need for `solc` version as required by `MockBridge.sol`

2. **Configuration file path**:
   - attempting to start services such as the `event_watcher` resulted in error due to incorrect file path:
     ```
     CRIT [04-29|11:01:00.527] failed to load config file               config file=./config.json error="open config.json: no such file or directory"
     ```
   - the corrected paths in the README.md has the actual location of configuration files (`./conf/config.json` instead of `./config.json`)

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
