### PR TITLE
fix(rollup): only enable chain-monitor in rollup-relayer

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.80"
+var tag = "v4.4.81"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -154,7 +154,7 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 	}
 
 	// chain_monitor client
-	if cfg.ChainMonitor.Enabled {
+	if serviceType == ServiceTypeL2RollupRelayer && cfg.ChainMonitor.Enabled {
 		layer2Relayer.chainMonitorClient = resty.New()
 		layer2Relayer.chainMonitorClient.SetRetryCount(cfg.ChainMonitor.TryTimes)
 		layer2Relayer.chainMonitorClient.SetTimeout(time.Duration(cfg.ChainMonitor.TimeOut) * time.Second)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Yet another config decoupling PR, before this PR, will cause a nil pointer error without chain-monitor configs, after this PR gas-oracle won't need chain-monitor configs in `config.json`.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the initialization logic for the chain monitor client, ensuring it activates only for the relevant service type, which may enhance performance and reduce unnecessary resource usage.
- **Version Update**
	- Updated the application version from v4.4.80 to v4.4.81.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->