### PR TITLE
opt: pre-allocate chunk blocks slice in chunk proposer

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.82"
+var tag = "v4.4.83"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.81"
+var tag = "v4.4.82"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.84"
+var tag = "v4.4.83"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -295,6 +295,7 @@ func (p *ChunkProposer) proposeChunk() error {
 	}
 
 	var chunk encoding.Chunk
+	chunk.Blocks = make([]*encoding.Block, 0, len(blocks))
 	for i, block := range blocks {
 		chunk.Blocks = append(chunk.Blocks, block)
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR improves performance by pre-allocating the capacity of chunk blocks slice based on the actual number of blocks to be processed.

What: Pre-allocate slice capacity in chunk proposer
Why: To reduce memory allocations and copying during chunk processing
How: Use len(blocks) as the initial capacity when creating the chunk.Blocks slice

### PR title

perf: pre-allocate chunk blocks slice in chunk proposer

- [x] perf: A code change that improves performance

### Deployment tag versioning

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag

### Breaking change label

- [x] No, this PR is not a breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling for chunk proposals, including checks for block limits.
	- New methods added for recording chunk metrics.

- **Bug Fixes**
	- Improved memory allocation for chunk blocks.

- **Chores**
	- Version updated from v4.4.81 to v4.4.83.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->