### PR TITLE
fix(gas-oracle): check blob gas fee before entering default gas price mode

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.75"
+var tag = "v4.4.76"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/cmd/gas_oracle/app/app.go
+++ b/rollup/cmd/gas_oracle/app/app.go
@@ -78,15 +78,9 @@ func action(ctx *cli.Context) error {
 		log.Crit("failed to connect l2 geth", "config file", cfgFile, "error", err)
 	}
 
-	genesisPath := ctx.String(utils.Genesis.Name)
-	genesis, err := utils.ReadGenesis(genesisPath)
-	if err != nil {
-		log.Crit("failed to read genesis", "genesis file", genesisPath, "error", err)
-	}
-
 	l1watcher := watcher.NewL1WatcherClient(ctx.Context, l1client, cfg.L1Config.StartHeight, db, registry)
 
-	l1relayer, err := relayer.NewLayer1Relayer(ctx.Context, db, cfg.L1Config.RelayerConfig, genesis.Config, relayer.ServiceTypeL1GasOracle, registry)
+	l1relayer, err := relayer.NewLayer1Relayer(ctx.Context, db, cfg.L1Config.RelayerConfig, relayer.ServiceTypeL1GasOracle, registry)
 	if err != nil {
 		log.Crit("failed to create new l1 relayer", "config file", cfgFile, "error", err)
 	}

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -20,7 +20,8 @@
         "gas_price_diff": 50000,
         "check_committed_batches_window_minutes": 5,
         "l1_base_fee_default": 15000000000,
-        "l1_blob_base_fee_default": 1
+        "l1_blob_base_fee_default": 1,
+        "l1_blob_base_fee_threshold": 100000000000
       },
       "gas_oracle_sender_signer_config": {
         "signer_type": "PrivateKey",

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -21,7 +21,7 @@
         "check_committed_batches_window_minutes": 5,
         "l1_base_fee_default": 15000000000,
         "l1_blob_base_fee_default": 1,
-        "l1_blob_base_fee_threshold": 100000000000
+        "l1_blob_base_fee_threshold": 0
       },
       "gas_oracle_sender_signer_config": {
         "signer_type": "PrivateKey",

--- a/rollup/internal/config/relayer.go
+++ b/rollup/internal/config/relayer.go
@@ -89,6 +89,9 @@ type GasOracleConfig struct {
 	CheckCommittedBatchesWindowMinutes int    `json:"check_committed_batches_window_minutes"`
 	L1BaseFeeDefault                   uint64 `json:"l1_base_fee_default"`
 	L1BlobBaseFeeDefault               uint64 `json:"l1_blob_base_fee_default"`
+
+	// L1BlobBaseFeeThreshold the threshold of L1 blob base fee to enter the default gas price mode
+	L1BlobBaseFeeThreshold uint64 `json:"l1_blob_base_fee_threshold"`
 }
 
 // SignerConfig - config of signer, contains type and config corresponding to type

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scroll-tech/go-ethereum/accounts/abi"
 	"github.com/scroll-tech/go-ethereum/log"
-	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
 
 	"scroll-tech/common/types"
@@ -30,8 +29,7 @@ import (
 type Layer1Relayer struct {
 	ctx context.Context
 
-	cfg      *config.RelayerConfig
-	chainCfg *params.ChainConfig
+	cfg *config.RelayerConfig
 
 	gasOracleSender *sender.Sender
 	l1GasOracleABI  *abi.ABI
@@ -49,7 +47,7 @@ type Layer1Relayer struct {
 }
 
 // NewLayer1Relayer will return a new instance of Layer1RelayerClient
-func NewLayer1Relayer(ctx context.Context, db *gorm.DB, cfg *config.RelayerConfig, chainCfg *params.ChainConfig, serviceType ServiceType, reg prometheus.Registerer) (*Layer1Relayer, error) {
+func NewLayer1Relayer(ctx context.Context, db *gorm.DB, cfg *config.RelayerConfig, serviceType ServiceType, reg prometheus.Registerer) (*Layer1Relayer, error) {
 	var gasOracleSender *sender.Sender
 	var err error
 
@@ -80,7 +78,6 @@ func NewLayer1Relayer(ctx context.Context, db *gorm.DB, cfg *config.RelayerConfi
 
 	l1Relayer := &Layer1Relayer{
 		cfg:        cfg,
-		chainCfg:   chainCfg,
 		ctx:        ctx,
 		l1BlockOrm: orm.NewL1Block(db),
 		l2BlockOrm: orm.NewL2Block(db),

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -166,7 +166,7 @@ func (r *Layer1Relayer) ProcessGasPriceOracle() {
 			// If we are not committing batches due to high fees then we shouldn't update fees to prevent users from paying high l1_data_fee
 			// Also, set fees to some default value, because we have already updated fees to some high values, probably
 			var reachTimeout bool
-			if reachTimeout, err = r.commitBatchReachTimeout(); reachTimeout && err == nil {
+			if reachTimeout, err = r.commitBatchReachTimeout(); reachTimeout && block.BlobBaseFee > r.cfg.GasOracleConfig.L1BlobBaseFeeThreshold && err == nil {
 				if r.lastBaseFee == r.cfg.GasOracleConfig.L1BaseFeeDefault && r.lastBlobBaseFee == r.cfg.GasOracleConfig.L1BlobBaseFeeDefault {
 					return
 				}

--- a/rollup/internal/controller/relayer/l1_relayer_test.go
+++ b/rollup/internal/controller/relayer/l1_relayer_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
-	"github.com/scroll-tech/go-ethereum/params"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
@@ -36,7 +35,7 @@ func setupL1RelayerDB(t *testing.T) *gorm.DB {
 func testCreateNewL1Relayer(t *testing.T) {
 	db := setupL1RelayerDB(t)
 	defer database.CloseDB(db)
-	relayer, err := NewLayer1Relayer(context.Background(), db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, ServiceTypeL1GasOracle, nil)
+	relayer, err := NewLayer1Relayer(context.Background(), db, cfg.L2Config.RelayerConfig, ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, relayer)
 	defer relayer.StopSenders()
@@ -58,7 +57,7 @@ func testL1RelayerGasOracleConfirm(t *testing.T) {
 	l1Cfg := cfg.L1Config
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, &params.ChainConfig{}, ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	defer l1Relayer.StopSenders()
 
@@ -91,7 +90,7 @@ func testL1RelayerProcessGasPriceOracle(t *testing.T) {
 	l1Cfg := cfg.L1Config
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, &params.ChainConfig{}, ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := NewLayer1Relayer(ctx, db, l1Cfg.RelayerConfig, ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, l1Relayer)
 	defer l1Relayer.StopSenders()

--- a/rollup/tests/gas_oracle_test.go
+++ b/rollup/tests/gas_oracle_test.go
@@ -30,7 +30,7 @@ func testImportL1GasPrice(t *testing.T) {
 	l1Cfg := rollupApp.Config.L1Config
 
 	// Create L1Relayer
-	l1Relayer, err := relayer.NewLayer1Relayer(context.Background(), db, l1Cfg.RelayerConfig, &params.ChainConfig{LondonBlock: big.NewInt(0), BernoulliBlock: big.NewInt(0), CurieBlock: big.NewInt(0), DarwinTime: new(uint64), DarwinV2Time: new(uint64)}, relayer.ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := relayer.NewLayer1Relayer(context.Background(), db, l1Cfg.RelayerConfig, relayer.ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	defer l1Relayer.StopSenders()
 
@@ -105,7 +105,7 @@ func testImportDefaultL1GasPriceDueToL1GasPriceSpike(t *testing.T) {
 	// set CheckCommittedBatchesWindowMinutes to zero to not pass check for commit batch timeout
 	l1CfgCopy.RelayerConfig.GasOracleConfig.CheckCommittedBatchesWindowMinutes = 0
 	// Create L1Relayer
-	l1Relayer, err := relayer.NewLayer1Relayer(context.Background(), db, l1CfgCopy.RelayerConfig, &params.ChainConfig{BernoulliBlock: big.NewInt(0), CurieBlock: big.NewInt(0)}, relayer.ServiceTypeL1GasOracle, nil)
+	l1Relayer, err := relayer.NewLayer1Relayer(context.Background(), db, l1CfgCopy.RelayerConfig, relayer.ServiceTypeL1GasOracle, nil)
 	assert.NoError(t, err)
 	defer l1Relayer.StopSenders()
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

gas-oracle will enter default gas price mode when commit batch is stuck.

This is unexpected during incidents, instead of due to high fees.

This PR adds an extra check to decrease these false positive cases.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration property for gas pricing related to blob transactions, enhancing configurability.
- **Improvements**
	- Updated gas oracle fee update logic to include a threshold check for blob base fees, improving validation and control over fee adjustments.
	- Simplified the initialization process for the Layer 1 relayer by removing the dependency on the genesis configuration.
- **Version Update**
	- Incremented the version number from v4.4.75 to v4.4.76, reflecting the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->