### PR TITLE
feat(rollup-relayer): make chunk & batch proposal intervals configurable

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.33"
+var tag = "v4.4.34"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/cmd/rollup_relayer/app/app.go
+++ b/rollup/cmd/rollup_relayer/app/app.go
@@ -106,9 +106,9 @@ func action(ctx *cli.Context) error {
 		l2watcher.TryFetchRunningMissingBlocks(number)
 	})
 
-	go utils.Loop(subCtx, 2*time.Second, chunkProposer.TryProposeChunk)
+	go utils.Loop(subCtx, time.Duration(cfg.L2Config.ChunkProposalIntervalMilliseconds)*time.Millisecond, chunkProposer.TryProposeChunk)
 
-	go utils.Loop(subCtx, 10*time.Second, batchProposer.TryProposeBatch)
+	go utils.Loop(subCtx, time.Duration(cfg.L2Config.BatchProposalIntervalMilliseconds)*time.Millisecond, batchProposer.TryProposeBatch)
 
 	go utils.Loop(subCtx, 2*time.Second, l2relayer.ProcessPendingBatches)
 

--- a/rollup/cmd/rollup_relayer/app/app.go
+++ b/rollup/cmd/rollup_relayer/app/app.go
@@ -106,9 +106,9 @@ func action(ctx *cli.Context) error {
 		l2watcher.TryFetchRunningMissingBlocks(number)
 	})
 
-	go utils.Loop(subCtx, time.Duration(cfg.L2Config.ChunkProposalIntervalMilliseconds)*time.Millisecond, chunkProposer.TryProposeChunk)
+	go utils.Loop(subCtx, time.Duration(cfg.L2Config.ChunkProposerConfig.ProposeIntervalMilliseconds)*time.Millisecond, chunkProposer.TryProposeChunk)
 
-	go utils.Loop(subCtx, time.Duration(cfg.L2Config.BatchProposalIntervalMilliseconds)*time.Millisecond, batchProposer.TryProposeBatch)
+	go utils.Loop(subCtx, time.Duration(cfg.L2Config.BatchProposerConfig.ProposeIntervalMilliseconds)*time.Millisecond, batchProposer.TryProposeBatch)
 
 	go utils.Loop(subCtx, 2*time.Second, l2relayer.ProcessPendingBatches)
 

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -61,6 +61,7 @@
       "l1_commit_gas_limit_multiplier": 1.2
     },
     "chunk_proposer_config": {
+      "propose_interval_milliseconds": 100,
       "max_block_num_per_chunk": 100,
       "max_tx_num_per_chunk": 100,
       "max_l1_commit_gas_per_chunk": 11234567,
@@ -71,14 +72,13 @@
       "max_uncompressed_batch_bytes_size": 634880
     },
     "batch_proposer_config": {
+      "propose_interval_milliseconds": 1000,
       "max_l1_commit_gas_per_batch": 11234567,
       "max_l1_commit_calldata_size_per_batch": 112345,
       "batch_timeout_sec": 300,
       "gas_cost_increase_multiplier": 1.2,
       "max_uncompressed_batch_bytes_size": 634880
-    },
-    "chunk_proposal_interval_milliseconds": 100,
-    "batch_proposal_interval_milliseconds": 1000
+    }
   },
   "db_config": {
     "driver_name": "postgres",

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -77,8 +77,8 @@
       "gas_cost_increase_multiplier": 1.2,
       "max_uncompressed_batch_bytes_size": 634880
     },
-    "chunk_proposal_interval_milliseconds": 0,
-    "batch_proposal_interval_milliseconds": 0
+    "chunk_proposal_interval_milliseconds": 100,
+    "batch_proposal_interval_milliseconds": 1000
   },
   "db_config": {
     "driver_name": "postgres",

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -76,7 +76,9 @@
       "batch_timeout_sec": 300,
       "gas_cost_increase_multiplier": 1.2,
       "max_uncompressed_batch_bytes_size": 634880
-    }
+    },
+    "chunk_proposal_interval_milliseconds": 0,
+    "batch_proposal_interval_milliseconds": 0
   },
   "db_config": {
     "driver_name": "postgres",

--- a/rollup/internal/config/l2.go
+++ b/rollup/internal/config/l2.go
@@ -22,6 +22,10 @@ type L2Config struct {
 	ChunkProposerConfig *ChunkProposerConfig `json:"chunk_proposer_config"`
 	// The batch_proposer config
 	BatchProposerConfig *BatchProposerConfig `json:"batch_proposer_config"`
+	// The interval between chunk proposals in milliseconds
+	ChunkProposalIntervalMilliseconds int `json:"chunk_proposal_interval_milliseconds"`
+	// The interval between batch proposals in milliseconds
+	BatchProposalIntervalMilliseconds int `json:"batch_proposal_interval_milliseconds"`
 }
 
 // ChunkProposerConfig loads chunk_proposer configuration items.

--- a/rollup/internal/config/l2.go
+++ b/rollup/internal/config/l2.go
@@ -22,14 +22,11 @@ type L2Config struct {
 	ChunkProposerConfig *ChunkProposerConfig `json:"chunk_proposer_config"`
 	// The batch_proposer config
 	BatchProposerConfig *BatchProposerConfig `json:"batch_proposer_config"`
-	// The interval between chunk proposals in milliseconds
-	ChunkProposalIntervalMilliseconds int `json:"chunk_proposal_interval_milliseconds"`
-	// The interval between batch proposals in milliseconds
-	BatchProposalIntervalMilliseconds int `json:"batch_proposal_interval_milliseconds"`
 }
 
 // ChunkProposerConfig loads chunk_proposer configuration items.
 type ChunkProposerConfig struct {
+	ProposeIntervalMilliseconds     uint64  `json:"propose_interval_milliseconds"`
 	MaxBlockNumPerChunk             uint64  `json:"max_block_num_per_chunk"`
 	MaxTxNumPerChunk                uint64  `json:"max_tx_num_per_chunk"`
 	MaxL1CommitGasPerChunk          uint64  `json:"max_l1_commit_gas_per_chunk"`
@@ -42,6 +39,7 @@ type ChunkProposerConfig struct {
 
 // BatchProposerConfig loads batch_proposer configuration items.
 type BatchProposerConfig struct {
+	ProposeIntervalMilliseconds     uint64  `json:"propose_interval_milliseconds"`
 	MaxL1CommitGasPerBatch          uint64  `json:"max_l1_commit_gas_per_batch"`
 	MaxL1CommitCalldataSizePerBatch uint64  `json:"max_l1_commit_calldata_size_per_batch"`
 	BatchTimeoutSec                 uint64  `json:"batch_timeout_sec"`


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR makes chunk & batch proposal intervals configurable.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
