### PR TITLE
feat(contracts): change `MAX_COMMIT_SCALAR` and `MAX_BLOB_SCALAR` to 1e18

### DIFF
--- a/contracts/src/L2/predeploys/L1GasPriceOracle.sol
+++ b/contracts/src/L2/predeploys/L1GasPriceOracle.sol
@@ -59,16 +59,16 @@ contract L1GasPriceOracle is OwnableBase, IL1GasPriceOracle {
     /// ```
     /// commit_scalar = commit_gas_per_tx * fluctuation_multiplier * 1e9
     /// ```
-    /// So, the value should not exceed 10^18 * 1e9 normally.
-    uint256 private constant MAX_COMMIT_SCALAR = 10 ** 18 * PRECISION;
+    /// So, the value should not exceed 10^9 * 1e9 normally.
+    uint256 private constant MAX_COMMIT_SCALAR = 10 ** 9 * PRECISION;
 
     /// @dev The maximum possible l1 blob fee scalar after Curie.
     /// We derive the blob scalar by
     /// ```
     /// blob_scalar = fluctuation_multiplier / compression_ratio / blob_util_ratio * 1e9
     /// ```
-    /// So, the value should not exceed 10^18 * 1e9 normally.
-    uint256 private constant MAX_BLOB_SCALAR = 10 ** 18 * PRECISION;
+    /// So, the value should not exceed 10^9 * 1e9 normally.
+    uint256 private constant MAX_BLOB_SCALAR = 10 ** 9 * PRECISION;
 
     /*************
      * Variables *

--- a/contracts/src/test/L1GasPriceOracle.t.sol
+++ b/contracts/src/test/L1GasPriceOracle.t.sol
@@ -11,8 +11,8 @@ contract L1GasPriceOracleTest is DSTestPlus {
     uint256 private constant PRECISION = 1e9;
     uint256 private constant MAX_OVERHEAD = 30000000 / 16;
     uint256 private constant MAX_SCALAR = 1000 * PRECISION;
-    uint256 private constant MAX_COMMIT_SCALAR = 10 ** 18 * PRECISION;
-    uint256 private constant MAX_BLOB_SCALAR = 10 ** 18 * PRECISION;
+    uint256 private constant MAX_COMMIT_SCALAR = 10 ** 9 * PRECISION;
+    uint256 private constant MAX_BLOB_SCALAR = 10 ** 9 * PRECISION;
 
     L1GasPriceOracle private oracle;
     Whitelist private whitelist;


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR change the value of `MAX_COMMIT_SCALAR` and `MAX_BLOB_SCALAR` to 1e18, since we are sure they won't have larger values.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
