### PR TITLE
fix(rollup-relayer): check if previous bundle or batch is finalized in fake finalize mode

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.72"
+var tag = "v4.4.73"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -586,7 +586,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 			}
 
 			if err := r.finalizeBundle(bundle, false); err != nil {
-				log.Error("Failed to finalize timeout bundle without proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
+				log.Error("failed to finalize timeout bundle without proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
 				return
 			}
 		}
@@ -595,7 +595,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 		log.Info("Start to roll up zk proof", "bundle hash", bundle.Hash)
 		r.metrics.rollupL2RelayerProcessPendingBundlesFinalizedTotal.Inc()
 		if err := r.finalizeBundle(bundle, true); err != nil {
-			log.Error("Failed to finalize bundle with proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
+			log.Error("failed to finalize bundle with proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
 			return
 		}
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -568,6 +568,22 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 	switch status {
 	case types.ProvingTaskUnassigned, types.ProvingTaskAssigned:
 		if r.cfg.EnableTestEnvBypassFeatures && utils.NowUTC().Sub(bundle.CreatedAt) > time.Duration(r.cfg.FinalizeBundleWithoutProofTimeoutSec)*time.Second {
+			// check if last batch is finalized, because in fake finalize bundle mode, we have not verified if the previous bundle or batch is finalized.
+			if bundle.StartBatchIndex == 0 {
+				log.Error("invalid args: start batch index of bundle is 0", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex)
+				return
+			}
+
+			lastBatch, err := r.batchOrm.GetBatchByIndex(r.ctx, bundle.StartBatchIndex-1)
+			if err != nil {
+				log.Error("failed to get last batch", "index", bundle.StartBatchIndex-1, "err", err)
+				return
+			}
+
+			if types.RollupStatus(lastBatch.RollupStatus) != types.RollupFinalized {
+				log.Error("previous bundle or batch is not finalized", "index", lastBatch.Index, "hash", lastBatch.Hash, "rollup status", types.RollupStatus(lastBatch.RollupStatus))
+			}
+
 			if err := r.finalizeBundle(bundle, false); err != nil {
 				log.Error("Failed to finalize timeout bundle without proof", "index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
 			}

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -576,17 +576,17 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 
 			lastBatch, err := r.batchOrm.GetBatchByIndex(r.ctx, bundle.StartBatchIndex-1)
 			if err != nil {
-				log.Error("failed to get last batch", "index", bundle.StartBatchIndex-1, "err", err)
+				log.Error("failed to get last batch", "batch index", bundle.StartBatchIndex-1, "err", err)
 				return
 			}
 
 			if types.RollupStatus(lastBatch.RollupStatus) != types.RollupFinalized {
-				log.Error("previous bundle or batch is not finalized", "index", lastBatch.Index, "hash", lastBatch.Hash, "rollup status", types.RollupStatus(lastBatch.RollupStatus))
+				log.Error("previous bundle or batch is not finalized", "batch index", lastBatch.Index, "batch hash", lastBatch.Hash, "rollup status", types.RollupStatus(lastBatch.RollupStatus))
 				return
 			}
 
 			if err := r.finalizeBundle(bundle, false); err != nil {
-				log.Error("Failed to finalize timeout bundle without proof", "index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
+				log.Error("Failed to finalize timeout bundle without proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
 				return
 			}
 		}
@@ -595,7 +595,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 		log.Info("Start to roll up zk proof", "bundle hash", bundle.Hash)
 		r.metrics.rollupL2RelayerProcessPendingBundlesFinalizedTotal.Inc()
 		if err := r.finalizeBundle(bundle, true); err != nil {
-			log.Error("Failed to finalize bundle with proof", "index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
+			log.Error("Failed to finalize bundle with proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
 			return
 		}
 
@@ -608,7 +608,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 		//     stop the ledger, fix the limit, revert all the violating blocks,
 		//     chunks, batches, bundles and all subsequent ones, and resume,
 		//     i.e. this case requires manual resolution.
-		log.Error("bundle proving failed", "index", bundle.Index, "hash", bundle.Hash, "proved at", bundle.ProvedAt, "proof time sec", bundle.ProofTimeSec)
+		log.Error("bundle proving failed", "bundle index", bundle.Index, "bundle hash", bundle.Hash, "proved at", bundle.ProvedAt, "proof time sec", bundle.ProofTimeSec)
 
 	default:
 		log.Error("encounter unreachable case in ProcessPendingBundles", "proving status", status)

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -582,10 +582,12 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 
 			if types.RollupStatus(lastBatch.RollupStatus) != types.RollupFinalized {
 				log.Error("previous bundle or batch is not finalized", "index", lastBatch.Index, "hash", lastBatch.Hash, "rollup status", types.RollupStatus(lastBatch.RollupStatus))
+				return
 			}
 
 			if err := r.finalizeBundle(bundle, false); err != nil {
 				log.Error("Failed to finalize timeout bundle without proof", "index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
+				return
 			}
 		}
 
@@ -594,6 +596,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 		r.metrics.rollupL2RelayerProcessPendingBundlesFinalizedTotal.Inc()
 		if err := r.finalizeBundle(bundle, true); err != nil {
 			log.Error("Failed to finalize bundle with proof", "index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
+			return
 		}
 
 	case types.ProvingTaskFailed:

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -568,7 +568,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 	switch status {
 	case types.ProvingTaskUnassigned, types.ProvingTaskAssigned:
 		if r.cfg.EnableTestEnvBypassFeatures && utils.NowUTC().Sub(bundle.CreatedAt) > time.Duration(r.cfg.FinalizeBundleWithoutProofTimeoutSec)*time.Second {
-			// check if last batch is finalized, because in fake finalize bundle mode, we have not verified if the previous bundle or batch is finalized.
+			// check if last batch is finalized, because in fake finalize bundle mode, the contract does not verify if the previous bundle or batch is finalized.
 			if bundle.StartBatchIndex == 0 {
 				log.Error("invalid args: start batch index of bundle is 0", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex)
 				return


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR adds a check that if last bundle or batch is finalized in fake finalize bundle mode before finalizing a new bundle. Because the contract does not verify if the previous bundle or batch is finalized.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Incremented version number to v4.4.73, indicating a new release.
  
- **Bug Fixes**
	- Enhanced validation in the bundle finalization process to ensure prerequisites are met before proceeding, improving robustness and error handling.
	- Updated logging for clarity in error messages related to bundle finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->