### PR TITLE
build: update golangci-lint

### DIFF
--- a/build/.golangci.yml
+++ b/build/.golangci.yml
@@ -104,10 +104,12 @@ linters-settings:
     # minimal occurrences count to trigger, 3 by default
     min-occurrences: 3
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/davecgh/go-spew/spew
+    rules:
+      main:
+        files:
+          - $all
+        deny:
+          - pkg: "github.com/davecgh/go-spew/spew"
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/build/lint.go
+++ b/build/lint.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// GolangCIVersion to be used for linting.
-	GolangCIVersion = "github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2"
+	GolangCIVersion = "github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2"
 )
 
 // GOBIN environment variable.


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*
What does this PR do?
- update golangci-lint from v1.52 to v1.57.2

Why does it do it?
- Expose problems early: Let the linter discover as many errors as possible during the compilation phase, rather than at runtime.

How does it do it?
- v1.57.2 supports a wider variety of linters

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
