### PR TITLE
feat(contracts): remove startBatchIndex check when updateVerifier in MultipleVersionRollupVerifier

### DIFF
--- a/contracts/scripts/foundry/DeployL1BridgeContracts.s.sol
+++ b/contracts/scripts/foundry/DeployL1BridgeContracts.s.sol
@@ -96,7 +96,7 @@ contract DeployL1BridgeContracts is Script {
         address[] memory _verifiers = new address[](1);
         _versions[0] = 0;
         _verifiers[0] = address(zkEvmVerifierV1);
-        rollupVerifier = new MultipleVersionRollupVerifier(L1_SCROLL_CHAIN_PROXY_ADDR, _versions, _verifiers);
+        rollupVerifier = new MultipleVersionRollupVerifier(_versions, _verifiers);
 
         logAddress("L1_MULTIPLE_VERSION_ROLLUP_VERIFIER_ADDR", address(rollupVerifier));
     }

--- a/contracts/src/test/MultipleVersionRollupVerifier.t.sol
+++ b/contracts/src/test/MultipleVersionRollupVerifier.t.sol
@@ -18,19 +18,17 @@ contract MultipleVersionRollupVerifierTest is DSTestPlus {
     MockZkEvmVerifier private v0;
     MockZkEvmVerifier private v1;
     MockZkEvmVerifier private v2;
-    MockScrollChain private chain;
 
     function setUp() external {
         v0 = new MockZkEvmVerifier();
         v1 = new MockZkEvmVerifier();
         v2 = new MockZkEvmVerifier();
 
-        chain = new MockScrollChain(address(1), address(1));
         uint256[] memory _versions = new uint256[](1);
         address[] memory _verifiers = new address[](1);
         _versions[0] = 0;
         _verifiers[0] = address(v0);
-        verifier = new MultipleVersionRollupVerifier(address(chain), _versions, _verifiers);
+        verifier = new MultipleVersionRollupVerifier(_versions, _verifiers);
     }
 
     function testUpdateVerifierVersion0(address _newVerifier) external {
@@ -41,10 +39,6 @@ contract MultipleVersionRollupVerifierTest is DSTestPlus {
         hevm.expectRevert("Ownable: caller is not the owner");
         verifier.updateVerifier(0, 0, address(0));
         hevm.stopPrank();
-
-        // start batch index finalized, revert
-        hevm.expectRevert(MultipleVersionRollupVerifier.ErrorStartBatchIndexFinalized.selector);
-        verifier.updateVerifier(0, 0, address(1));
 
         // zero verifier address, revert
         hevm.expectRevert(MultipleVersionRollupVerifier.ErrorZeroAddress.selector);
@@ -92,10 +86,6 @@ contract MultipleVersionRollupVerifierTest is DSTestPlus {
         hevm.expectRevert("Ownable: caller is not the owner");
         verifier.updateVerifier(version, 0, address(0));
         hevm.stopPrank();
-
-        // start batch index finalized, revert
-        hevm.expectRevert(MultipleVersionRollupVerifier.ErrorStartBatchIndexFinalized.selector);
-        verifier.updateVerifier(version, 0, address(1));
 
         // zero verifier address, revert
         hevm.expectRevert(MultipleVersionRollupVerifier.ErrorZeroAddress.selector);


### PR DESCRIPTION
### Purpose or design rationale of this PR

We have 7D timelock to update a new verifier in `MultipleVersionRollupVerifier` and it is hard to predict `lastFinalizedBatchIndex` by that time. We shall remove the check to make verifier upgrading more smoothly.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
