### PR TITLE
feat(prover): log utilization

### DIFF
--- a/prover/src/coordinator_client.rs
+++ b/prover/src/coordinator_client.rs
@@ -14,6 +14,8 @@ use types::*;
 
 use crate::{config::Config, key_signer::KeySigner};
 
+pub use errors::ProofStatusNotOKError;
+
 pub struct CoordinatorClient<'a> {
     api: Api,
     token: Option<String>,

--- a/prover/src/coordinator_client/errors.rs
+++ b/prover/src/coordinator_client/errors.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Deserializer};
+use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ErrorCode {
@@ -49,5 +50,16 @@ impl<'de> Deserialize<'de> for ErrorCode {
     {
         let v: i32 = i32::deserialize(deserializer)?;
         Ok(ErrorCode::from_i32(v))
+    }
+}
+
+// ====================================================
+
+#[derive(Debug, Clone)]
+pub struct ProofStatusNotOKError;
+
+impl fmt::Display for ProofStatusNotOKError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "proof status not ok")
     }
 }

--- a/prover/src/main.rs
+++ b/prover/src/main.rs
@@ -37,7 +37,7 @@ struct Args {
     log_file: Option<String>,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn start() -> Result<()> {
     let args = Args::parse();
 
     if args.version {
@@ -75,4 +75,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     task_processor.start();
 
     Ok(())
+}
+
+fn main() {
+    let result = start();
+    if let Err(e) = result {
+        log::error!("main exit with error {:#}", e)
+    }
 }

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -112,17 +112,7 @@ impl<'a> Prover<'a> {
             ..Default::default()
         };
 
-        match handler.get_proof_data(task.task_type, task) {
-            Err(e) => {
-                log::error!(
-                    "[prover] failed to get_proof_data, task id {}, error: {:#}",
-                    task.id,
-                    e
-                );
-            }
-            Result::Ok(proof) => proof_detail.proof_data = proof,
-        }
-
+        proof_detail.proof_data = handler.get_proof_data(task.task_type, task)?;
         Ok(proof_detail)
     }
 

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -112,7 +112,13 @@ impl<'a> Prover<'a> {
             ..Default::default()
         };
 
-        proof_detail.proof_data = handler.get_proof_data(task.task_type, task)?;
+        match handler.get_proof_data(task.task_type, task) {
+            Err(e) => {
+                log::error!("[prover] failed to get_proof_data, task id {}, error: {:#}", task.id, e);
+            },
+            Result::Ok(proof) => proof_detail.proof_data = proof,
+        }
+
         Ok(proof_detail)
     }
 

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -114,8 +114,12 @@ impl<'a> Prover<'a> {
 
         match handler.get_proof_data(task.task_type, task) {
             Err(e) => {
-                log::error!("[prover] failed to get_proof_data, task id {}, error: {:#}", task.id, e);
-            },
+                log::error!(
+                    "[prover] failed to get_proof_data, task id {}, error: {:#}",
+                    task.id,
+                    e
+                );
+            }
             Result::Ok(proof) => proof_detail.proof_data = proof,
         }
 

--- a/prover/src/task_processor.rs
+++ b/prover/src/task_processor.rs
@@ -59,13 +59,17 @@ impl<'a> TaskProcessor<'a> {
             let result = match self.prover.prove_task(&task_wrapper.task) {
                 Ok(proof_detail) => self.prover.submit_proof(proof_detail, &task_wrapper.task),
                 Err(error) => {
-                    log::error!("failed to prove task, id: {}, error: {:#}", &task_wrapper.task.id, error);
+                    log::error!(
+                        "failed to prove task, id: {}, error: {:#}",
+                        &task_wrapper.task.id,
+                        error
+                    );
                     self.prover.submit_error(
                         &task_wrapper.task,
                         super::types::ProofFailureType::NoPanic,
                         error,
                     )
-                },
+                }
             };
             return result;
         }

--- a/prover/src/task_processor.rs
+++ b/prover/src/task_processor.rs
@@ -58,11 +58,14 @@ impl<'a> TaskProcessor<'a> {
             );
             let result = match self.prover.prove_task(&task_wrapper.task) {
                 Ok(proof_detail) => self.prover.submit_proof(proof_detail, &task_wrapper.task),
-                Err(error) => self.prover.submit_error(
-                    &task_wrapper.task,
-                    super::types::ProofFailureType::NoPanic,
-                    error,
-                ),
+                Err(error) => {
+                    log::error!("failed to prove task, id: {}, error: {:#}", &task_wrapper.task.id, error);
+                    self.prover.submit_error(
+                        &task_wrapper.task,
+                        super::types::ProofFailureType::NoPanic,
+                        error,
+                    )
+                },
             };
             return result;
         }

--- a/prover/src/task_processor.rs
+++ b/prover/src/task_processor.rs
@@ -1,4 +1,4 @@
-use super::{prover::Prover, task_cache::TaskCache};
+use super::{coordinator_client::ProofStatusNotOKError, prover::Prover, task_cache::TaskCache};
 use anyhow::{Context, Result};
 use std::rc::Rc;
 
@@ -16,7 +16,11 @@ impl<'a> TaskProcessor<'a> {
         loop {
             log::info!("start a new round.");
             if let Err(err) = self.prove_and_submit() {
-                log::error!("encounter error: {:#}", err);
+                if err.is::<ProofStatusNotOKError>() {
+                    log::info!("proof status not ok, downgrade level to info.");
+                } else {
+                    log::error!("encounter error: {:#}", err);
+                }
             } else {
                 log::info!("prove & submit succeed.");
             }

--- a/prover/src/zk_circuits_handler.rs
+++ b/prover/src/zk_circuits_handler.rs
@@ -119,7 +119,6 @@ impl<'a> CircuitsHandlerProvider<'a> {
                 if let Some(handler) = &self.current_circuit {
                     Ok(handler.clone())
                 } else {
-                    log::error!("missing cached handler, there must be something wrong.");
                     bail!("missing cached handler, there must be something wrong.")
                 }
             }
@@ -136,7 +135,6 @@ impl<'a> CircuitsHandlerProvider<'a> {
                     self.current_circuit = Some(rc_handler.clone());
                     Ok(rc_handler)
                 } else {
-                    log::error!("missing builder, there must be something wrong.");
                     bail!("missing builder, there must be something wrong.")
                 }
             }


### PR DESCRIPTION
### Purpose or design rationale of this PR

log utilization
- add detailed log in main.rs
- add error log when failed to prove task, such as failed to get trace from l2geth
- no longer adding error log when prover already knows it's submitting an error

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
