### PR TITLE
ci(Makefile): add missing help msg of Makefile target `update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Display this help message
 	@grep -h \
 		-E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-update:
+update: ## Update dependencies
 	go work sync
 	cd $(PWD)/bridge-history-api/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
 	cd $(PWD)/common/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG}&& go mod tidy
@@ -15,14 +15,14 @@ update:
 	cd $(PWD)/rollup/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
 	cd $(PWD)/tests/integration-test/ && go get -u github.com/scroll-tech/go-ethereum@${L2GETH_TAG} && go mod tidy
 
-lint: ## The code's format and security checks.
+lint: ## The code's format and security checks
 	make -C rollup lint
 	make -C common lint
 	make -C coordinator lint
 	make -C database lint
 	make -C bridge-history-api lint
 
-fmt: ## format the code
+fmt: ## Format the code
 	go work sync
 	cd $(PWD)/bridge-history-api/ && go mod tidy
 	cd $(PWD)/common/ && go mod tidy
@@ -38,7 +38,7 @@ fmt: ## format the code
 	goimports -local $(PWD)/rollup/ -w .
 	goimports -local $(PWD)/tests/integration-test/ -w .
 
-dev_docker: ## build docker images for development/testing usages
+dev_docker: ## Build docker images for development/testing usages
 	docker pull postgres
 	docker build -t scroll_l1geth ./common/testcontainers/docker/l1geth/
 	docker build -t scroll_l2geth ./common/testcontainers/docker/l2geth/


### PR DESCRIPTION
### Purpose or design rationale of this PR

ci(Makefile): add missing help msg of Makefile target `update` and keep targets help message format consistent

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [x] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
