### PR TITLE
fix(db): the function UpdateProvingStatusFailed proving_status determines the condition incorrectly

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.17"
+var tag = "v4.4.18"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -309,7 +309,7 @@ func (o *Batch) UpdateProvingStatusFailed(ctx context.Context, hash string, maxA
 	db = db.Model(&Batch{})
 	db = db.Where("hash", hash)
 	db = db.Where("total_attempts >= ?", maxAttempts)
-	db = db.Where("proving_status != ?", int(types.ProverProofValid))
+	db = db.Where("proving_status != ?", int(types.ProvingTaskVerified))
 	if err := db.Update("proving_status", int(types.ProvingTaskFailed)).Error; err != nil {
 		return fmt.Errorf("Batch.UpdateProvingStatus error: %w, batch hash: %v, status: %v", err, hash, types.ProvingTaskFailed.String())
 	}

--- a/coordinator/internal/orm/chunk.go
+++ b/coordinator/internal/orm/chunk.go
@@ -332,7 +332,7 @@ func (o *Chunk) UpdateProvingStatusFailed(ctx context.Context, hash string, maxA
 	db = db.Model(&Chunk{})
 	db = db.Where("hash", hash)
 	db = db.Where("total_attempts >= ?", maxAttempts)
-	db = db.Where("proving_status != ?", int(types.ProverProofValid))
+	db = db.Where("proving_status != ?", int(types.ProvingTaskVerified))
 	if err := db.Update("proving_status", int(types.ProvingTaskFailed)).Error; err != nil {
 		return fmt.Errorf("Batch.UpdateProvingStatus error: %w, batch hash: %v, status: %v", err, hash, types.ProvingTaskFailed.String())
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

This PR fixes the problem that the UpdateProvingStatusFailed function incorrectly uses `type.ProverProofValid` as the filtering condition when using proving_status as the judging condition.


### PR title

Your PR title must follow [[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [[types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes