### PR TITLE
prover(branch): `release/v0.12.0`

### DIFF
--- a/common/libzkp/impl/Cargo.lock
+++ b/common/libzkp/impl/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "ark-std 0.3.0",
  "bitstream-io",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "bus-mapping"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "eth-types 0.12.0",
  "ethers-core",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "base64 0.13.1",
  "ethers-core",
@@ -1383,7 +1383,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "eth-types 0.12.0",
  "geth-utils 0.12.0",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "eth-types 0.12.0",
  "halo2_proofs",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "env_logger 0.10.0",
  "gobuild",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "eth-types 0.12.0",
  "ethers-core",
@@ -2403,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "eth-types 0.12.0",
  "halo2curves",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "aggregator 0.12.0",
  "anyhow",
@@ -4588,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.12.0-rc.2#86158b58907aac1c4c8f43ce9d5b29170d309401"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?branch=release/v0.12.0#d93717c4fe6df6451eeac6b05279c39d7927bb93"
 dependencies = [
  "array-init",
  "bus-mapping 0.12.0",

--- a/common/libzkp/impl/Cargo.toml
+++ b/common/libzkp/impl/Cargo.toml
@@ -29,7 +29,7 @@ snark-verifier-sdk = { git = "https://github.com/scroll-tech/snark-verifier", br
 # curie
 prover_v3 = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.4", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
 # darwin
-prover_v4 = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.12.0-rc.2", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
+prover_v4 = { git = "https://github.com/scroll-tech/zkevm-circuits.git", branch = "release/v0.12.0", package = "prover", default-features = false, features = ["parallel_syn", "scroll"] }
 
 base64 = "0.13.0"
 env_logger = "0.9.0"

--- a/common/libzkp/impl/src/batch.rs
+++ b/common/libzkp/impl/src/batch.rs
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn verify_batch_proof(
             // Post upgrade #4 (Darwin), batch proofs are not EVM-verifiable. Instead they are
             // halo2 proofs meant to be bundled recursively.
             let proof = serde_json::from_slice::<BatchProofV4>(proof.as_slice()).unwrap();
-            VERIFIER_V4.get().unwrap().verify_batch_proof(proof)
+            VERIFIER_V4.get().unwrap().verify_batch_proof(&proof)
         }
     });
     verified.unwrap_or(false) as c_char


### PR DESCRIPTION
### Purpose or design rationale of this PR

Update `prover` version before we switch back to `tag = "v0.12.0-rc.3"` or `tag = "v0.12.0"`