### PR TITLE
fix(Makefile): remove outdated prover in golang-related cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ update:
 	cd $(PWD)/common/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG}&& go mod tidy
 	cd $(PWD)/coordinator/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
 	cd $(PWD)/database/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
-	cd $(PWD)/prover/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG}&& go mod tidy
 	cd $(PWD)/rollup/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
 	cd $(PWD)/tests/integration-test/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
 
@@ -21,7 +20,6 @@ lint: ## The code's format and security checks.
 	make -C common lint
 	make -C coordinator lint
 	make -C database lint
-	make -C prover lint
 	make -C bridge-history-api lint
 
 fmt: ## format the code
@@ -30,7 +28,6 @@ fmt: ## format the code
 	cd $(PWD)/common/ && go mod tidy
 	cd $(PWD)/coordinator/ && go mod tidy
 	cd $(PWD)/database/ && go mod tidy
-	cd $(PWD)/prover/ && go mod tidy
 	cd $(PWD)/rollup/ && go mod tidy
 	cd $(PWD)/tests/integration-test/ && go mod tidy
 
@@ -38,7 +35,6 @@ fmt: ## format the code
 	goimports -local $(PWD)/common/ -w .
 	goimports -local $(PWD)/coordinator/ -w .
 	goimports -local $(PWD)/database/ -w .
-	goimports -local $(PWD)/prover/ -w .
 	goimports -local $(PWD)/rollup/ -w .
 	goimports -local $(PWD)/tests/integration-test/ -w .
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -34,12 +34,7 @@ import (
 	rutils "scroll-tech/rollup/internal/utils"
 )
 
-// Layer2Relayer is responsible for
-//  1. Committing and finalizing L2 blocks on L1
-//  2. Relaying messages from L2 to L1
-//
-// Actions are triggered by new head from layer 1 geth node.
-// @todo It's better to be triggered by watcher.
+// Layer2Relayer is responsible for committing and finalizing L2 blocks on L1.
 type Layer2Relayer struct {
 	ctx context.Context
 
@@ -602,7 +597,7 @@ func (r *Layer2Relayer) finalizeBatch(dbBatch *orm.Batch, withProof bool) error 
 
 	log.Info("finalizeBatch in layer1", "with proof", withProof, "index", dbBatch.Index, "batch hash", dbBatch.Hash, "tx hash", txHash.String())
 
-	// record and sync with db, @todo handle db error
+	// Updating rollup status in database.
 	if err := r.batchOrm.UpdateFinalizeTxHashAndRollupStatus(r.ctx, dbBatch.Hash, txHash.String(), types.RollupFinalizing); err != nil {
 		log.Error("UpdateFinalizeTxHashAndRollupStatus failed", "index", dbBatch.Index, "batch hash", dbBatch.Hash, "tx hash", txHash.String(), "err", err)
 		return err


### PR DESCRIPTION
### Purpose or design rationale of this PR

Remove outdated prover in golang-related cmds.
Update some outdated comments.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
