### PR TITLE
fix(coordinator): get hard_fork_name is empty string

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.12"
+var tag = "v4.4.13"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -32,7 +32,9 @@ type ProverTask interface {
 func reverseMap(input map[string]string) map[string]string {
 	output := make(map[string]string, len(input))
 	for k, v := range input {
-		output[v] = k
+		if k != "" {
+			output[v] = k
+		}
 	}
 	return output
 }

--- a/coordinator/internal/logic/verifier/verifier.go
+++ b/coordinator/internal/logic/verifier/verifier.go
@@ -166,7 +166,5 @@ func (v *Verifier) loadEmbedVK() error {
 
 	v.BatchVKMap["bernoulli"] = base64.StdEncoding.EncodeToString(batchVKBytes)
 	v.ChunkVKMap["bernoulli"] = base64.StdEncoding.EncodeToString(chunkVkBytes)
-	v.BatchVKMap[""] = base64.StdEncoding.EncodeToString(batchVKBytes)
-	v.ChunkVKMap[""] = base64.StdEncoding.EncodeToString(chunkVkBytes)
 	return nil
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

Fix issue

fix the reverse map of hardfork map

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [x] Yes
