### PR TITLE
fix(rollup-relayer): update batch finalizing status and unify db time…

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.83"
+var tag = "v4.4.84"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -529,7 +529,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 		}
 
 	case types.ProvingTaskVerified:
-		log.Info("Start to roll up zk proof", "bundle hash", bundle.Hash)
+		log.Info("Start to roll up zk proof", "index", bundle.Index, "bundle hash", bundle.Hash)
 		r.metrics.rollupL2RelayerProcessPendingBundlesFinalizedTotal.Inc()
 		if err := r.finalizeBundle(bundle, true); err != nil {
 			log.Error("failed to finalize bundle with proof", "bundle index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "err", err)
@@ -638,12 +638,12 @@ func (r *Layer2Relayer) finalizeBundle(bundle *orm.Bundle, withProof bool) error
 	// Updating rollup status in database.
 	err = r.db.Transaction(func(dbTX *gorm.DB) error {
 		if err = r.batchOrm.UpdateFinalizeTxHashAndRollupStatusByBundleHash(r.ctx, bundle.Hash, txHash.String(), types.RollupFinalizing, dbTX); err != nil {
-			log.Warn("UpdateFinalizeTxHashAndRollupStatusByBundleHash failed", "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
+			log.Warn("UpdateFinalizeTxHashAndRollupStatusByBundleHash failed", "index", bundle.Index, "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
 			return err
 		}
 
 		if err = r.bundleOrm.UpdateFinalizeTxHashAndRollupStatus(r.ctx, bundle.Hash, txHash.String(), types.RollupFinalizing, dbTX); err != nil {
-			log.Warn("UpdateFinalizeTxHashAndRollupStatus failed", "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
+			log.Warn("UpdateFinalizeTxHashAndRollupStatus failed", "index", bundle.Index, "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
 			return err
 		}
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -636,8 +636,22 @@ func (r *Layer2Relayer) finalizeBundle(bundle *orm.Bundle, withProof bool) error
 	log.Info("finalizeBundle in layer1", "with proof", withProof, "index", bundle.Index, "start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex, "tx hash", txHash.String())
 
 	// Updating rollup status in database.
-	if err := r.bundleOrm.UpdateFinalizeTxHashAndRollupStatus(r.ctx, bundle.Hash, txHash.String(), types.RollupFinalizing); err != nil {
-		log.Error("UpdateFinalizeTxHashAndRollupStatus failed", "index", bundle.Index, "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
+	err = r.db.Transaction(func(dbTX *gorm.DB) error {
+		if err = r.batchOrm.UpdateFinalizeTxHashAndRollupStatusByBundleHash(r.ctx, bundle.Hash, txHash.String(), types.RollupFinalizing, dbTX); err != nil {
+			log.Warn("UpdateFinalizeTxHashAndRollupStatusByBundleHash failed", "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
+			return err
+		}
+
+		if err = r.bundleOrm.UpdateFinalizeTxHashAndRollupStatus(r.ctx, bundle.Hash, txHash.String(), types.RollupFinalizing, dbTX); err != nil {
+			log.Warn("UpdateFinalizeTxHashAndRollupStatus failed", "bundle hash", bundle.Hash, "tx hash", txHash.String(), "err", err)
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Warn("failed to update rollup status of bundle and batches", "err", err)
 		return err
 	}
 

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -13,9 +13,8 @@ import (
 
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
-	"scroll-tech/common/utils"
 
-	rutils "scroll-tech/rollup/internal/utils"
+	"scroll-tech/rollup/internal/utils"
 )
 
 // Batch represents a batch of chunks.
@@ -250,7 +249,7 @@ func (o *Batch) GetBatchByIndex(ctx context.Context, index uint64) (*Batch, erro
 }
 
 // InsertBatch inserts a new batch into the database.
-func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVersion encoding.CodecVersion, metrics rutils.BatchMetrics, dbTX ...*gorm.DB) (*Batch, error) {
+func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVersion encoding.CodecVersion, metrics utils.BatchMetrics, dbTX ...*gorm.DB) (*Batch, error) {
 	if batch == nil {
 		return nil, errors.New("invalid args: batch is nil")
 	}
@@ -271,7 +270,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVer
 		startChunkIndex = parentBatch.EndChunkIndex + 1
 	}
 
-	batchMeta, err := rutils.GetBatchMetadata(batch, codecVersion)
+	batchMeta, err := utils.GetBatchMetadata(batch, codecVersion)
 	if err != nil {
 		log.Error("failed to get batch metadata", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
 			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
@@ -347,11 +346,11 @@ func (o *Batch) UpdateProvingStatus(ctx context.Context, hash string, status typ
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now()
+		updateFields["prover_assigned_at"] = time.Now().UTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now()
+		updateFields["proved_at"] = time.Now().UTC()
 	}
 
 	db := o.db
@@ -375,9 +374,9 @@ func (o *Batch) UpdateRollupStatus(ctx context.Context, hash string, status type
 
 	switch status {
 	case types.RollupCommitted:
-		updateFields["committed_at"] = utils.NowUTC()
+		updateFields["committed_at"] = time.Now().UTC()
 	case types.RollupFinalized:
-		updateFields["finalized_at"] = utils.NowUTC()
+		updateFields["finalized_at"] = time.Now().UTC()
 	}
 
 	db := o.db
@@ -400,7 +399,7 @@ func (o *Batch) UpdateCommitTxHashAndRollupStatus(ctx context.Context, hash stri
 	updateFields["commit_tx_hash"] = commitTxHash
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupCommitted {
-		updateFields["committed_at"] = utils.NowUTC()
+		updateFields["committed_at"] = time.Now().UTC()
 	}
 
 	db := o.db.WithContext(ctx)
@@ -419,7 +418,7 @@ func (o *Batch) UpdateFinalizeTxHashAndRollupStatus(ctx context.Context, hash st
 	updateFields["finalize_tx_hash"] = finalizeTxHash
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupFinalized {
-		updateFields["finalized_at"] = time.Now()
+		updateFields["finalized_at"] = time.Now().UTC()
 	}
 
 	db := o.db.WithContext(ctx)
@@ -478,11 +477,11 @@ func (o *Batch) UpdateProvingStatusByBundleHash(ctx context.Context, bundleHash 
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now()
+		updateFields["prover_assigned_at"] = time.Now().UTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now()
+		updateFields["proved_at"] = time.Now().UTC()
 	}
 
 	db := o.db
@@ -507,7 +506,7 @@ func (o *Batch) UpdateFinalizeTxHashAndRollupStatusByBundleHash(ctx context.Cont
 
 	switch status {
 	case types.RollupFinalized:
-		updateFields["finalized_at"] = utils.NowUTC()
+		updateFields["finalized_at"] = time.Now().UTC()
 	}
 
 	db := o.db

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -13,8 +13,9 @@ import (
 
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
+	"scroll-tech/common/utils"
 
-	"scroll-tech/rollup/internal/utils"
+	rutils "scroll-tech/rollup/internal/utils"
 )
 
 // Batch represents a batch of chunks.
@@ -249,7 +250,7 @@ func (o *Batch) GetBatchByIndex(ctx context.Context, index uint64) (*Batch, erro
 }
 
 // InsertBatch inserts a new batch into the database.
-func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVersion encoding.CodecVersion, metrics utils.BatchMetrics, dbTX ...*gorm.DB) (*Batch, error) {
+func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVersion encoding.CodecVersion, metrics rutils.BatchMetrics, dbTX ...*gorm.DB) (*Batch, error) {
 	if batch == nil {
 		return nil, errors.New("invalid args: batch is nil")
 	}
@@ -270,7 +271,7 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVer
 		startChunkIndex = parentBatch.EndChunkIndex + 1
 	}
 
-	batchMeta, err := utils.GetBatchMetadata(batch, codecVersion)
+	batchMeta, err := rutils.GetBatchMetadata(batch, codecVersion)
 	if err != nil {
 		log.Error("failed to get batch metadata", "index", batch.Index, "total l1 message popped before", batch.TotalL1MessagePoppedBefore,
 			"parent hash", batch.ParentBatchHash.Hex(), "number of chunks", numChunks, "err", err)
@@ -346,11 +347,11 @@ func (o *Batch) UpdateProvingStatus(ctx context.Context, hash string, status typ
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now().UTC()
+		updateFields["prover_assigned_at"] = utils.NowUTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now().UTC()
+		updateFields["proved_at"] = utils.NowUTC()
 	}
 
 	db := o.db
@@ -374,9 +375,9 @@ func (o *Batch) UpdateRollupStatus(ctx context.Context, hash string, status type
 
 	switch status {
 	case types.RollupCommitted:
-		updateFields["committed_at"] = time.Now().UTC()
+		updateFields["committed_at"] = utils.NowUTC()
 	case types.RollupFinalized:
-		updateFields["finalized_at"] = time.Now().UTC()
+		updateFields["finalized_at"] = utils.NowUTC()
 	}
 
 	db := o.db
@@ -399,7 +400,7 @@ func (o *Batch) UpdateCommitTxHashAndRollupStatus(ctx context.Context, hash stri
 	updateFields["commit_tx_hash"] = commitTxHash
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupCommitted {
-		updateFields["committed_at"] = time.Now().UTC()
+		updateFields["committed_at"] = utils.NowUTC()
 	}
 
 	db := o.db.WithContext(ctx)
@@ -418,7 +419,7 @@ func (o *Batch) UpdateFinalizeTxHashAndRollupStatus(ctx context.Context, hash st
 	updateFields["finalize_tx_hash"] = finalizeTxHash
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupFinalized {
-		updateFields["finalized_at"] = time.Now().UTC()
+		updateFields["finalized_at"] = utils.NowUTC()
 	}
 
 	db := o.db.WithContext(ctx)
@@ -477,11 +478,11 @@ func (o *Batch) UpdateProvingStatusByBundleHash(ctx context.Context, bundleHash 
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now().UTC()
+		updateFields["prover_assigned_at"] = utils.NowUTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now().UTC()
+		updateFields["proved_at"] = utils.NowUTC()
 	}
 
 	db := o.db
@@ -506,7 +507,7 @@ func (o *Batch) UpdateFinalizeTxHashAndRollupStatusByBundleHash(ctx context.Cont
 
 	switch status {
 	case types.RollupFinalized:
-		updateFields["finalized_at"] = time.Now().UTC()
+		updateFields["finalized_at"] = utils.NowUTC()
 	}
 
 	db := o.db

--- a/rollup/internal/orm/bundle.go
+++ b/rollup/internal/orm/bundle.go
@@ -15,7 +15,6 @@ import (
 
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
-	"scroll-tech/common/utils"
 )
 
 // Bundle represents a bundle of batches.
@@ -194,7 +193,7 @@ func (o *Bundle) UpdateFinalizeTxHashAndRollupStatus(ctx context.Context, hash s
 	updateFields["finalize_tx_hash"] = finalizeTxHash
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupFinalized {
-		updateFields["finalized_at"] = time.Now()
+		updateFields["finalized_at"] = time.Now().UTC()
 	}
 
 	db := o.db
@@ -218,7 +217,7 @@ func (o *Bundle) UpdateProvingStatus(ctx context.Context, hash string, status ty
 
 	switch status {
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now()
+		updateFields["proved_at"] = time.Now().UTC()
 	}
 
 	db := o.db
@@ -241,7 +240,7 @@ func (o *Bundle) UpdateRollupStatus(ctx context.Context, hash string, status typ
 	updateFields := make(map[string]interface{})
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupFinalized {
-		updateFields["finalized_at"] = time.Now()
+		updateFields["finalized_at"] = time.Now().UTC()
 	}
 
 	db := o.db.WithContext(ctx)
@@ -271,7 +270,7 @@ func (o *Bundle) UpdateProofAndProvingStatusByHash(ctx context.Context, hash str
 	updateFields["proof"] = proofBytes
 	updateFields["proving_status"] = provingStatus
 	updateFields["proof_time_sec"] = proofTimeSec
-	updateFields["proved_at"] = utils.NowUTC()
+	updateFields["proved_at"] = time.Now().UTC()
 
 	db = db.WithContext(ctx)
 	db = db.Model(&Bundle{})

--- a/rollup/internal/orm/bundle.go
+++ b/rollup/internal/orm/bundle.go
@@ -15,6 +15,7 @@ import (
 
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
+	"scroll-tech/common/utils"
 )
 
 // Bundle represents a bundle of batches.
@@ -193,7 +194,7 @@ func (o *Bundle) UpdateFinalizeTxHashAndRollupStatus(ctx context.Context, hash s
 	updateFields["finalize_tx_hash"] = finalizeTxHash
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupFinalized {
-		updateFields["finalized_at"] = time.Now().UTC()
+		updateFields["finalized_at"] = utils.NowUTC()
 	}
 
 	db := o.db
@@ -217,7 +218,7 @@ func (o *Bundle) UpdateProvingStatus(ctx context.Context, hash string, status ty
 
 	switch status {
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now().UTC()
+		updateFields["proved_at"] = utils.NowUTC()
 	}
 
 	db := o.db
@@ -240,7 +241,7 @@ func (o *Bundle) UpdateRollupStatus(ctx context.Context, hash string, status typ
 	updateFields := make(map[string]interface{})
 	updateFields["rollup_status"] = int(status)
 	if status == types.RollupFinalized {
-		updateFields["finalized_at"] = time.Now().UTC()
+		updateFields["finalized_at"] = utils.NowUTC()
 	}
 
 	db := o.db.WithContext(ctx)
@@ -270,7 +271,7 @@ func (o *Bundle) UpdateProofAndProvingStatusByHash(ctx context.Context, hash str
 	updateFields["proof"] = proofBytes
 	updateFields["proving_status"] = provingStatus
 	updateFields["proof_time_sec"] = proofTimeSec
-	updateFields["proved_at"] = time.Now().UTC()
+	updateFields["proved_at"] = utils.NowUTC()
 
 	db = db.WithContext(ctx)
 	db = db.Model(&Bundle{})

--- a/rollup/internal/orm/chunk.go
+++ b/rollup/internal/orm/chunk.go
@@ -261,11 +261,11 @@ func (o *Chunk) UpdateProvingStatus(ctx context.Context, hash string, status typ
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now()
+		updateFields["prover_assigned_at"] = time.Now().UTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now()
+		updateFields["proved_at"] = time.Now().UTC()
 	}
 
 	db := o.db
@@ -289,11 +289,11 @@ func (o *Chunk) UpdateProvingStatusByBatchHash(ctx context.Context, batchHash st
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now()
+		updateFields["prover_assigned_at"] = time.Now().UTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now()
+		updateFields["proved_at"] = time.Now().UTC()
 	}
 
 	db := o.db

--- a/rollup/internal/orm/chunk.go
+++ b/rollup/internal/orm/chunk.go
@@ -11,8 +11,9 @@ import (
 	"gorm.io/gorm"
 
 	"scroll-tech/common/types"
+	"scroll-tech/common/utils"
 
-	"scroll-tech/rollup/internal/utils"
+	rutils "scroll-tech/rollup/internal/utils"
 )
 
 // Chunk represents a chunk of blocks in the database.
@@ -177,7 +178,7 @@ func (o *Chunk) GetChunksByBatchHash(ctx context.Context, batchHash string) ([]*
 }
 
 // InsertChunk inserts a new chunk into the database.
-func (o *Chunk) InsertChunk(ctx context.Context, chunk *encoding.Chunk, codecVersion encoding.CodecVersion, metrics utils.ChunkMetrics, dbTX ...*gorm.DB) (*Chunk, error) {
+func (o *Chunk) InsertChunk(ctx context.Context, chunk *encoding.Chunk, codecVersion encoding.CodecVersion, metrics rutils.ChunkMetrics, dbTX ...*gorm.DB) (*Chunk, error) {
 	if chunk == nil || len(chunk.Blocks) == 0 {
 		return nil, errors.New("invalid args")
 	}
@@ -202,7 +203,7 @@ func (o *Chunk) InsertChunk(ctx context.Context, chunk *encoding.Chunk, codecVer
 		parentChunkStateRoot = parentChunk.StateRoot
 	}
 
-	chunkHash, err := utils.GetChunkHash(chunk, totalL1MessagePoppedBefore, codecVersion)
+	chunkHash, err := rutils.GetChunkHash(chunk, totalL1MessagePoppedBefore, codecVersion)
 	if err != nil {
 		log.Error("failed to get chunk hash", "err", err)
 		return nil, fmt.Errorf("Chunk.InsertChunk error: %w", err)
@@ -261,11 +262,11 @@ func (o *Chunk) UpdateProvingStatus(ctx context.Context, hash string, status typ
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now().UTC()
+		updateFields["prover_assigned_at"] = utils.NowUTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now().UTC()
+		updateFields["proved_at"] = utils.NowUTC()
 	}
 
 	db := o.db
@@ -289,11 +290,11 @@ func (o *Chunk) UpdateProvingStatusByBatchHash(ctx context.Context, batchHash st
 
 	switch status {
 	case types.ProvingTaskAssigned:
-		updateFields["prover_assigned_at"] = time.Now().UTC()
+		updateFields["prover_assigned_at"] = utils.NowUTC()
 	case types.ProvingTaskUnassigned:
 		updateFields["prover_assigned_at"] = nil
 	case types.ProvingTaskVerified:
-		updateFields["proved_at"] = time.Now().UTC()
+		updateFields["proved_at"] = utils.NowUTC()
 	}
 
 	db := o.db


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR solves two known issues:
- https://scroll.io/rollupscan does not show "finalizing" status, it's due to the batch "finalizing" status is not updated.
- The db timestamp timezone is not unified, this pr modifies all into `Universal Coordinated Time`.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version number to v4.4.84.
- **Improvements**
	- Enhanced transaction handling for bundle finalization, ensuring atomic updates and better error management.
	- Standardized timestamp handling across various methods to use UTC format for improved accuracy.
	- Streamlined utility function usage by consolidating imports and renaming for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->