### PR TITLE
ci: upgrade checkout action to version with node20

### DIFF
--- a/.github/workflows/bridge_history_api.yml
+++ b/.github/workflows/bridge_history_api.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint
       run: |
         rm -rf $HOME/.cache/golangci-lint
@@ -48,7 +48,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Test
       run: |
         make test
@@ -67,7 +67,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - run: goimports -local scroll-tech/bridge-history-api/ -w .

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
       - name: check diff

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2
       with:
@@ -56,7 +56,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -81,7 +81,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint
       working-directory: 'coordinator'
       run: |
@@ -56,7 +56,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -77,7 +77,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout code
-  #     uses: actions/checkout@v2
+  #     uses: actions/checkout@v4
   #   - name: Set up Docker Buildx
   #     uses: docker/setup-buildx-action@v2
   #   - name: Build and push
@@ -97,7 +97,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint
       working-directory: 'database'
       run: |
@@ -49,7 +49,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -74,7 +74,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Test
       run: |
         go test -tags="mock_prover" -v -coverprofile=coverage.txt ./...
@@ -58,7 +58,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2
       with:
@@ -75,7 +75,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint
       run: |
         rm -rf $HOME/.cache/golangci-lint
@@ -89,7 +89,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - run: goimports -local scroll-tech/prover/ -w .

--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:
@@ -60,7 +60,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -85,7 +85,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:
@@ -117,7 +117,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout code
-  #     uses: actions/checkout@v2
+  #     uses: actions/checkout@v4
   #   - name: Set up Docker Buildx
   #     uses: docker/setup-buildx-action@v2
   #   - run: make docker


### PR DESCRIPTION
Node16 is deprecated and Actions using it will stop being used 3rd of June
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/