### PR TITLE
feat(coordinator & prover): upgrade libzkp to v0.11.3

### DIFF
--- a/common/libzkp/impl/Cargo.lock
+++ b/common/libzkp/impl/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "ark-std 0.3.0",
  "bitstream-io",
@@ -537,7 +537,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 [[package]]
 name = "bus-mapping"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "base64 0.13.1",
  "ethers-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types",
  "halo2_proofs",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "env_logger 0.10.0",
  "gobuild",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types",
  "halo2curves",
@@ -2724,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "aggregator",
  "anyhow",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/common/libzkp/impl/Cargo.toml
+++ b/common/libzkp/impl/Cargo.toml
@@ -25,7 +25,7 @@ bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/i
 [dependencies]
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "v1.1" }
 snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
-prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.1", default-features = false, features = ["parallel_syn", "scroll"] }
+prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.3", default-features = false, features = ["parallel_syn", "scroll"] }
 
 base64 = "0.13.0"
 env_logger = "0.9.0"

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.18"
+var tag = "v4.4.19"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "ark-std 0.3.0",
  "bitstream-io",
@@ -661,7 +661,7 @@ dependencies = [
 [[package]]
 name = "bus-mapping"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types 0.11.0",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "base64 0.13.1",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types 0.11.0",
  "geth-utils 0.11.0",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types 0.11.0",
  "halo2_proofs",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "env_logger 0.10.2",
  "gobuild",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types 0.11.0",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -2815,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "eth-types 0.11.0",
  "halo2curves",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "aggregator 0.11.0",
  "anyhow",
@@ -5584,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.3#19c813167ed0dfa72753a9f1eacdac969c6e94e6"
 dependencies = [
  "array-init",
  "bus-mapping 0.11.0",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "ark-std 0.3.0",
  "bitstream-io",
@@ -661,7 +661,7 @@ dependencies = [
 [[package]]
 name = "bus-mapping"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "eth-types 0.11.0",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "base64 0.13.1",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "eth-types 0.11.0",
  "geth-utils 0.11.0",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "eth-types 0.11.0",
  "halo2_proofs",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "env_logger 0.10.2",
  "gobuild",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "eth-types 0.11.0",
  "ethers-core 2.0.7 (git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7)",
@@ -2815,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "eth-types 0.11.0",
  "halo2curves",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "aggregator 0.11.0",
  "anyhow",
@@ -5584,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.1#512996f1bac1218c93d9d3de49d7b86f52726c27"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.2#4bd2f6267645e6dd2d81ea59be0e05311fccb497"
 dependencies = [
  "array-init",
  "bus-mapping 0.11.0",

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -30,7 +30,7 @@ ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branc
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "v1.1" }
 snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "v0.10", default-features = false, features = ["parallel_syn", "scroll", "shanghai"] }
-prover_next = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.2", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
+prover_next = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.3", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
 base64 = "0.13.1"
 reqwest = { version = "0.12.4", features = ["gzip"] }
 reqwest-middleware = "0.3"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -30,7 +30,7 @@ ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branc
 halo2_proofs = { git = "https://github.com/scroll-tech/halo2.git", branch = "v1.1" }
 snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", branch = "develop", default-features = false, features = ["loader_halo2", "loader_evm", "halo2-pse"] }
 prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "v0.10", default-features = false, features = ["parallel_syn", "scroll", "shanghai"] }
-prover_next = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.1", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
+prover_next = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.2", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
 base64 = "0.13.1"
 reqwest = { version = "0.12.4", features = ["gzip"] }
 reqwest-middleware = "0.3"


### PR DESCRIPTION
v0.11.3:

new assets and solidity verifier.    
Chunk prover / batch prover / coordinator need to be upgraded. 
l2geth does not need to be upgraded.  