### PR TITLE
fix(build): image building

### DIFF
--- a/build/dockerfiles/bridgehistoryapi-db-cli.Dockerfile
+++ b/build/dockerfiles/bridgehistoryapi-db-cli.Dockerfile
@@ -10,7 +10,7 @@ FROM base as builder
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd /src/bridge-history-api/cmd/db_cli && CGO_LDFLAGS="-ldl" go build -v -p 4 -o /bin/db_cli
+    cd /src/bridge-history-api/cmd/db_cli && CGO_LDFLAGS="-Wl,--no-as-needed -ldl" go build -v -p 4 -o /bin/db_cli
 
 # Pull db_cli into a second stage deploy ubuntu container
 FROM ubuntu:20.04

--- a/build/dockerfiles/bridgehistoryapi-db-cli.Dockerfile
+++ b/build/dockerfiles/bridgehistoryapi-db-cli.Dockerfile
@@ -10,10 +10,11 @@ FROM base as builder
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd /src/bridge-history-api/cmd/db_cli && go build -v -p 4 -o /bin/db_cli
+    cd /src/bridge-history-api/cmd/db_cli && CGO_LDFLAGS="-ldl" go build -v -p 4 -o /bin/db_cli
 
-# Pull db_cli into a second stage deploy alpine container
-FROM alpine:latest
+# Pull db_cli into a second stage deploy ubuntu container
+FROM ubuntu:20.04
+ENV CGO_LDFLAGS="-ldl"
 COPY --from=builder /bin/db_cli /bin/
 WORKDIR /app
 ENTRYPOINT ["db_cli"]

--- a/build/dockerfiles/bridgehistoryapi-db-cli.Dockerfile
+++ b/build/dockerfiles/bridgehistoryapi-db-cli.Dockerfile
@@ -1,5 +1,5 @@
 # Download Go dependencies
-FROM golang:1.21-alpine3.19 as base
+FROM scrolltech/go-rust-builder:go-1.21-rust-nightly-2023-12-03 as base
 
 WORKDIR /src
 COPY ./bridge-history-api/go.* ./

--- a/build/dockerfiles/db_cli.Dockerfile
+++ b/build/dockerfiles/db_cli.Dockerfile
@@ -1,5 +1,5 @@
 # Download Go dependencies
-FROM scrolltech/go-alpine-builder:1.21 as base
+FROM scrolltech/go-rust-builder:go-1.21-rust-nightly-2023-12-03 as base
 
 WORKDIR /src
 COPY go.work* ./

--- a/build/dockerfiles/db_cli.Dockerfile
+++ b/build/dockerfiles/db_cli.Dockerfile
@@ -16,7 +16,7 @@ FROM base as builder
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd /src/database/cmd && CGO_LDFLAGS="-ldl" go build -v -p 4 -o /bin/db_cli
+    cd /src/database/cmd && CGO_LDFLAGS="-Wl,--no-as-needed -ldl" go build -v -p 4 -o /bin/db_cli
 
 # Pull db_cli into a second stage deploy ubuntu container
 FROM ubuntu:20.04

--- a/build/dockerfiles/db_cli.Dockerfile
+++ b/build/dockerfiles/db_cli.Dockerfile
@@ -16,10 +16,11 @@ FROM base as builder
 
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd /src/database/cmd && go build -v -p 4 -o /bin/db_cli
+    cd /src/database/cmd && CGO_LDFLAGS="-ldl" go build -v -p 4 -o /bin/db_cli
 
-# Pull db_cli into a second stage deploy alpine container
-FROM alpine:latest
+# Pull db_cli into a second stage deploy ubuntu container
+FROM ubuntu:20.04
+ENV CGO_LDFLAGS="-ldl"
 COPY --from=builder /bin/db_cli /bin/
 WORKDIR /app
 ENTRYPOINT ["db_cli"]

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.88"
+var tag = "v4.4.89"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/go.work.sum
+++ b/go.work.sum
@@ -629,6 +629,7 @@ github.com/dave/jennifer v1.2.0 h1:S15ZkFMRoJ36mGAQgWL1tnr0NQJh9rZ8qatseX/VbBc=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/dchest/blake512 v1.0.0 h1:oDFEQFIqFSeuA34xLtXZ/rWxCXdSjirjzPhey5EUvmA=
 github.com/dchest/blake512 v1.0.0/go.mod h1:FV1x7xPPLWukZlpDpWQ88rF/SFwZ5qbskrzhLMB92JI=
+github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/deepmap/oapi-codegen v1.6.0 h1:w/d1ntwh91XI0b/8ja7+u5SvA4IFfM0UNNLmiDR1gg0=
 github.com/deepmap/oapi-codegen v1.6.0/go.mod h1:ryDa9AgbELGeB+YEXE1dR53yAjHwFvE9iAUlWl9Al3M=

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -12,7 +12,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scroll-tech/go-ethereum/common"
-	"github.com/scroll-tech/go-ethereum/consensus/misc/eip4844"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
 	"github.com/scroll-tech/go-ethereum/ethclient"
@@ -675,7 +675,7 @@ func (s *Sender) getBlockNumberAndBaseFeeAndBlobFee(ctx context.Context) (uint64
 
 	var blobBaseFee uint64
 	if excess := header.ExcessBlobGas; excess != nil {
-		blobBaseFee = eip4844.CalcBlobFee(*excess).Uint64()
+		blobBaseFee = misc.CalcBlobFee(*excess).Uint64()
 	}
 	// header.Number.Uint64() returns the pendingBlockNumber, so we minus 1 to get the latestBlockNumber.
 	return header.Number.Uint64() - 1, baseFee, blobBaseFee, nil

--- a/rollup/internal/controller/watcher/l1_watcher.go
+++ b/rollup/internal/controller/watcher/l1_watcher.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/scroll-tech/go-ethereum/consensus/misc/eip4844"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/log"
@@ -80,7 +80,7 @@ func (w *L1WatcherClient) FetchBlockHeader(blockHeight uint64) error {
 
 	var blobBaseFee uint64
 	if excess := block.ExcessBlobGas; excess != nil {
-		blobBaseFee = eip4844.CalcBlobFee(*excess).Uint64()
+		blobBaseFee = misc.CalcBlobFee(*excess).Uint64()
 	}
 
 	l1Block := orm.L1Block{


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fixes `go.work.sync` update in image building and fixes compile errors in `rollup-relayer` and `gas-oracle`. It also changes the base images of `rollup-db-cli` and `bridgehistoryapi-db-cli` to Ubuntu, making them compatible with `.a` files in `da-codec`'s `zstd` library.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to v4.4.89.
  - Improved build and deployment setups by switching to updated container images and adding necessary build flags.
  
- **Refactor**
  - Consolidated fee calculation dependencies to streamline internal logic without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->