### PR TITLE
feat(bridge-history): change FinalizeBatch event logic

### DIFF
--- a/bridge-history-api/internal/controller/fetcher/l1_fetcher.go
+++ b/bridge-history-api/internal/controller/fetcher/l1_fetcher.go
@@ -153,6 +153,7 @@ func (c *L1MessageFetcher) fetchAndSaveEvents(confirmation uint64) {
 			return
 		}
 
+		c.l1FetcherLogic.ShiftToNextLastFinalizedBatchIndex()
 		c.updateL1SyncHeight(to, lastBlockHash)
 		c.l1MessageFetcherRunningTotal.Inc()
 	}

--- a/bridge-history-api/internal/controller/fetcher/l1_fetcher.go
+++ b/bridge-history-api/internal/controller/fetcher/l1_fetcher.go
@@ -41,7 +41,7 @@ func NewL1MessageFetcher(ctx context.Context, cfg *config.FetcherConfig, db *gor
 		cfg:              cfg,
 		client:           client,
 		eventUpdateLogic: logic.NewEventUpdateLogic(db, true),
-		l1FetcherLogic:   logic.NewL1FetcherLogic(cfg, db, client),
+		l1FetcherLogic:   logic.NewL1FetcherLogic(ctx, cfg, db, client),
 	}
 
 	reg := prometheus.DefaultRegisterer

--- a/bridge-history-api/internal/logic/l1_fetcher.go
+++ b/bridge-history-api/internal/logic/l1_fetcher.go
@@ -52,7 +52,7 @@ type L1FetcherLogic struct {
 }
 
 // NewL1FetcherLogic creates L1 fetcher logic
-func NewL1FetcherLogic(cfg *config.FetcherConfig, db *gorm.DB, client *ethclient.Client) *L1FetcherLogic {
+func NewL1FetcherLogic(ctx context.Context, cfg *config.FetcherConfig, db *gorm.DB, client *ethclient.Client) *L1FetcherLogic {
 	addressList := []common.Address{
 		common.HexToAddress(cfg.ETHGatewayAddr),
 
@@ -121,7 +121,7 @@ func NewL1FetcherLogic(cfg *config.FetcherConfig, db *gorm.DB, client *ethclient
 		parser:          NewL1EventParser(cfg, client),
 	}
 
-	index, err := f.batchEventOrm.GetLastFinalizedBatchIndex(context.TODO())
+	index, err := f.batchEventOrm.GetLastFinalizedBatchIndex(ctx)
 	if err == gorm.ErrRecordNotFound {
 		// do nothing, leaving lastFinalizedBatchIndex to be nil
 		log.Warn("all bacthes are non-finalized, this should happen only once")

--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -73,6 +73,18 @@ func (c *BatchEvent) GetFinalizedBatchesLEBlockHeight(ctx context.Context, block
 
 // InsertOrUpdateBatchEvents inserts a new batch event or updates an existing one based on the BatchStatusType.
 func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvents []*BatchEvent) error {
+	var startFinalizedBatchIndex, endFinalizedBatchIndex uint64
+	collectFinalizedBatches := func(batchIndex uint64) {
+		if startFinalizedBatchIndex == 0 {
+			startFinalizedBatchIndex = batchIndex
+		} else if batchIndex < startFinalizedBatchIndex {
+			startFinalizedBatchIndex = batchIndex
+		}
+		// end is not inclueded
+		if endFinalizedBatchIndex <= batchIndex {
+			endFinalizedBatchIndex = batchIndex + 1
+		}
+	}
 	for _, l1BatchEvent := range l1BatchEvents {
 		db := c.db
 		db = db.WithContext(ctx)
@@ -91,11 +103,8 @@ func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvent
 		case btypes.BatchStatusTypeFinalized:
 			// After darwin, FinalizeBatch event signals a range of batches are finalized,
 			// thus losing the batch hash info. Meanwhile, only batch_index is enough to find the target batch when finalizing batches.
-			db = db.Where("batch_index = ?", l1BatchEvent.BatchIndex)
-			updateFields["batch_status"] = btypes.BatchStatusTypeFinalized
-			if err := db.Updates(updateFields).Error; err != nil {
-				return fmt.Errorf("failed to update batch event, error: %w", err)
-			}
+			endFinalizedBatchIndex = 1
+			collectFinalizedBatches(l1BatchEvent.BatchIndex)
 		case btypes.BatchStatusTypeReverted:
 			db = db.Where("batch_index = ?", l1BatchEvent.BatchIndex)
 			db = db.Where("batch_hash = ?", l1BatchEvent.BatchHash)
@@ -107,6 +116,20 @@ func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvent
 			if err := db.Delete(l1BatchEvent).Error; err != nil {
 				return fmt.Errorf("failed to soft delete batch event, error: %w", err)
 			}
+		}
+	}
+	// initial end value is 0, this can signal that there are some finalized events
+	if endFinalizedBatchIndex > 0 {
+		db := c.db
+		db = db.WithContext(ctx)
+		db = db.Model(&BatchEvent{})
+		updateFields := make(map[string]interface{})
+		db = db.Where("batch_index >= ?", startFinalizedBatchIndex)
+		db = db.Where("batch_index < ?", endFinalizedBatchIndex)
+		db = db.Where("batch_status != ?", btypes.BatchStatusTypeFinalized)
+		updateFields["batch_status"] = btypes.BatchStatusTypeFinalized
+		if err := db.Updates(updateFields).Error; err != nil {
+			return fmt.Errorf("failed to update batch event, error: %w", err)
 		}
 	}
 	return nil

--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -90,7 +90,7 @@ func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvent
 			}
 		case btypes.BatchStatusTypeFinalized:
 			// After darwin, FinalizeBatch event signals a range of batches are finalized,
-			// thus losing the batch hash info. Meanwhile, only batch_index is enough to find the target batch.
+			// thus losing the batch hash info. Meanwhile, only batch_index is enough to find the target batch when finalizing batches.
 			db = db.Where("batch_index = ?", l1BatchEvent.BatchIndex)
 			updateFields["batch_status"] = btypes.BatchStatusTypeFinalized
 			if err := db.Updates(updateFields).Error; err != nil {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Upgrade the logic when dealing with FinalizeBatch event. 
This is intended to support darwin as well as backward compatible.

One thing need caution: "GetLastFinalizedBatchIndex" from db can not use any index and it's not suitable to add such index since there will be almost 100% batches are all finalized as time goes. Do we need add a key-value mode cache to save the "last finalized batch index"? it can be a small kv table in postgres or using redis..

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
