### PR TITLE
typo-Update config.rs

### DIFF
--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -62,7 +62,7 @@ impl AssetsDirEnvConfig {
         let value = std::env::var(SCROLL_PROVER_ASSETS_DIR_ENV_NAME)?;
         let dirs: Vec<&str> = value.split(',').collect();
         if dirs.len() != 2 {
-            bail!("env variable SCROLL_PROVER_ASSETS_DIR value must be 2 parts seperated by comma.")
+            bail!("env variable SCROLL_PROVER_ASSETS_DIR value must be 2 parts separated by comma.")
         }
         unsafe {
             SCROLL_PROVER_ASSETS_DIRS = dirs.into_iter().map(|s| s.to_string()).collect();


### PR DESCRIPTION
# Fix: Corrected typo in Rust source file

## What was changed
1. **Corrected typo**:
   - Replaced `seperated` with `separated` in `prover/src/config.rs:65`.

## Why these changes were made
- **Fixing typos** improves the clarity and professionalism of the codebase, ensuring accuracy and ease of understanding for developers.

## Additional Notes
- This change focuses solely on correcting a typographical error and does not affect the functionality of the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the error message for improved clarity regarding the environment variable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->