### PR TITLE
refactor(sender): split signer address checks into gas-oracle and rollup-relayer

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.79"
+var tag = "v4.4.80"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -71,27 +71,8 @@ type Layer2Relayer struct {
 
 // NewLayer2Relayer will return a new instance of Layer2RelayerClient
 func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.DB, cfg *config.RelayerConfig, chainCfg *params.ChainConfig, initGenesis bool, serviceType ServiceType, reg prometheus.Registerer) (*Layer2Relayer, error) {
-
 	var gasOracleSender, commitSender, finalizeSender *sender.Sender
 	var err error
-
-	// check that all 3 signer addresses are different, because there will be a problem in managing nonce for different senders
-	gasOracleSenderAddr, err := addrFromSignerConfig(cfg.GasOracleSenderSignerConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse addr from gas oracle signer config, err: %v", err)
-	}
-	commitSenderAddr, err := addrFromSignerConfig(cfg.CommitSenderSignerConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse addr from commit sender config, err: %v", err)
-	}
-	finalizeSenderAddr, err := addrFromSignerConfig(cfg.FinalizeSenderSignerConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse addr from finalize sender config, err: %v", err)
-	}
-	if gasOracleSenderAddr == commitSenderAddr || gasOracleSenderAddr == finalizeSenderAddr || commitSenderAddr == finalizeSenderAddr {
-		return nil, fmt.Errorf("gas oracle, commit, and finalize sender addresses must be different. Got: Gas Oracle=%s, Commit=%s, Finalize=%s",
-			gasOracleSenderAddr.Hex(), commitSenderAddr.Hex(), finalizeSenderAddr.Hex())
-	}
 
 	switch serviceType {
 	case ServiceTypeL2GasOracle:
@@ -106,6 +87,18 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 		}
 
 	case ServiceTypeL2RollupRelayer:
+		commitSenderAddr, err := addrFromSignerConfig(cfg.CommitSenderSignerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse addr from commit sender config, err: %v", err)
+		}
+		finalizeSenderAddr, err := addrFromSignerConfig(cfg.FinalizeSenderSignerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse addr from finalize sender config, err: %v", err)
+		}
+		if commitSenderAddr == finalizeSenderAddr {
+			return nil, fmt.Errorf("commit, and finalize sender addresses must be different. Got: Commit=%s, Finalize=%s", commitSenderAddr.Hex(), finalizeSenderAddr.Hex())
+		}
+
 		commitSender, err = sender.NewSender(ctx, cfg.SenderConfig, cfg.CommitSenderSignerConfig, "l2_relayer", "commit_sender", types.SenderTypeCommitBatch, db, reg)
 		if err != nil {
 			return nil, fmt.Errorf("new commit sender failed, err: %w", err)

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -96,7 +96,7 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 			return nil, fmt.Errorf("failed to parse addr from finalize sender config, err: %v", err)
 		}
 		if commitSenderAddr == finalizeSenderAddr {
-			return nil, fmt.Errorf("commit, and finalize sender addresses must be different. Got: Commit=%s, Finalize=%s", commitSenderAddr.Hex(), finalizeSenderAddr.Hex())
+			return nil, fmt.Errorf("commit and finalize sender addresses must be different. Got: Commit=%s, Finalize=%s", commitSenderAddr.Hex(), finalizeSenderAddr.Hex())
 		}
 
 		commitSender, err = sender.NewSender(ctx, cfg.SenderConfig, cfg.CommitSenderSignerConfig, "l2_relayer", "commit_sender", types.SenderTypeCommitBatch, db, reg)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Decouples the config dependencies so that `gas-oracle` and `rollup-relayer` only need to initialize the needed accounts.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified error handling for sender address validation in the Layer2 Relayer service.
	- Updated error messages to align with the new validation logic focusing on commit and finalize sender addresses.

- **Bug Fixes**
	- Improved control flow and error handling related to sender address configurations.

- **Chores**
	- Version updated from v4.4.79 to v4.4.80.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->