### PR TITLE
feat(bundle-proposer): static batch per bundle

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.76"
+var tag = "v4.4.77"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.75"
+var tag = "v4.4.76"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -103,8 +103,7 @@
       "max_uncompressed_batch_bytes_size": 634880
     },
     "bundle_proposer_config": {
-      "max_batch_num_per_bundle": 20,
-      "bundle_timeout_sec": 36000
+      "batch_num_per_bundle": 20
     }
   },
   "db_config": {

--- a/rollup/internal/config/l2.go
+++ b/rollup/internal/config/l2.go
@@ -51,6 +51,5 @@ type BatchProposerConfig struct {
 
 // BundleProposerConfig loads bundle_proposer configuration items.
 type BundleProposerConfig struct {
-	MaxBatchNumPerBundle uint64 `json:"max_batch_num_per_bundle"`
-	BundleTimeoutSec     uint64 `json:"bundle_timeout_sec"`
+	BatchNumPerBundle uint64 `json:"batch_num_per_bundle"`
 }

--- a/rollup/internal/controller/watcher/bundle_proposer_test.go
+++ b/rollup/internal/controller/watcher/bundle_proposer_test.go
@@ -23,33 +23,33 @@ import (
 func testBundleProposerLimits(t *testing.T) {
 	tests := []struct {
 		name                         string
-		maxBatchNumPerBundle         uint64
+		batchNumPerBundle            uint64
 		bundleTimeoutSec             uint64
 		expectedBundlesLen           int
 		expectedBatchesInFirstBundle uint64 // only be checked when expectedBundlesLen > 0
 	}{
 		{
-			name:                 "NoLimitReached",
-			maxBatchNumPerBundle: math.MaxUint64,
-			bundleTimeoutSec:     math.MaxUint32,
-			expectedBundlesLen:   0,
+			name:               "NoLimitReached",
+			batchNumPerBundle:  math.MaxUint64,
+			bundleTimeoutSec:   math.MaxUint32,
+			expectedBundlesLen: 0,
 		},
 		{
 			name:                         "Timeout",
-			maxBatchNumPerBundle:         math.MaxUint64,
+			batchNumPerBundle:            math.MaxUint64,
 			bundleTimeoutSec:             0,
 			expectedBundlesLen:           1,
 			expectedBatchesInFirstBundle: 2,
 		},
 		{
-			name:                 "maxBatchNumPerBundleIs0",
-			maxBatchNumPerBundle: 0,
-			bundleTimeoutSec:     math.MaxUint32,
-			expectedBundlesLen:   0,
+			name:               "maxBatchNumPerBundleIs0",
+			batchNumPerBundle:  0,
+			bundleTimeoutSec:   math.MaxUint32,
+			expectedBundlesLen: 0,
 		},
 		{
 			name:                         "maxBatchNumPerBundleIs1",
-			maxBatchNumPerBundle:         1,
+			batchNumPerBundle:            1,
 			bundleTimeoutSec:             math.MaxUint32,
 			expectedBundlesLen:           1,
 			expectedBatchesInFirstBundle: 1,
@@ -115,8 +115,7 @@ func testBundleProposerLimits(t *testing.T) {
 			bap.TryProposeBatch() // batch2 contains chunk2
 
 			bup := NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-				MaxBatchNumPerBundle: tt.maxBatchNumPerBundle,
-				BundleTimeoutSec:     tt.bundleTimeoutSec,
+				BatchNumPerBundle: tt.batchNumPerBundle,
 			}, chainConfig, db, nil)
 
 			bup.TryProposeBundle()
@@ -205,8 +204,7 @@ func testBundleProposerRespectHardforks(t *testing.T) {
 	}
 
 	bup := NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-		MaxBatchNumPerBundle: math.MaxUint64,
-		BundleTimeoutSec:     0,
+		BatchNumPerBundle: math.MaxUint64,
 	}, chainConfig, db, nil)
 
 	for i := 0; i < 5; i++ {

--- a/rollup/internal/controller/watcher/bundle_proposer_test.go
+++ b/rollup/internal/controller/watcher/bundle_proposer_test.go
@@ -35,13 +35,6 @@ func testBundleProposerLimits(t *testing.T) {
 			expectedBundlesLen: 0,
 		},
 		{
-			name:                         "Timeout",
-			batchNumPerBundle:            math.MaxUint64,
-			bundleTimeoutSec:             0,
-			expectedBundlesLen:           1,
-			expectedBatchesInFirstBundle: 2,
-		},
-		{
 			name:               "maxBatchNumPerBundleIs0",
 			batchNumPerBundle:  0,
 			bundleTimeoutSec:   math.MaxUint32,
@@ -143,6 +136,7 @@ func testBundleProposerRespectHardforks(t *testing.T) {
 		BernoulliBlock: big.NewInt(1),
 		CurieBlock:     big.NewInt(2),
 		DarwinTime:     func() *uint64 { t := uint64(4); return &t }(),
+		DarwinV2Time:   func() *uint64 { t := uint64(4); return &t }(),
 	}
 
 	// Add genesis batch.
@@ -204,7 +198,7 @@ func testBundleProposerRespectHardforks(t *testing.T) {
 	}
 
 	bup := NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-		BatchNumPerBundle: math.MaxUint64,
+		BatchNumPerBundle: 1,
 	}, chainConfig, db, nil)
 
 	for i := 0; i < 5; i++ {

--- a/rollup/tests/rollup_test.go
+++ b/rollup/tests/rollup_test.go
@@ -113,7 +113,7 @@ func testCommitBatchAndFinalizeBatchOrBundleWithAllCodecVersions(t *testing.T) {
 		}, chainConfig, db, nil)
 
 		bup := watcher.NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-			BatchNumPerBundle: 1000000,
+			BatchNumPerBundle: 2,
 		}, chainConfig, db, nil)
 
 		l2BlockOrm := orm.NewL2Block(db)
@@ -279,7 +279,7 @@ func testCommitBatchAndFinalizeBatchOrBundleCrossingAllTransitions(t *testing.T)
 	}, chainConfig, db, nil)
 
 	bup := watcher.NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-		BatchNumPerBundle: 1000000,
+		BatchNumPerBundle: 1,
 	}, chainConfig, db, nil)
 
 	cp.TryProposeChunk()

--- a/rollup/tests/rollup_test.go
+++ b/rollup/tests/rollup_test.go
@@ -113,8 +113,7 @@ func testCommitBatchAndFinalizeBatchOrBundleWithAllCodecVersions(t *testing.T) {
 		}, chainConfig, db, nil)
 
 		bup := watcher.NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-			MaxBatchNumPerBundle: 1000000,
-			BundleTimeoutSec:     300,
+			BatchNumPerBundle: 1000000,
 		}, chainConfig, db, nil)
 
 		l2BlockOrm := orm.NewL2Block(db)
@@ -280,8 +279,7 @@ func testCommitBatchAndFinalizeBatchOrBundleCrossingAllTransitions(t *testing.T)
 	}, chainConfig, db, nil)
 
 	bup := watcher.NewBundleProposer(context.Background(), &config.BundleProposerConfig{
-		MaxBatchNumPerBundle: 1000000,
-		BundleTimeoutSec:     300,
+		BatchNumPerBundle: 1000000,
 	}, chainConfig, db, nil)
 
 	cp.TryProposeChunk()


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR makes bundle-proposer compatible with new contract design by:
* deleting timeout feature.
* make bundle size static and configurable.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated version to v4.4.77, reflecting the latest release.
	- Simplified configuration for batch proposals by renaming and consolidating parameters.

- **Bug Fixes**
	- Ensured consistent naming across tests and implementation for batch processing parameters.

- **Documentation**
	- Improved clarity in configuration settings related to bundle proposals.

- **Tests**
	- Updated tests to align with the new naming convention for batch proposal parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->