### PR TITLE
fix: typos in documentation files

### DIFF
--- a/common/bytecode/README.md
+++ b/common/bytecode/README.md
@@ -22,7 +22,7 @@
 ```
 
 ## How to get contract abi?
-* Other contracts' step same to eth20, e.g:
+* Other contracts' step same to erc20, e.g:
 1. Install solc.
    
     *Reference to https://docs.soliditylang.org/en/latest/installing-solidity.html*


### PR DESCRIPTION
Corrected `eth20` to `erc20`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for contract deployment and ABI retrieval in the README file.
	- Corrected terminology from "eth20" to "erc20" for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->