### PR TITLE
fix(gas-oracle): excluded genesis batch when check commit batch timeout

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.48"
+var tag = "v4.4.49"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -290,5 +290,6 @@ func (r *Layer1Relayer) commitBatchReachTimeout() (bool, error) {
 		return false, err
 	}
 	// len(batches) == 0 probably shouldn't ever happen, but need to check this
-	return len(batches) == 0 || utils.NowUTC().Sub(*batches[0].CommittedAt) > time.Duration(r.cfg.GasOracleConfig.CheckCommittedBatchesWindowMinutes)*time.Minute, nil
+	// Also, we should check if it's a genesis batch. If so, skip the timeout check.
+	return len(batches) == 0 || (batches[0].Index != 0 && utils.NowUTC().Sub(*batches[0].CommittedAt) > time.Duration(r.cfg.GasOracleConfig.CheckCommittedBatchesWindowMinutes)*time.Minute), nil
 }

--- a/rollup/tests/gas_oracle_test.go
+++ b/rollup/tests/gas_oracle_test.go
@@ -221,13 +221,21 @@ func testImportDefaultL1GasPriceDueToL1GasPriceSpike(t *testing.T) {
 			},
 		},
 	}
-	batch := &encoding.Batch{
+	batch0 := &encoding.Batch{
 		Index:                      0,
 		TotalL1MessagePoppedBefore: 0,
 		ParentBatchHash:            common.Hash{},
 		Chunks:                     []*encoding.Chunk{chunk},
 	}
+	batch := &encoding.Batch{
+		Index:                      1,
+		TotalL1MessagePoppedBefore: 0,
+		ParentBatchHash:            common.Hash{},
+		Chunks:                     []*encoding.Chunk{chunk},
+	}
 	batchOrm := orm.NewBatch(db)
+	_, err = batchOrm.InsertBatch(context.Background(), batch0, utils.CodecConfig{Version: encoding.CodecV0}, utils.BatchMetrics{})
+	assert.NoError(t, err)
 	dbBatch, err := batchOrm.InsertBatch(context.Background(), batch, utils.CodecConfig{Version: encoding.CodecV0}, utils.BatchMetrics{})
 	assert.NoError(t, err)
 	err = batchOrm.UpdateCommitTxHashAndRollupStatus(context.Background(), dbBatch.Hash, common.Hash{}.String(), types.RollupCommitted)


### PR DESCRIPTION
### Purpose or design rationale of this PR

In gas oracle, when it comes to function `commitBatchReachTimeout`, there will be a `nil pointer dereference` error if we get the genesis batch. Because genesis batch doesn't have `CommittedAt` field.
So we skip the `commitBatchReachTimeout` check if it a genesis batch.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
