### PR TITLE
fix(coordinator): add compatible logic to jwt when curie prover not adding public_key in login request

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.39"
+var tag = "v4.4.40"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/controller/api/auth.go
+++ b/coordinator/internal/controller/api/auth.go
@@ -66,7 +66,7 @@ func (a *AuthController) PayloadFunc(data interface{}) jwt.MapClaims {
 		if err != nil {
 			// do not handle error here since already called v.Verify() beforehands so there should be no error
 			// add log just in case some error happens
-			log.Error("failed to recover public key from signature", "error", err.Error())
+			log.Error("impossible path: failed to recover public key from signature", "error", err.Error())
 		}
 	}
 

--- a/coordinator/internal/types/auth.go
+++ b/coordinator/internal/types/auth.go
@@ -77,6 +77,22 @@ func (a *LoginParameter) Verify() (bool, error) {
 	return isValid, nil
 }
 
+// RecoverPublicKeyFromSignature get public key from signature.
+// This method is for pre-darwin's compatible.
+func (a *LoginParameter) RecoverPublicKeyFromSignature() (string, error) {
+	hash, err := a.Message.Hash()
+	if err != nil {
+		return "", err
+	}
+	sig := common.FromHex(a.Signature)
+	// recover public key
+	pk, err := crypto.SigToPub(hash, sig)
+	if err != nil {
+		return "", err
+	}
+	return common.Bytes2Hex(crypto.CompressPubkey(pk)), nil
+}
+
 // Hash returns the hash of the auth message, which should be the message used
 // to construct the Signature.
 func (i *Message) Hash() ([]byte, error) {


### PR DESCRIPTION

### Purpose or design rationale of this PR

add compatible logic to jwt when curie prover not adding public_key in login request


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
