### PR TITLE
Fix Directory Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@
 ├── <a href="./common/">common</a>: Common libraries and types
 ├── <a href="./coordinator/">coordinator</a>: Prover coordinator service that dispatches proving tasks to provers
 ├── <a href="./database">database</a>: Database client and schema definition
-├── <a href="./src">l2geth</a>: Scroll execution node
 ├── <a href="./prover">prover</a>: Prover client that runs proof generation for zkEVM circuit and aggregation circuit
 ├── <a href="./rollup">rollup</a>: Rollup-related services
-├── <a href="./rpc-gateway">rpc-gateway</a>: RPC gateway external repo
+├── <a href="./scroll-contract">scroll-contract</a>: Rollup-related solidity smart contract
 └── <a href="./tests">tests</a>: Integration tests
 </pre>
 


### PR DESCRIPTION
`l2geth & rpc-gateway` folders had been removed for a long time.

`scroll-contract` folder is missing