### PR TITLE
docs: reference to a section that does not exist

### DIFF
--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -20,8 +20,6 @@ The built coordinator binary is in the `build/bin` directory.
 
 ## Test
 
-**Note:** Our test code may not directly support Apple Silicon (M1/M2) chips. However, we've provided a Docker-based solution for local testing on M1/M2 Macs. Please refer to the [Local Testing on M1/M2 Mac](../README.md#local-testing-on-m1m2-mac) section in the main README for details. After preparing the environment, you can then proceed with the testing.
-
 When developing the coordinator, use the following command to mock verifier results and run coordinator tests:
 
 ```bash

--- a/rollup/README.md
+++ b/rollup/README.md
@@ -1,9 +1,10 @@
 # Rollup
 
-This directory contains the three essential rollup services for the Scroll chain:
+This directory contains the two essential rollup services for the Scroll chain:
 - Gas Oracle (<a href="./cmd/gas_oracle/">gas_oracle</a>): monitors the L1 and L2 gas price and sends transactions to update the gas price oracle contracts on L1 and L2.
-- Rollup Relayer (<a href="./cmd/rollup_relayer/">rollup_relayer</a>): consists of three components: chunk and batch proposer and a relayer.
-    - The chunk and batch proposer proposes new chunks and batches that sends Commit Transactions for data availability and Finalize Transactions for proof verification and state finalization.
+- Rollup Relayer (<a href="./cmd/rollup_relayer/">rollup_relayer</a>): consists of two components: chunk and batch proposer and a relayer.
+    - The chunk and batch proposer proposes new chunks and batches that send Commit Transactions for data availability and Finalize Transactions for proof verification and state finalization.
+    - The relayer handles the submission of transactions to the network.
 
 ## Dependency
 
@@ -15,7 +16,7 @@ go install -v github.com/scroll-tech/go-ethereum/cmd/abigen
 
 2. `solc`
 
-Ensure you install the version of solc required by [MockBridge.sol](./mock_bridge/MockBridge.sol#L2) (e.g., 0.8.24). See https://docs.soliditylang.org/en/latest/installing-solidity.html
+Ensure you install the version of solc required by [MockBridge.sol](./mock_bridge/MockBridge.sol#L2) (e.g., 0.8.24). See [Installing the Solidity Compiler](https://docs.soliditylang.org/en/latest/installing-solidity.html)
 
 ## Build
 


### PR DESCRIPTION
closes #1535 

### Purpose or design rationale of this PR

This pull request addresses two primary issues in the project’s documentation to enhance its accuracy and usability:

### First is Fixing Reference to a Non-Existent Section:

### Description of Changes:
Removed the "Note: ..."  section from the Test section in [coordinator/README.md](https://github.com/scroll-tech/scroll/blob/develop/coordinator/README.md). This block previously contained a link to a non-existent section [Local Testing on M1/M2 Mac](https://github.com/scroll-tech/scroll/README.md#local-testing-on-m1m2-mac), resulting in broken links.

Deleted Broken Link: Removed the reference to the [Local Testing on M1/M2 Mac](https://github.com/scroll-tech/scroll/README.md#local-testing-on-m1m2-mac) section from the main README.md. This eliminates the issue of users encountering dead links, thereby improving the reliability of the documentation.

### Motivation:
The existing "Note: ..." block contained a link to a section that does not exist in the main README.md, leading to broken links. This can confuse developers and hinder their ability to follow the documentation effectively. Removing these elements ensures that the documentation remains accurate and user-friendly.

	
### Second is Correcting Errors in rollup/README.md:

### Description of Changes:
Updated Number of Services: Changed the description in [rollup/README.md](https://github.com/scroll-tech/scroll/blob/develop/rollup/README.md) from three essential rollup services to two essential rollup services, reflecting the actual number of services present in the [cmd](https://github.com/scroll-tech/scroll/tree/develop/rollup/cmd) directory (gas_oracle and rollup_relayer).

Adjusted Number of Components: Modified the Rollup Relayer section in [rollup/README.md](https://github.com/scroll-tech/scroll/blob/develop/rollup/README.md) to indicate that it consists of two components instead of three, aligning with the actual implementation.

Converted HTML Links to Markdown: Replaced HTML <a> tags with Markdown link syntax in rollup/README.md for consistency and improved readability across the documentation.
### Motivation
The original documentation incorrectly stated the number of services and components, leading to potential misunderstandings about the project’s architecture. Additionally, using consistent Markdown syntax for links enhances the overall readability and maintainability of the documentation.




### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [x] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
