### PR TITLE
fix(sender): nonce update

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.81"
+var tag = "v4.4.82"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -247,7 +247,7 @@ func (s *Sender) SendTransaction(contextID string, target *common.Address, data 
 		return common.Hash{}, fmt.Errorf("failed to send transaction, err: %w", err)
 	}
 
-	s.transactionSigner.SetNonce(s.transactionSigner.GetNonce() + 1)
+	s.transactionSigner.SetNonce(signedTx.Nonce() + 1)
 
 	return signedTx.Hash(), nil
 }

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -216,7 +216,7 @@ func (s *Sender) SendTransaction(contextID string, target *common.Address, data 
 		return common.Hash{}, fmt.Errorf("failed to get fee data, err: %w", err)
 	}
 
-	signedTx, err := s.createTx(feeData, target, data, sidecar, nil)
+	signedTx, err := s.createTx(feeData, target, data, sidecar, s.transactionSigner.GetNonce())
 	if err != nil {
 		s.metrics.sendTransactionFailureSendTx.WithLabelValues(s.service, s.name).Inc()
 		log.Error("failed to create signed tx (non-resubmit case)", "from", s.transactionSigner.GetAddr().String(), "nonce", s.transactionSigner.GetNonce(), "err", err)
@@ -247,19 +247,13 @@ func (s *Sender) SendTransaction(contextID string, target *common.Address, data 
 		return common.Hash{}, fmt.Errorf("failed to send transaction, err: %w", err)
 	}
 
+	s.transactionSigner.SetNonce(s.transactionSigner.GetNonce() + 1)
+
 	return signedTx.Hash(), nil
 }
 
-func (s *Sender) createTx(feeData *FeeData, target *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, overrideNonce *uint64) (*gethTypes.Transaction, error) {
-	var (
-		nonce  = s.transactionSigner.GetNonce()
-		txData gethTypes.TxData
-	)
-
-	// this is a resubmit call, override the nonce
-	if overrideNonce != nil {
-		nonce = *overrideNonce
-	}
+func (s *Sender) createTx(feeData *FeeData, target *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, nonce uint64) (*gethTypes.Transaction, error) {
+	var txData gethTypes.TxData
 
 	switch s.config.TxType {
 	case LegacyTxType:
@@ -310,11 +304,6 @@ func (s *Sender) createTx(feeData *FeeData, target *common.Address, data []byte,
 	if err != nil {
 		log.Error("failed to sign tx", "address", s.transactionSigner.GetAddr().String(), "err", err)
 		return nil, err
-	}
-
-	// update nonce when it is not from resubmit
-	if overrideNonce == nil {
-		s.transactionSigner.SetNonce(nonce + 1)
 	}
 
 	if feeData.gasTipCap != nil {
@@ -492,7 +481,7 @@ func (s *Sender) createReplacingTransaction(tx *gethTypes.Transaction, baseFee, 
 
 	nonce := tx.Nonce()
 	s.metrics.resubmitTransactionTotal.WithLabelValues(s.service, s.name).Inc()
-	signedTx, err := s.createTx(&feeData, tx.To(), tx.Data(), tx.BlobTxSidecar(), &nonce)
+	signedTx, err := s.createTx(&feeData, tx.To(), tx.Data(), tx.BlobTxSidecar(), nonce)
 	if err != nil {
 		log.Error("failed to create signed tx (resubmit case)", "from", s.transactionSigner.GetAddr().String(), "nonce", nonce, "err", err)
 		return nil, err

--- a/rollup/internal/controller/sender/sender_test.go
+++ b/rollup/internal/controller/sender/sender_test.go
@@ -282,7 +282,7 @@ func testResubmitZeroGasPriceTransaction(t *testing.T) {
 			gasFeeCap: big.NewInt(0),
 			gasLimit:  50000,
 		}
-		tx, err := s.createTx(feeData, &common.Address{}, nil, nil, nil)
+		tx, err := s.createTx(feeData, &common.Address{}, nil, nil, s.transactionSigner.GetNonce())
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
 		err = s.client.SendTransaction(s.ctx, tx)
@@ -373,7 +373,7 @@ func testResubmitNonZeroGasPriceTransaction(t *testing.T) {
 			sidecar, err = makeSidecar(txBlob[i])
 			assert.NoError(t, err)
 		}
-		tx, err := s.createTx(feeData, &common.Address{}, nil, sidecar, nil)
+		tx, err := s.createTx(feeData, &common.Address{}, nil, sidecar, s.transactionSigner.GetNonce())
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
 		err = s.client.SendTransaction(s.ctx, tx)
@@ -420,7 +420,7 @@ func testResubmitUnderpricedTransaction(t *testing.T) {
 			gasFeeCap: big.NewInt(1000000000),
 			gasLimit:  50000,
 		}
-		tx, err := s.createTx(feeData, &common.Address{}, nil, nil, nil)
+		tx, err := s.createTx(feeData, &common.Address{}, nil, nil, s.transactionSigner.GetNonce())
 		assert.NoError(t, err)
 		assert.NotNil(t, tx)
 		err = s.client.SendTransaction(s.ctx, tx)


### PR DESCRIPTION
### Purpose or design rationale of this PR

Only updating nonce when sending transaction success.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated version number to v4.4.82, reflecting the latest release.
	- Improved transaction sending logic to directly manage nonce, enhancing transaction reliability.

- **Bug Fixes**
	- Enhanced error handling and logging for transaction creation and sending processes.

- **Tests**
	- Updated tests to ensure correct nonce usage and transaction status tracking across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->