### PR TITLE
fix(coordinator): jwt backward compatibility

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.89"
+var tag = "v4.4.90"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -79,7 +79,8 @@ func (b *BaseProverTask) checkParameter(ctx *gin.Context) (*proverTaskContext, e
 
 	ProverProviderType, ProverProviderTypeExist := ctx.Get(coordinatorType.ProverProviderTypeKey)
 	if !ProverProviderTypeExist {
-		return nil, errors.New("get prover provider type from context failed")
+		// for backward compatibility, set ProverProviderType as internal
+		ProverProviderType = coordinatorType.ProverProviderTypeInternal
 	}
 	ptc.ProverProviderType = uint8(ProverProviderType.(float64))
 

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -80,7 +80,7 @@ func (b *BaseProverTask) checkParameter(ctx *gin.Context) (*proverTaskContext, e
 	ProverProviderType, ProverProviderTypeExist := ctx.Get(coordinatorType.ProverProviderTypeKey)
 	if !ProverProviderTypeExist {
 		// for backward compatibility, set ProverProviderType as internal
-		ProverProviderType = coordinatorType.ProverProviderTypeInternal
+		ProverProviderType = float64(coordinatorType.ProverProviderTypeInternal)
 	}
 	ptc.ProverProviderType = uint8(ProverProviderType.(float64))
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

To fix the issue when a prover holds a jwt token that dispatched by old version of coordinator, it will fail to pass the jwt token fields check, and not able to query task until jwt expires. So we should add the jwt backward compatibility here.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the software version to v4.4.90.
- **Bug Fixes**
	- Improved error handling by adopting a fallback default when a required configuration is missing, enhancing the application’s stability and ensuring a smoother operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->