### PR TITLE
perf(prover): replace fmt.Errorf() with errors.New() if no param required

### DIFF
--- a/prover/prover.go
+++ b/prover/prover.go
@@ -282,7 +282,7 @@ func (r *Prover) prove(task *store.ProvingTask) (*message.ProofDetail, error) {
 
 func (r *Prover) proveChunk(task *store.ProvingTask) (*message.ChunkProof, error) {
 	if task.Task.ChunkTaskDetail == nil {
-		return nil, fmt.Errorf("ChunkTaskDetail is empty")
+		return nil, errors.New("ChunkTaskDetail is empty")
 	}
 	traces, err := r.getSortedTracesByHashes(task.Task.ChunkTaskDetail.BlockHashes)
 	if err != nil {
@@ -293,7 +293,7 @@ func (r *Prover) proveChunk(task *store.ProvingTask) (*message.ChunkProof, error
 
 func (r *Prover) proveBatch(task *store.ProvingTask) (*message.BatchProof, error) {
 	if task.Task.BatchTaskDetail == nil {
-		return nil, fmt.Errorf("BatchTaskDetail is empty")
+		return nil, errors.New("BatchTaskDetail is empty")
 	}
 	return r.proverCore.ProveBatch(task.Task.ID, task.Task.BatchTaskDetail.ChunkInfos, task.Task.BatchTaskDetail.ChunkProofs)
 }
@@ -378,7 +378,7 @@ func (r *Prover) submitErr(task *store.ProvingTask, proofFailureType message.Pro
 
 func (r *Prover) getSortedTracesByHashes(blockHashes []common.Hash) ([]*types.BlockTrace, error) {
 	if len(blockHashes) == 0 {
-		return nil, fmt.Errorf("blockHashes is empty")
+		return nil, errors.New("blockHashes is empty")
 	}
 
 	var traces []*types.BlockTrace


### PR DESCRIPTION
### Purpose or design rationale of this PR

string formatting takes time (even if there's nothing to format), and also that the errors.New is optimized away.

ref:https://github.com/ethereum/go-ethereum/pull/27329

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
