### PR TITLE
fix(rollup-relayer): wrong l1 messages popped num

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.69"
+var tag = "v4.4.70"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -260,7 +260,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	if err != nil {
 		log.Error("failed to create new DA batch",
 			"index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, err
 	}
 
@@ -268,7 +268,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	parentBatch, err := o.GetLatestBatch(ctx)
 	if err != nil {
 		log.Error("failed to get latest batch", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
@@ -282,14 +282,14 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	startDAChunk, err := codec.NewDAChunk(batch.Chunks[0], batch.TotalL1MessagePoppedBefore)
 	if err != nil {
 		log.Error("failed to create start DA chunk", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
 	startDAChunkHash, err := startDAChunk.Hash()
 	if err != nil {
 		log.Error("failed to get start DA chunk hash", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
@@ -300,14 +300,14 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	endDAChunk, err := codec.NewDAChunk(batch.Chunks[numChunks-1], totalL1MessagePoppedBeforeEndDAChunk)
 	if err != nil {
 		log.Error("failed to create end DA chunk", "index", batch.Index, "total l1 message popped before", totalL1MessagePoppedBeforeEndDAChunk,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
 	endDAChunkHash, err := endDAChunk.Hash()
 	if err != nil {
 		log.Error("failed to get end DA chunk hash", "index", batch.Index, "total l1 message popped before", totalL1MessagePoppedBeforeEndDAChunk,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -265,7 +265,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVer
 		parentBatch, getErr := o.GetBatchByIndex(ctx, batch.Index-1)
 		if getErr != nil {
 			log.Error("failed to get batch by index", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-				"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", getErr)
+				"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", getErr)
 			return nil, fmt.Errorf("Batch.InsertBatch error: %w", getErr)
 		}
 		startChunkIndex = parentBatch.EndChunkIndex + 1
@@ -274,14 +274,14 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVer
 	batchMeta, err := rutils.GetBatchMetadata(batch, codecVersion)
 	if err != nil {
 		log.Error("failed to get batch metadata", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
 	enableCompress, err := encoding.GetBatchEnableCompression(codecVersion, batch)
 	if err != nil {
 		log.Error("failed to get batch enable compress", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 

--- a/rollup/internal/utils/utils.go
+++ b/rollup/internal/utils/utils.go
@@ -199,7 +199,7 @@ func GetBatchMetadata(batch *encoding.Batch, codecVersion encoding.CodecVersion)
 		return nil, fmt.Errorf("failed to get start DA chunk hash, version: %v, err: %w", codecVersion, err)
 	}
 
-	var totalL1MessagePoppedBeforeEndDAChunk uint64
+	totalL1MessagePoppedBeforeEndDAChunk := batch.TotalL1MessagePoppedBefore
 	for i := 0; i < len(batch.Chunks)-1; i++ {
 		totalL1MessagePoppedBeforeEndDAChunk += batch.Chunks[i].NumL1Messages(totalL1MessagePoppedBeforeEndDAChunk)
 	}

--- a/tests/integration-test/orm/batch.go
+++ b/tests/integration-test/orm/batch.go
@@ -106,7 +106,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	if err != nil {
 		log.Error("failed to create new DA batch",
 			"index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, err
 	}
 
@@ -114,7 +114,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	parentBatch, err := o.GetLatestBatch(ctx)
 	if err != nil {
 		log.Error("failed to get latest batch", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
@@ -128,14 +128,14 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	startDAChunk, err := codec.NewDAChunk(batch.Chunks[0], batch.TotalL1MessagePoppedBefore)
 	if err != nil {
 		log.Error("failed to create start DA chunk", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
 	startDAChunkHash, err := startDAChunk.Hash()
 	if err != nil {
 		log.Error("failed to get start DA chunk hash", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
@@ -146,14 +146,14 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, dbTX ...
 	endDAChunk, err := codec.NewDAChunk(batch.Chunks[numChunks-1], totalL1MessagePoppedBeforeEndDAChunk)
 	if err != nil {
 		log.Error("failed to create end DA chunk", "index", batch.Index, "total l1 message popped before", totalL1MessagePoppedBeforeEndDAChunk,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 
 	endDAChunkHash, err := endDAChunk.Hash()
 	if err != nil {
 		log.Error("failed to get end DA chunk hash", "index", batch.Index, "total l1 message popped before", totalL1MessagePoppedBeforeEndDAChunk,
-			"parent hash", batch.ParentBatchHash, "number of chunks", numChunks, "err", err)
+			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versioning information to version 4.4.70.
  
- **Bug Fixes**
	- Improved error logging by converting `ParentBatchHash` to hexadecimal format in multiple locations, enhancing clarity in logs.

- **Chores**
	- Simplified variable initialization in the `GetBatchMetadata` function for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->