### PR TITLE
fix: correct usage of "a" vs. "an" in comments and constants

### DIFF
--- a/common/testcontainers/testcontainers.go
+++ b/common/testcontainers/testcontainers.go
@@ -166,7 +166,7 @@ func (t *TestcontainerApps) GetPoSL1EndPoint() (string, error) {
 	return contrainer.PortEndpoint(context.Background(), "8545/tcp", "http")
 }
 
-// GetPoSL1Client returns a ethclient by dialing running PoS L1 client
+// GetPoSL1Client returns an ethclient by dialing running PoS L1 client
 func (t *TestcontainerApps) GetPoSL1Client() (*ethclient.Client, error) {
 	endpoint, err := t.GetPoSL1EndPoint()
 	if err != nil {
@@ -218,7 +218,7 @@ func (t *TestcontainerApps) GetGormDBClient() (*gorm.DB, error) {
 	return database.InitDB(dbCfg)
 }
 
-// GetL2GethClient returns a ethclient by dialing running L2Geth
+// GetL2GethClient returns an ethclient by dialing running L2Geth
 func (t *TestcontainerApps) GetL2GethClient() (*ethclient.Client, error) {
 	endpoint, err := t.GetL2GethEndPoint()
 	if err != nil {

--- a/coordinator/internal/logic/verifier/types.go
+++ b/coordinator/internal/logic/verifier/types.go
@@ -5,7 +5,7 @@ import (
 )
 
 // InvalidTestProof invalid proof used in tests
-const InvalidTestProof = "this is a invalid proof"
+const InvalidTestProof = "this is an invalid proof"
 
 // Verifier represents a rust ffi to a halo2 verifier.
 type Verifier struct {

--- a/prover/src/coordinator_client/types.rs
+++ b/prover/src/coordinator_client/types.rs
@@ -26,7 +26,7 @@ impl Encodable for LoginMessage {
         s.append(&self.challenge);
         s.append(&self.prover_version);
         s.append(&self.prover_name);
-        // The ProverType in go side is an type alias of uint8
+        // The ProverType in go side is a type alias of uint8
         // A uint8 slice is treated as a string when doing the rlp encoding
         let prover_types = self
             .prover_types


### PR DESCRIPTION
This PR addresses multiple instances of incorrect article usage in the codebase. Specifically, it changes the usage of "a" to "an" when the following word starts with a vowel sound and vice versa.

#### What does this PR do?
- Corrects the use of articles in comments and constants across the codebase, specifically:
  - Changes "a ethclient" to "an ethclient" in `testcontainers.go`
  - Updates the constant description for `InvalidTestProof` in `types.go` to use "an" instead of "a"
  - Fixes the comment in `types.rs` to use "a" instead of "an" before "type alias"

#### Why does it do it?
- To ensure proper grammar and readability of the codebase, adhering to standard English rules for indefinite articles.

#### How does it do it?
- Modifies instances of "a ethclient" to "an ethclient"
- Corrects "this is a invalid proof" to "this is an invalid proof"
- Changes "an type alias" to "a type alias"

### Changes:
- **testcontainers.go**: Fixed incorrect article use in comments.
- **types.go**: Corrected the constant description for `InvalidTestProof`.
- **types.rs**: Fixed comment describing the type alias for `ProverType`.

### Checklist:
- [ ] No new deployment, git tag, or docker image tag is required.
- [ ] This PR does not introduce any breaking changes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected grammatical errors in comments and string values across multiple files.
	- Enhanced error handling and logging for container startup processes to provide clearer feedback.
	- Ensured proper termination of running containers in the container management logic.

- **Documentation**
	- Updated comments for clarity in various methods and constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->