### PR TITLE
fix(rollup-relayer): wrong registration of metric

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.62"
+var tag = "v4.4.63"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/watcher/l2_watcher_metrics.go
+++ b/rollup/internal/controller/watcher/l2_watcher_metrics.go
@@ -45,7 +45,7 @@ func initL2WatcherMetrics(reg prometheus.Registerer) *l2WatcherMetrics {
 				Name: "rollup_l2_watcher_fetch_nil_row_consumption_block_total",
 				Help: "The total number of occurrences where a fetched block has nil RowConsumption",
 			}),
-			rollupL2WatcherSyncThroughput: prometheus.NewCounter(prometheus.CounterOpts{
+			rollupL2WatcherSyncThroughput: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 				Name: "rollup_l2_watcher_sync_throughput",
 				Help: "The cumulative gas used in blocks that L2 watcher sync",
 			}),


### PR DESCRIPTION
### Purpose or design rationale of this PR

found this one when configuring metrics. others look good.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
