### PR TITLE
feat(bridge-history): generate withdraw proofs by bundle

### DIFF
--- a/bridge-history-api/conf/config.json
+++ b/bridge-history-api/conf/config.json
@@ -19,7 +19,7 @@
 		"ScrollChainAddr": "0xa13BAF47339d63B743e7Da8741db5456DAc1E556",
 		"GatewayRouterAddr": "0xF8B1378579659D8F7EE5f3C929c2f3E332E41Fd6",
 		"MessageQueueAddr": "0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B",
-		"BatchBridgeGatewayAddr": "0x0000000000000000000000000000000000000000"
+		"BatchBridgeGatewayAddr": "0x5Bcfd99c34cf7E06fc756f6f5aE7400504852bc4"
 	},
 	"L2": {
 		"confirmation": 0,
@@ -39,7 +39,7 @@
 		"PufferGatewayAddr": "0x9eBf2f33526CD571f8b2ad312492cb650870CFd6",
 		"GatewayRouterAddr": "0x4C0926FF5252A435FD19e10ED15e5a249Ba19d79",
 		"MessageQueueAddr": "0x5300000000000000000000000000000000000000",
-		"BatchBridgeGatewayAddr": "0x0000000000000000000000000000000000000000"
+		"BatchBridgeGatewayAddr": "0xa1a12158bE6269D7580C63eC5E609Cdc0ddD82bC"
 	},
 	"db": {
 		"dsn": "postgres://postgres:123456@localhost:5444/test?sslmode=disable",

--- a/bridge-history-api/internal/controller/fetcher/l2_fetcher.go
+++ b/bridge-history-api/internal/controller/fetcher/l2_fetcher.go
@@ -141,7 +141,7 @@ func (c *L2MessageFetcher) fetchAndSaveEvents(confirmation uint64) {
 			return
 		}
 
-		if updateErr := c.eventUpdateLogic.UpdateL1BatchIndexAndStatus(c.ctx, c.l2SyncHeight); updateErr != nil {
+		if updateErr := c.eventUpdateLogic.UpdateL2WithdrawMessageProofs(c.ctx, c.l2SyncHeight); updateErr != nil {
 			log.Error("failed to update L1 batch index and status", "from", from, "to", to, "err", updateErr)
 			return
 		}

--- a/bridge-history-api/internal/logic/event_update.go
+++ b/bridge-history-api/internal/logic/event_update.go
@@ -183,7 +183,7 @@ func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, he
 
 	finalizedBatches, err := b.batchEventOrm.GetUnupdatedFinalizedBatchesLEBlockHeight(ctx, height)
 	if err != nil {
-		log.Error("failed to get batches >= block height", "error", err)
+		log.Error("failed to get unupdated finalized batches >= block height", "error", err)
 		return err
 	}
 
@@ -198,7 +198,7 @@ func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, he
 	}
 
 	for _, finalizedBatch := range finalizedBatches {
-		log.Info("update finalized batch info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "lastlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
+		log.Info("update finalized batch or bundle info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "lastlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
 		// This method is compatible with both "finalize by batch" and "finalize by bundle" modes:
 		// - In "finalize by batch" mode, each batch emits a FinalizedBatch event.
 		// - In "finalize by bundle" mode, all batches in the bundle emit only one FinalizedBatch event, using the last batch's index and hash.

--- a/bridge-history-api/internal/logic/event_update.go
+++ b/bridge-history-api/internal/logic/event_update.go
@@ -125,6 +125,11 @@ func (b *EventUpdateLogic) L1InsertOrUpdate(ctx context.Context, l1FetcherResult
 }
 
 func (b *EventUpdateLogic) updateL2WithdrawMessageInfos(ctx context.Context, batchIndex, startBlock, endBlock uint64) error {
+	if startBlock > endBlock {
+		log.Warn("start block is greater than end block", "start", startBlock, "end", endBlock)
+		return nil
+	}
+
 	l2WithdrawMessages, err := b.crossMessageOrm.GetL2WithdrawalsByBlockRange(ctx, startBlock, endBlock)
 	if err != nil {
 		log.Error("failed to get L2 withdrawals by batch index", "batch index", batchIndex, "err", err)
@@ -185,16 +190,6 @@ func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, he
 	if err != nil {
 		log.Error("failed to get unupdated finalized batches >= block height", "error", err)
 		return err
-	}
-
-	if len(finalizedBatches) == 0 {
-		log.Warn("no finalized batches to update", "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight)
-		return nil
-	}
-
-	if finalizedBatches[0].EndBlockNumber <= lastUpdatedFinalizedBlockHeight {
-		log.Warn("no finalized batches to update", "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight, "endBlockNumber", finalizedBatches[0].EndBlockNumber)
-		return nil
 	}
 
 	for _, finalizedBatch := range finalizedBatches {

--- a/bridge-history-api/internal/logic/event_update.go
+++ b/bridge-history-api/internal/logic/event_update.go
@@ -198,7 +198,7 @@ func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, he
 	}
 
 	for _, finalizedBatch := range finalizedBatches {
-		log.Info("update finalized batch or bundle info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "lastlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
+		log.Info("update finalized batch or bundle info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
 		// This method is compatible with both "finalize by batch" and "finalize by bundle" modes:
 		// - In "finalize by batch" mode, each batch emits a FinalizedBatch event.
 		// - In "finalize by bundle" mode, all batches in the bundle emit only one FinalizedBatch event, using the last batch's index and hash.

--- a/bridge-history-api/internal/logic/event_update.go
+++ b/bridge-history-api/internal/logic/event_update.go
@@ -175,9 +175,9 @@ func (b *EventUpdateLogic) updateL2WithdrawMessageInfos(ctx context.Context, bat
 
 // UpdateL2WithdrawMessageProofs updates L2 withdrawal message proofs.
 func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, height uint64) error {
-	lastUpdatedFinalizedBlockHeight, err := b.batchEventOrm.GetUpdatedFinalizedBlockHeight(ctx)
+	lastUpdatedFinalizedBlockHeight, err := b.batchEventOrm.GetLastUpdatedFinalizedBlockHeight(ctx)
 	if err != nil {
-		log.Error("failed to get latest processed finalized batch", "error", err)
+		log.Error("failed to get last updated finalized block height", "error", err)
 		return err
 	}
 

--- a/bridge-history-api/internal/logic/event_update.go
+++ b/bridge-history-api/internal/logic/event_update.go
@@ -173,24 +173,42 @@ func (b *EventUpdateLogic) updateL2WithdrawMessageInfos(ctx context.Context, bat
 	return nil
 }
 
-// UpdateL1BatchIndexAndStatus updates L1 finalized batch index and status
-func (b *EventUpdateLogic) UpdateL1BatchIndexAndStatus(ctx context.Context, height uint64) error {
-	finalizedBatches, err := b.batchEventOrm.GetFinalizedBatchesLEBlockHeight(ctx, height)
+// UpdateL2WithdrawMessageProofs updates L2 withdrawal message proofs.
+func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, height uint64) error {
+	lastUpdatedFinalizedBlockHeight, err := b.batchEventOrm.GetUpdatedFinalizedBlockHeight(ctx)
+	if err != nil {
+		log.Error("failed to get latest processed finalized batch", "error", err)
+		return err
+	}
+
+	finalizedBatches, err := b.batchEventOrm.GetUnupdatedFinalizedBatchesLEBlockHeight(ctx, height)
 	if err != nil {
 		log.Error("failed to get batches >= block height", "error", err)
 		return err
 	}
 
 	for _, finalizedBatch := range finalizedBatches {
-		log.Info("update finalized batch info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
-		if updateErr := b.updateL2WithdrawMessageInfos(ctx, finalizedBatch.BatchIndex, finalizedBatch.StartBlockNumber, finalizedBatch.EndBlockNumber); updateErr != nil {
-			log.Error("failed to update L2 withdraw message infos", "index", finalizedBatch.BatchIndex, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber, "error", updateErr)
+		log.Info("update finalized batch info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "lastlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
+		// This method is compatible with both "finalize by batch" and "finalize by bundle" modes:
+		// - In "finalize by batch" mode, each batch emits a FinalizedBatch event.
+		// - In "finalize by bundle" mode, all batches in the bundle emit only one FinalizedBatch event, using the last batch's index and hash.
+		//
+		// The method updates two types of information in L2 withdrawal messages:
+		// 1. Withdraw proof generation:
+		//    - finalize by batch: Generates proofs for each batch.
+		//    - finalize by bundle: Generates proofs for the entire bundle at once.
+		// 2. Batch index updating:
+		//    - finalize by batch: Updates the batch index for withdrawal messages in each processed batch.
+		//    - finalize by bundle: Updates the batch index for all withdrawal messages in the bundle, using the index of the last batch in the bundle.
+		if updateErr := b.updateL2WithdrawMessageInfos(ctx, finalizedBatch.BatchIndex, lastUpdatedFinalizedBlockHeight+1, finalizedBatch.EndBlockNumber); updateErr != nil {
+			log.Error("failed to update L2 withdraw message infos", "index", finalizedBatch.BatchIndex, "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber, "error", updateErr)
 			return updateErr
 		}
 		if dbErr := b.batchEventOrm.UpdateBatchEventStatus(ctx, finalizedBatch.BatchIndex); dbErr != nil {
-			log.Error("failed to update batch event status as updated", "index", finalizedBatch.BatchIndex, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber, "error", dbErr)
+			log.Error("failed to update batch event status as updated", "index", finalizedBatch.BatchIndex, "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber, "error", dbErr)
 			return dbErr
 		}
+		lastUpdatedFinalizedBlockHeight = finalizedBatch.EndBlockNumber
 		b.eventUpdateLogicL1FinalizeBatchEventL2BlockUpdateHeight.Set(float64(finalizedBatch.EndBlockNumber))
 	}
 	return nil

--- a/bridge-history-api/internal/logic/event_update.go
+++ b/bridge-history-api/internal/logic/event_update.go
@@ -187,6 +187,16 @@ func (b *EventUpdateLogic) UpdateL2WithdrawMessageProofs(ctx context.Context, he
 		return err
 	}
 
+	if len(finalizedBatches) == 0 {
+		log.Warn("no finalized batches to update", "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight)
+		return nil
+	}
+
+	if finalizedBatches[0].EndBlockNumber <= lastUpdatedFinalizedBlockHeight {
+		log.Warn("no finalized batches to update", "lastUpdatedFinalizedBlockHeight", lastUpdatedFinalizedBlockHeight, "endBlockNumber", finalizedBatches[0].EndBlockNumber)
+		return nil
+	}
+
 	for _, finalizedBatch := range finalizedBatches {
 		log.Info("update finalized batch info of L2 withdrawals", "index", finalizedBatch.BatchIndex, "lastlockHeight", lastUpdatedFinalizedBlockHeight, "start", finalizedBatch.StartBlockNumber, "end", finalizedBatch.EndBlockNumber)
 		// This method is compatible with both "finalize by batch" and "finalize by bundle" modes:

--- a/bridge-history-api/internal/logic/l1_event_parser.go
+++ b/bridge-history-api/internal/logic/l1_event_parser.go
@@ -273,6 +273,7 @@ func (e *L1EventParser) ParseL1BatchEventLogs(ctx context.Context, logs []types.
 			l1BatchEvents = append(l1BatchEvents, &orm.BatchEvent{
 				BatchStatus:   int(btypes.BatchStatusTypeFinalized),
 				BatchIndex:    event.BatchIndex.Uint64(),
+				BatchHash:     event.BatchHash.String(),
 				L1BlockNumber: vlog.BlockNumber,
 			})
 		}

--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -63,6 +63,7 @@ func (c *BatchEvent) GetUpdatedFinalizedBlockHeight(ctx context.Context) (uint64
 	db = db.Order("batch_index desc")
 	if err := db.First(&batch).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
+			// No finalized batch found, return genesis batch's end block number.
 			return 0, nil
 		}
 		return 0, fmt.Errorf("failed to get latest processed finalized batch, error: %w", err)

--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -84,7 +84,7 @@ func (c *BatchEvent) GetUnupdatedFinalizedBatchesLEBlockHeight(ctx context.Conte
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get batches >= block height, error: %w", err)
+		return nil, fmt.Errorf("failed to get unupdated finalized batches >= block height, error: %w", err)
 	}
 	return batches, nil
 }

--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -53,8 +53,8 @@ func (c *BatchEvent) GetBatchEventSyncedHeightInDB(ctx context.Context) (uint64,
 	return batch.L1BlockNumber, nil
 }
 
-// GetUpdatedFinalizedBlockHeight returns the processed finalized block height in db.
-func (c *BatchEvent) GetUpdatedFinalizedBlockHeight(ctx context.Context) (uint64, error) {
+// GetLastUpdatedFinalizedBlockHeight returns the last updated finalized block height in db.
+func (c *BatchEvent) GetLastUpdatedFinalizedBlockHeight(ctx context.Context) (uint64, error) {
 	var batch BatchEvent
 	db := c.db.WithContext(ctx)
 	db = db.Model(&BatchEvent{})
@@ -66,7 +66,7 @@ func (c *BatchEvent) GetUpdatedFinalizedBlockHeight(ctx context.Context) (uint64
 			// No finalized batch found, return genesis batch's end block number.
 			return 0, nil
 		}
-		return 0, fmt.Errorf("failed to get latest processed finalized batch, error: %w", err)
+		return 0, fmt.Errorf("failed to get last updated finalized block height, error: %w", err)
 	}
 	return batch.EndBlockNumber, nil
 }

--- a/bridge-history-api/internal/orm/batch_event.go
+++ b/bridge-history-api/internal/orm/batch_event.go
@@ -53,8 +53,25 @@ func (c *BatchEvent) GetBatchEventSyncedHeightInDB(ctx context.Context) (uint64,
 	return batch.L1BlockNumber, nil
 }
 
-// GetFinalizedBatchesLEBlockHeight returns the finalized batches with end block <= given block height in db.
-func (c *BatchEvent) GetFinalizedBatchesLEBlockHeight(ctx context.Context, blockHeight uint64) ([]*BatchEvent, error) {
+// GetUpdatedFinalizedBlockHeight returns the processed finalized block height in db.
+func (c *BatchEvent) GetUpdatedFinalizedBlockHeight(ctx context.Context) (uint64, error) {
+	var batch BatchEvent
+	db := c.db.WithContext(ctx)
+	db = db.Model(&BatchEvent{})
+	db = db.Where("batch_status = ?", btypes.BatchStatusTypeFinalized)
+	db = db.Where("update_status = ?", btypes.UpdateStatusTypeUpdated)
+	db = db.Order("batch_index desc")
+	if err := db.First(&batch).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to get latest processed finalized batch, error: %w", err)
+	}
+	return batch.EndBlockNumber, nil
+}
+
+// GetUnupdatedFinalizedBatchesLEBlockHeight returns the finalized batches with end block <= given block height in db.
+func (c *BatchEvent) GetUnupdatedFinalizedBatchesLEBlockHeight(ctx context.Context, blockHeight uint64) ([]*BatchEvent, error) {
 	var batches []*BatchEvent
 	db := c.db.WithContext(ctx)
 	db = db.Model(&BatchEvent{})
@@ -73,9 +90,6 @@ func (c *BatchEvent) GetFinalizedBatchesLEBlockHeight(ctx context.Context, block
 
 // InsertOrUpdateBatchEvents inserts a new batch event or updates an existing one based on the BatchStatusType.
 func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvents []*BatchEvent) error {
-	var maxFinalizedBatchIndex uint64
-	var containsFinalizedEvent bool
-	var maxL1BlockNumber uint64
 	for _, l1BatchEvent := range l1BatchEvents {
 		db := c.db
 		db = db.WithContext(ctx)
@@ -92,13 +106,12 @@ func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvent
 				return fmt.Errorf("failed to insert or ignore batch event, error: %w", err)
 			}
 		case btypes.BatchStatusTypeFinalized:
-			containsFinalizedEvent = true
-			// get the maxFinalizedBatchIndex, which signals all the batch before it are all finalized
-			if l1BatchEvent.BatchIndex > maxFinalizedBatchIndex {
-				maxFinalizedBatchIndex = l1BatchEvent.BatchIndex
-			}
-			if l1BatchEvent.L1BlockNumber > maxL1BlockNumber {
-				maxL1BlockNumber = l1BatchEvent.L1BlockNumber
+			db = db.Where("batch_index = ?", l1BatchEvent.BatchIndex)
+			db = db.Where("batch_hash = ?", l1BatchEvent.BatchHash)
+			updateFields["batch_status"] = btypes.BatchStatusTypeFinalized
+			updateFields["l1_block_number"] = l1BatchEvent.L1BlockNumber
+			if err := db.Updates(updateFields).Error; err != nil {
+				return fmt.Errorf("failed to update batch event, error: %w", err)
 			}
 		case btypes.BatchStatusTypeReverted:
 			db = db.Where("batch_index = ?", l1BatchEvent.BatchIndex)
@@ -111,21 +124,6 @@ func (c *BatchEvent) InsertOrUpdateBatchEvents(ctx context.Context, l1BatchEvent
 			if err := db.Delete(l1BatchEvent).Error; err != nil {
 				return fmt.Errorf("failed to soft delete batch event, error: %w", err)
 			}
-		}
-	}
-	if containsFinalizedEvent {
-		db := c.db
-		db = db.WithContext(ctx)
-		db = db.Model(&BatchEvent{})
-		updateFields := make(map[string]interface{})
-		// After darwin, FinalizeBatch event signals a range of batches are finalized,
-		// thus losing the batch hash info. Meanwhile, only batch_index is enough to update finalized batches.
-		db = db.Where("batch_index <= ?", maxFinalizedBatchIndex)
-		db = db.Where("batch_status != ?", btypes.BatchStatusTypeFinalized)
-		updateFields["batch_status"] = btypes.BatchStatusTypeFinalized
-		updateFields["l1_block_number"] = maxL1BlockNumber
-		if err := db.Updates(updateFields).Error; err != nil {
-			return fmt.Errorf("failed to update batch event, error: %w", err)
 		}
 	}
 	return nil

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.23"
+var tag = "v4.4.24"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR adds generating withdraw proofs by bundle logic, and it's backward compatible.

Notes:
It keeps commit/revert batches to maintain block range of the batch, because in `FinalizeBatch` event, there isn't a block range.

Only updating batch's status as `finalized` when listening to the `FinalizeBatch` event (when "finalize by bundle", only each bundle's last batch will be updated as `finalized`), so that bridge-history-backend can track the block range to update regardless "finalize by batch" or "finalize by bundle".

This PR is compatible with both "finalize by batch" and "finalize by bundle" modes:
- In "finalize by batch" mode, each batch emits a FinalizedBatch event.
- In "finalize by bundle" mode, all batches in the bundle emit only one `FinalizedBatch` event, using the last batch's index and hash.

For withdraw proof generation:
- finalize by batch: Generates proofs for each batch.
- finalize by bundle: Generates proofs for the entire bundle at once.

For batch index updating:
- finalize by batch: Updates the batch index for withdrawal messages in each processed batch.
- finalize by bundle: Updates the batch index for all withdrawal messages in the bundle, using the index of the last batch in the bundle.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
