### PR TITLE
Delete dead badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Scroll Monorepo
 
 [![rollup](https://github.com/scroll-tech/scroll/actions/workflows/rollup.yml/badge.svg)](https://github.com/scroll-tech/scroll/actions/workflows/rollup.yml)
-[![contracts](https://github.com/scroll-tech/scroll/actions/workflows/contracts.yml/badge.svg)](https://github.com/scroll-tech/scroll/actions/workflows/contracts.yml)
 [![bridge-history](https://github.com/scroll-tech/scroll/actions/workflows/bridge_history_api.yml/badge.svg)](https://github.com/scroll-tech/scroll/actions/workflows/bridge_history_api.yml)
 [![coordinator](https://github.com/scroll-tech/scroll/actions/workflows/coordinator.yml/badge.svg)](https://github.com/scroll-tech/scroll/actions/workflows/coordinator.yml)
 [![prover](https://github.com/scroll-tech/scroll/actions/workflows/prover.yml/badge.svg)](https://github.com/scroll-tech/scroll/actions/workflows/prover.yml)


### PR DESCRIPTION
Sorry for the bothering, but it looks like your homepage(README) badge is down due to [PR](https://github.com/scroll-tech/scroll/commit/ab9c5414093082141c55ff562899234462a1e7e3#diff-d0024dcfce8263455f76f35323f55051631264ba689777e927397480a6914ff4), if this action is not used anymore, I think we should delete it?

<img width="839" alt="image" src="https://github.com/scroll-tech/scroll/assets/174255298/cd9b59f9-3146-4e35-9bc1-cec45ec71bc3">
