### PR TITLE
feat(coordinator): add version check for sdk provers

### DIFF
--- a/common/version/prover_version.go
+++ b/common/version/prover_version.go
@@ -9,6 +9,10 @@ import (
 
 // CheckScrollProverVersion check the "scroll-prover" version, if it's different from the local one, return false
 func CheckScrollProverVersion(proverVersion string) bool {
+	if strings.HasPrefix(proverVersion, "sdk") {
+		return CheckProverSDKVersion(proverVersion)
+	}
+
 	// note the version is in fact in the format of "tag-commit-scroll_prover-halo2",
 	// so split-by-'-' length should be 4
 	remote := strings.Split(proverVersion, "-")
@@ -23,8 +27,18 @@ func CheckScrollProverVersion(proverVersion string) bool {
 	return remote[2] == local[2]
 }
 
+// CheckProverSDKVersion check prover sdk version, it simply returns true for now,
+// and more checks will be added as we evolve.
+func CheckProverSDKVersion(proverVersion string) bool {
+	return true
+}
+
 // CheckScrollRepoVersion checks if the proverVersion is at least the minimum required version.
 func CheckScrollRepoVersion(proverVersion, minVersion string) bool {
+	if strings.HasPrefix(proverVersion, "sdk") {
+		return CheckProverSDKWithMinVersion(proverVersion, minVersion)
+	}
+
 	c, err := semver.NewConstraint(">= " + minVersion + "-0")
 	if err != nil {
 		log.Error("failed to initialize constraint", "minVersion", minVersion, "error", err)
@@ -38,4 +52,10 @@ func CheckScrollRepoVersion(proverVersion, minVersion string) bool {
 	}
 
 	return c.Check(v)
+}
+
+// CheckProverSDKWithMinVersion check prover sdk version is at least the minimum required version, it simply returns true for now,
+// and more checks will be added as we evolve.
+func CheckProverSDKWithMinVersion(proverVersion string, minVersion string) bool {
+	return true
 }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.70"
+var tag = "v4.4.71"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.71"
+var tag = "v4.4.72"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Currently the sdk-provers are hard to get the "repo" commit hash and hard to follow the version check we are using in coordinator now: see https://github.com/scroll-tech/scroll-proving-sdk/blob/haoyu/sindri_tokio/src/utils.rs#L5-L9, we have to hardcode a version to bypass the version check for now.

This PR add a dedicated version check mechanism for sdk-prover. And it simply returns true for now. 


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for enhanced SDK version handling in the prover.
	- Added specific checks for SDK versions in existing version validation logic.

- **Bug Fixes**
	- Updated versioning information to reflect the new version number (v4.4.72).

These changes improve the application's capability to manage SDK versions while ensuring existing functionalities remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->