### PR TITLE
feat(l2-watcher): add nil row consumption block metric

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.60"
+var tag = "v4.4.61"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/watcher/l2_watcher.go
+++ b/rollup/internal/controller/watcher/l2_watcher.go
@@ -127,6 +127,7 @@ func (w *L2WatcherClient) getAndStoreBlocks(ctx context.Context, from, to uint64
 			return fmt.Errorf("failed to GetBlockByNumberOrHash: %v. number: %v", err, number)
 		}
 		if block.RowConsumption == nil {
+			w.metrics.fetchNilRowConsumptionBlockTotal.Inc()
 			return fmt.Errorf("fetched block does not contain RowConsumption. number: %v", number)
 		}
 

--- a/rollup/internal/controller/watcher/l2_watcher_metrics.go
+++ b/rollup/internal/controller/watcher/l2_watcher_metrics.go
@@ -12,6 +12,7 @@ type l2WatcherMetrics struct {
 	fetchRunningMissingBlocksHeight   prometheus.Gauge
 	rollupL2BlocksFetchedGap          prometheus.Gauge
 	rollupL2BlockL1CommitCalldataSize prometheus.Gauge
+	fetchNilRowConsumptionBlockTotal  prometheus.Counter
 }
 
 var (
@@ -37,6 +38,10 @@ func initL2WatcherMetrics(reg prometheus.Registerer) *l2WatcherMetrics {
 			rollupL2BlockL1CommitCalldataSize: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 				Name: "rollup_l2_block_l1_commit_calldata_size",
 				Help: "The l1 commitBatch calldata size of the l2 block",
+			}),
+			fetchNilRowConsumptionBlockTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+				Name: "rollup_l2_watcher_fetch_nil_row_consumption_block_total",
+				Help: "The total number of occurrences where a fetched block has nil RowConsumption",
 			}),
 		}
 	})


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR adds a metric to track the number of times that l2 watcher fetches a block with nil row consumption:
When it's added, there are two cases:
(i) this field is temporarily missed in the internal node, and it will be recovered shortly after async ccc fills it.
(ii) a bug case: either the signer or internal node generates a block without row consumption.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
