### PR TITLE
refactor(coordinator): remove unused metrics

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.43"
+var tag = "v4.4.44"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -29,7 +29,6 @@ import (
 type BatchProverTask struct {
 	BaseProverTask
 
-	batchAttemptsExceedTotal prometheus.Counter
 	batchTaskGetTaskTotal    *prometheus.CounterVec
 	batchTaskGetTaskProver   *prometheus.CounterVec
 }
@@ -47,10 +46,6 @@ func NewBatchProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *go
 			proverTaskOrm:      orm.NewProverTask(db),
 			proverBlockListOrm: orm.NewProverBlockList(db),
 		},
-		batchAttemptsExceedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "coordinator_batch_attempts_exceed_total",
-			Help: "Total number of batch attempts exceed.",
-		}),
 		batchTaskGetTaskTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "coordinator_batch_get_task_total",
 			Help: "Total number of batch get task.",

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -29,8 +29,8 @@ import (
 type BatchProverTask struct {
 	BaseProverTask
 
-	batchTaskGetTaskTotal    *prometheus.CounterVec
-	batchTaskGetTaskProver   *prometheus.CounterVec
+	batchTaskGetTaskTotal  *prometheus.CounterVec
+	batchTaskGetTaskProver *prometheus.CounterVec
 }
 
 // NewBatchProverTask new a batch collector

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -27,9 +27,8 @@ import (
 type BundleProverTask struct {
 	BaseProverTask
 
-	bundleAttemptsExceedTotal prometheus.Counter
-	bundleTaskGetTaskTotal    *prometheus.CounterVec
-	bundleTaskGetTaskProver   *prometheus.CounterVec
+	bundleTaskGetTaskTotal  *prometheus.CounterVec
+	bundleTaskGetTaskProver *prometheus.CounterVec
 }
 
 // NewBundleProverTask new a bundle collector
@@ -46,10 +45,6 @@ func NewBundleProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *g
 			proverTaskOrm:      orm.NewProverTask(db),
 			proverBlockListOrm: orm.NewProverBlockList(db),
 		},
-		bundleAttemptsExceedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "coordinator_bundle_attempts_exceed_total",
-			Help: "Total number of bundle attempts exceed.",
-		}),
 		bundleTaskGetTaskTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "coordinator_bundle_get_task_total",
 			Help: "Total number of bundle get task.",

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -27,8 +27,8 @@ import (
 type ChunkProverTask struct {
 	BaseProverTask
 
-	chunkTaskGetTaskTotal    *prometheus.CounterVec
-	chunkTaskGetTaskProver   *prometheus.CounterVec
+	chunkTaskGetTaskTotal  *prometheus.CounterVec
+	chunkTaskGetTaskProver *prometheus.CounterVec
 }
 
 // NewChunkProverTask new a chunk prover task

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -27,7 +27,6 @@ import (
 type ChunkProverTask struct {
 	BaseProverTask
 
-	chunkAttemptsExceedTotal prometheus.Counter
 	chunkTaskGetTaskTotal    *prometheus.CounterVec
 	chunkTaskGetTaskProver   *prometheus.CounterVec
 }
@@ -44,10 +43,6 @@ func NewChunkProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *go
 			proverTaskOrm:      orm.NewProverTask(db),
 			proverBlockListOrm: orm.NewProverBlockList(db),
 		},
-		chunkAttemptsExceedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "coordinator_chunk_attempts_exceed_total",
-			Help: "Total number of chunk attempts exceed.",
-		}),
 		chunkTaskGetTaskTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "coordinator_chunk_get_task_total",
 			Help: "Total number of chunk get task.",


### PR DESCRIPTION
### Purpose or design rationale of this PR

These metrics are replaced by querying the db from rollupscan-monitor directly.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
