### PR TITLE
feat(database): allow environment variables to override config.json

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.59"
+var tag = "v4.4.60"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/database/config.go
+++ b/database/config.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"scroll-tech/common/utils"
 )
 
 // DBConfig db config
@@ -25,6 +27,12 @@ func NewConfig(file string) (*DBConfig, error) {
 
 	cfg := &DBConfig{}
 	err = json.Unmarshal(buf, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Override config with environment variables
+	err = utils.OverrideConfigWithEnv(cfg, "SCROLL_ROLLUP_DB_CONFIG")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR

To allow database config file to be override using environmental variables.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
