### PR TITLE
feat(prover): remove BlockTrace wrapper in geth_client.rs to make it more flexible for circuits

### DIFF
--- a/prover/src/geth_client.rs
+++ b/prover/src/geth_client.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use ethers_core::types::BlockNumber;
 use tokio::runtime::Runtime;
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 use ethers_providers::{Http, Provider};

--- a/prover/src/geth_client.rs
+++ b/prover/src/geth_client.rs
@@ -8,30 +8,6 @@ use std::fmt::Debug;
 
 use ethers_providers::{Http, Provider};
 
-// ======================= types ============================
-
-/// L2 block full trace which tracks to the version in golang.
-///
-/// The inner block_trace is a generic type, whose real implementation
-/// lies in two version's zkevm-circuits library.
-///
-/// The inner block_trace missed some fields compared to the go version.
-/// These fields are defined here for clarity although not used.
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct BlockTrace<T> {
-    #[serde(flatten)]
-    pub block_trace: T,
-
-    pub version: String,
-
-    pub withdraw_trie_root: Option<CommonHash>,
-
-    #[serde(rename = "mptwitness", default)]
-    pub mpt_witness: Vec<u8>,
-}
-
-// ======================= geth client ============================
-
 pub struct GethClient {
     id: String,
     provider: Provider<Http>,
@@ -52,7 +28,7 @@ impl GethClient {
         })
     }
 
-    pub fn get_block_trace_by_hash<T>(&mut self, hash: &CommonHash) -> Result<BlockTrace<T>>
+    pub fn get_block_trace_by_hash<T>(&mut self, hash: &CommonHash) -> Result<T>
     where
         T: Serialize + DeserializeOwned + Debug + Send,
     {

--- a/prover/src/zk_circuits_handler/bernoulli.rs
+++ b/prover/src/zk_circuits_handler/bernoulli.rs
@@ -132,7 +132,7 @@ impl BaseCircuitsHandler {
                 .unwrap()
                 .borrow_mut()
                 .get_block_trace_by_hash(hash)?;
-            block_traces.push(trace.block_trace);
+            block_traces.push(trace);
         }
 
         block_traces.sort_by(|a, b| {

--- a/prover/src/zk_circuits_handler/curie.rs
+++ b/prover/src/zk_circuits_handler/curie.rs
@@ -132,7 +132,7 @@ impl NextCircuitsHandler {
                 .unwrap()
                 .borrow_mut()
                 .get_block_trace_by_hash(hash)?;
-            block_traces.push(trace.block_trace);
+            block_traces.push(trace);
         }
 
         block_traces.sort_by(|a, b| {


### PR DESCRIPTION
### Purpose or design rationale of this PR

remove BlockTrace wrapper in geth_client.rs to make it more flexible for circuits modifying BlockTrace fields


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
