### PR TITLE
chore(zkvm-circuit): upgrade to 0.1.0-rc.6

### DIFF
--- a/common/libzkp/impl/Cargo.lock
+++ b/common/libzkp/impl/Cargo.lock
@@ -2877,13 +2877,13 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bytemuck",
  "hex-literal",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
  "serde",
 ]
@@ -2891,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2930,14 +2930,14 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "halo2curves-axiom 0.5.3",
  "num-bigint 0.4.6",
  "openvm",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-macros",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "serde-big-array",
  "strum_macros 0.26.4",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -2993,12 +2993,12 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "openvm",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "strum_macros 0.26.4",
 ]
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3021,13 +3021,13 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "cargo_metadata",
  "dirs",
  "eyre",
  "hex",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "serde_json",
  "tempfile",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -3074,7 +3074,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -3122,9 +3122,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-custom-insn"
+version = "0.1.0"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3155,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3171,8 +3181,9 @@ dependencies = [
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
  "openvm-ecc-sw-macros",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
+ "p256",
  "rand",
  "serde",
  "strum_macros 0.26.4",
@@ -3181,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3191,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -3205,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -3222,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3232,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -3261,9 +3272,9 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "tiny-keccak",
 ]
@@ -3271,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3285,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "syn 2.0.98",
 ]
@@ -3293,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -3312,7 +3323,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -3340,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -3364,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3374,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "cfg-if",
  "itertools 0.13.0",
@@ -3401,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3432,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
@@ -3447,7 +3458,7 @@ dependencies = [
  "openvm-algebra-moduli-macros",
  "openvm-ecc-guest",
  "openvm-ecc-sw-macros",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
  "rand",
  "serde",
@@ -3457,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3473,9 +3484,19 @@ name = "openvm-platform"
 version = "1.0.0-rc.1"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
 dependencies = [
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1)",
+ "stability",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "openvm-platform"
+version = "1.0.0-rc.1"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+dependencies = [
  "getrandom 0.2.15",
  "libm",
- "openvm-custom-insn",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "stability",
  "strum_macros 0.26.4",
 ]
@@ -3483,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derivative",
  "itertools 0.13.0",
@@ -3503,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.13.0",
@@ -3524,7 +3545,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -3551,16 +3572,16 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3576,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3619,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -3630,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -3654,17 +3675,17 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "sha2",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3678,7 +3699,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.0-rc.0#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=bc364134b8315c27bfd29c6e77ac79fe77090137#bc364134b8315c27bfd29c6e77ac79fe77090137"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3704,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.0-rc.0#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=bc364134b8315c27bfd29c6e77ac79fe77090137#bc364134b8315c27bfd29c6e77ac79fe77090137"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",
@@ -3739,13 +3760,13 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive_more 1.0.0",
  "elf",
  "eyre",
  "openvm-instructions",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-stark-backend",
  "rrs-lib",
  "strum 0.26.3",
@@ -4581,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4600,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4617,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4628,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4641,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4654,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4678,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -4703,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4717,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4733,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -4748,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4768,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4793,7 +4814,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4814,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4828,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4846,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "serde",
  "serde_json",
@@ -4856,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "metrics 0.24.1",
  "metrics-derive",
@@ -4865,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4878,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4895,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -4908,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4937,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -4950,7 +4971,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4965,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4988,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -4996,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5022,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5034,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5058,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -5071,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -5082,7 +5103,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5107,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5122,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "clap",
  "eyre",
@@ -5137,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5159,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5182,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5200,7 +5221,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5215,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "zstd",
 ]
@@ -5238,13 +5259,28 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "19.4.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
 dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
  "revm-interpreter 15.1.0",
  "revm-precompile 16.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm"
+version = "19.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc5bef3c95fadf3b6a24a253600348380c169ef285f9780a793bb7090c8990d"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 15.2.0",
+ "revm-precompile 16.1.0",
  "serde",
  "serde_json",
 ]
@@ -5262,9 +5298,19 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
 dependencies = [
  "revm-primitives 15.1.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "15.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
+dependencies = [
+ "revm-primitives 15.2.0",
  "serde",
 ]
 
@@ -5290,7 +5336,26 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "16.0.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
+dependencies = [
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "once_cell",
+ "p256",
+ "revm-primitives 15.1.0",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "16.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6caa1a7ff2cc4a09a263fcf9de99151706f323d30f33d519ed329f017a02b046"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -5298,8 +5363,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "once_cell",
- "p256",
- "revm-primitives 15.1.0",
+ "revm-primitives 15.2.0",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -5329,7 +5393,27 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702 0.5.1",
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hex",
+ "serde",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "15.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.5.1",
@@ -5544,7 +5628,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 [[package]]
 name = "sbv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "sbv-core",
  "sbv-helpers",
@@ -5556,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "sbv-core"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
@@ -5567,16 +5651,13 @@ dependencies = [
  "sbv-kv",
  "sbv-primitives",
  "sbv-trie",
- "serde",
- "serde_json",
  "thiserror 1.0.69",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "sbv-helpers"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -5584,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "sbv-kv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "auto_impl",
  "hashbrown 0.15.2",
@@ -5594,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "sbv-primitives"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5605,9 +5686,11 @@ dependencies = [
  "auto_impl",
  "itertools 0.14.0",
  "reth-chainspec",
+ "reth-ethereum-forks",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-scroll-chainspec",
+ "reth-scroll-forks",
  "reth-scroll-primitives",
  "revm 19.4.0",
  "rkyv",
@@ -5623,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "sbv-trie"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "alloy-rlp",
  "alloy-trie",
@@ -5638,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5655,8 +5738,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-alloy-network"
-version = "1.2.0"
-source = "git+https://github.com/scroll-tech/reth?branch=scroll#6e900070fb70a33e540df15c2c368d744032e148"
+version = "1.1.5"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5669,8 +5752,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-alloy-rpc-types"
-version = "1.2.0"
-source = "git+https://github.com/scroll-tech/reth?branch=scroll#6e900070fb70a33e540df15c2c368d744032e148"
+version = "1.1.5"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5686,8 +5769,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-circuit-input-types"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.5#618390488e7fbe6843bced19348c5113fedc1245"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.6#3c961e850691dd0990df4d64deea6d00e70dff00"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.8.3",
@@ -5701,8 +5784,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-prover"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.5#618390488e7fbe6843bced19348c5113fedc1245"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.6#3c961e850691dd0990df4d64deea6d00e70dff00"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -5717,7 +5800,7 @@ dependencies = [
  "openvm-native-recursion",
  "openvm-sdk",
  "openvm-stark-sdk",
- "revm 19.4.0",
+ "revm 19.5.0",
  "rkyv",
  "sbv",
  "scroll-zkvm-circuit-input-types",
@@ -5733,8 +5816,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-verifier"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.5#618390488e7fbe6843bced19348c5113fedc1245"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.6#3c961e850691dd0990df4d64deea6d00e70dff00"
 dependencies = [
  "bincode",
  "eyre",
@@ -5742,7 +5825,7 @@ dependencies = [
  "openvm-native-circuit",
  "openvm-native-recursion",
  "openvm-sdk",
- "revm 19.4.0",
+ "revm 19.5.0",
  "scroll-zkvm-circuit-input-types",
  "serde",
  "snark-verifier-sdk",
@@ -6413,7 +6496,7 @@ source = "git+https://github.com/scroll-tech/tiny-keccak?branch=scroll-patch-v2.
 dependencies = [
  "cfg-if",
  "crunchy",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1)",
 ]
 
 [[package]]
@@ -7235,4 +7318,4 @@ dependencies = [
 [[package]]
 name = "zstd"
 version = "1.1.4"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"

--- a/common/libzkp/impl/Cargo.toml
+++ b/common/libzkp/impl/Cargo.toml
@@ -10,39 +10,12 @@ crate-type = ["cdylib"]
 [patch.crates-io]
 # patched add rkyv support & MSRV 1.77
 alloy-primitives = { git = "https://github.com/scroll-tech/alloy-core", branch = "v0.8.21" }
-revm = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-interpreter = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-precompile = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-primitives = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
 ruint = { git = "https://github.com/scroll-tech/uint.git", branch = "v1.12.3" }
 tiny-keccak = { git = "https://github.com/scroll-tech/tiny-keccak", branch = "scroll-patch-v2.0.2-openvm-v1.0.0-rc.1" }
 
-[patch."https://github.com/scroll-tech/revm.git"]
-revm = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-interpreter = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-precompile = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-primitives = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-
-[patch."https://github.com/scroll-tech/reth.git"]
-reth-chainspec = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-evm = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-evm-ethereum = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-execution-types = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-primitives = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-primitives-traits = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-storage-errors = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-trie = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-trie-sparse = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-
-reth-scroll-chainspec = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-scroll-evm = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-scroll-primitives = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-
-scroll-alloy-consensus = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-
 [dependencies]
-euclid_prover = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.5", package = "scroll-zkvm-prover" }
-euclid_verifier = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.5", package = "scroll-zkvm-verifier" }
+euclid_prover = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.6", package = "scroll-zkvm-prover" }
+euclid_verifier = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.6", package = "scroll-zkvm-verifier" }
 
 base64 = "0.13.0"
 env_logger = "0.9.0"

--- a/zkvm-prover/Cargo.lock
+++ b/zkvm-prover/Cargo.lock
@@ -4099,13 +4099,13 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bytemuck",
  "hex-literal",
  "num-bigint 0.4.6",
  "num-traits",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
  "serde",
 ]
@@ -4113,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4142,7 +4142,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4152,14 +4152,14 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "halo2curves-axiom 0.5.3",
  "num-bigint 0.4.6",
  "openvm",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-macros",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "serde-big-array",
  "strum_macros 0.26.4",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4178,7 +4178,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4215,12 +4215,12 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "openvm",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "strum_macros 0.26.4",
 ]
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4243,13 +4243,13 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "cargo_metadata",
  "dirs",
  "eyre",
  "hex",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "serde_json",
  "tempfile",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -4296,7 +4296,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -4344,9 +4344,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-custom-insn"
+version = "0.1.0"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4377,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4393,8 +4403,9 @@ dependencies = [
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
  "openvm-ecc-sw-macros",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
+ "p256",
  "rand",
  "serde",
  "strum_macros 0.26.4",
@@ -4403,7 +4414,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4413,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4427,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4444,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4454,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -4483,9 +4494,9 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "serde",
  "tiny-keccak",
 ]
@@ -4493,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4507,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "syn 2.0.98",
 ]
@@ -4515,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -4534,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -4562,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -4586,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4596,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "cfg-if",
  "itertools 0.13.0",
@@ -4623,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4654,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
@@ -4669,7 +4680,7 @@ dependencies = [
  "openvm-algebra-moduli-macros",
  "openvm-ecc-guest",
  "openvm-ecc-sw-macros",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
  "rand",
  "serde",
@@ -4679,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4695,9 +4706,19 @@ name = "openvm-platform"
 version = "1.0.0-rc.1"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
 dependencies = [
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1)",
+ "stability",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "openvm-platform"
+version = "1.0.0-rc.1"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+dependencies = [
  "getrandom 0.2.15",
  "libm",
- "openvm-custom-insn",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "stability",
  "strum_macros 0.26.4",
 ]
@@ -4705,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derivative",
  "itertools 0.13.0",
@@ -4725,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.13.0",
@@ -4746,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -4773,16 +4794,16 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4798,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4841,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4852,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "bitcode",
  "derive-new 0.6.0",
@@ -4876,17 +4897,17 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "sha2",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4900,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.0-rc.0#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=bc364134b8315c27bfd29c6e77ac79fe77090137#bc364134b8315c27bfd29c6e77ac79fe77090137"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4926,7 +4947,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.0.0-rc.0#18cf1c084ebeb3ca1163e55b87893f1d1fd7fc1f"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=bc364134b8315c27bfd29c6e77ac79fe77090137#bc364134b8315c27bfd29c6e77ac79fe77090137"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",
@@ -4961,13 +4982,13 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
 dependencies = [
  "derive_more 1.0.0",
  "elf",
  "eyre",
  "openvm-instructions",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-stark-backend",
  "rrs-lib",
  "strum 0.26.3",
@@ -6143,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6162,7 +6183,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6179,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -6190,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6203,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6216,7 +6237,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6240,7 +6261,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6265,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6279,7 +6300,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6295,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -6310,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6330,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6355,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6376,7 +6397,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6390,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6408,7 +6429,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "serde",
  "serde_json",
@@ -6418,7 +6439,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "metrics 0.24.1",
  "metrics-derive",
@@ -6427,7 +6448,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6440,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6457,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -6470,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6499,7 +6520,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -6512,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6527,7 +6548,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6550,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -6558,7 +6579,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6584,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6596,7 +6617,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6620,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -6633,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -6644,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6669,7 +6690,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6684,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "clap",
  "eyre",
@@ -6699,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6721,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6744,7 +6765,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6762,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6777,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "zstd",
 ]
@@ -6811,13 +6832,28 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "19.4.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
 dependencies = [
  "auto_impl",
  "cfg-if",
  "dyn-clone",
  "revm-interpreter 15.1.0",
  "revm-precompile 16.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm"
+version = "19.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc5bef3c95fadf3b6a24a253600348380c169ef285f9780a793bb7090c8990d"
+dependencies = [
+ "auto_impl",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter 15.2.0",
+ "revm-precompile 16.1.0",
  "serde",
  "serde_json",
 ]
@@ -6835,9 +6871,19 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
 dependencies = [
  "revm-primitives 15.1.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "15.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcab7ef2064057acfc84731205f4bc77f4ec1b35630800b26ff6a185731c5ab"
+dependencies = [
+ "revm-primitives 15.2.0",
  "serde",
 ]
 
@@ -6863,7 +6909,26 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "16.0.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
+dependencies = [
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "once_cell",
+ "p256",
+ "revm-primitives 15.1.0",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "16.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6caa1a7ff2cc4a09a263fcf9de99151706f323d30f33d519ed329f017a02b046"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -6871,8 +6936,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "once_cell",
- "p256",
- "revm-primitives 15.1.0",
+ "revm-primitives 15.2.0",
  "ripemd",
  "secp256k1",
  "sha2",
@@ -6902,7 +6966,27 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech//revm?branch=scroll-evm-executor%2Fv55#6accb0ba959747d717443954a8bd988efa8f98fc"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#fdfbc90666769aec55c05a6aefdb6e5e1c32a3b3"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702 0.5.1",
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.8.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hex",
+ "serde",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "15.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.5.1",
@@ -7261,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "sbv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "sbv-core",
  "sbv-helpers",
@@ -7273,7 +7357,7 @@ dependencies = [
 [[package]]
 name = "sbv-core"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
@@ -7284,16 +7368,13 @@ dependencies = [
  "sbv-kv",
  "sbv-primitives",
  "sbv-trie",
- "serde",
- "serde_json",
  "thiserror 1.0.69",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "sbv-helpers"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -7301,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "sbv-kv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "auto_impl",
  "hashbrown 0.15.2",
@@ -7311,7 +7392,7 @@ dependencies = [
 [[package]]
 name = "sbv-primitives"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7322,9 +7403,11 @@ dependencies = [
  "auto_impl",
  "itertools 0.14.0",
  "reth-chainspec",
+ "reth-ethereum-forks",
  "reth-primitives",
  "reth-primitives-traits",
  "reth-scroll-chainspec",
+ "reth-scroll-forks",
  "reth-scroll-primitives",
  "revm 19.4.0",
  "rkyv",
@@ -7340,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "sbv-trie"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "alloy-rlp",
  "alloy-trie",
@@ -7355,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "sbv-utils"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Frevm-v55-upgrade#a3454462fe7a7b567e44965162cb7854b629842c"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#d8d215eb23262030e3e628b4156867cee2b1c50f"
 dependencies = [
  "alloy-provider",
  "alloy-transport",
@@ -7407,7 +7490,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7424,8 +7507,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-alloy-network"
-version = "1.2.0"
-source = "git+https://github.com/scroll-tech/reth?branch=scroll#6e900070fb70a33e540df15c2c368d744032e148"
+version = "1.1.5"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -7438,8 +7521,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-alloy-rpc-types"
-version = "1.2.0"
-source = "git+https://github.com/scroll-tech/reth?branch=scroll#6e900070fb70a33e540df15c2c368d744032e148"
+version = "1.1.5"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7456,7 +7539,7 @@ dependencies = [
 [[package]]
 name = "scroll-proving-sdk"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/scroll-proving-sdk.git?rev=eed375d#eed375df2d310a3e794280caba073efded99642c"
+source = "git+https://github.com/scroll-tech/scroll-proving-sdk.git?rev=9524a42#9524a42db51477d1c7658c8f3d192330b449ef21"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7488,8 +7571,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-circuit-input-types"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.5#618390488e7fbe6843bced19348c5113fedc1245"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.6#3c961e850691dd0990df4d64deea6d00e70dff00"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.8.3",
@@ -7503,8 +7586,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-prover"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.5#618390488e7fbe6843bced19348c5113fedc1245"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.6#3c961e850691dd0990df4d64deea6d00e70dff00"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -7519,7 +7602,7 @@ dependencies = [
  "openvm-native-recursion",
  "openvm-sdk",
  "openvm-stark-sdk",
- "revm 19.4.0",
+ "revm 19.5.0",
  "rkyv",
  "sbv",
  "scroll-zkvm-circuit-input-types",
@@ -7535,8 +7618,8 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-verifier"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.5#618390488e7fbe6843bced19348c5113fedc1245"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.6#3c961e850691dd0990df4d64deea6d00e70dff00"
 dependencies = [
  "bincode",
  "eyre",
@@ -7544,7 +7627,7 @@ dependencies = [
  "openvm-native-circuit",
  "openvm-native-recursion",
  "openvm-sdk",
- "revm 19.4.0",
+ "revm 19.5.0",
  "scroll-zkvm-circuit-input-types",
  "serde",
  "snark-verifier-sdk",
@@ -8425,7 +8508,7 @@ source = "git+https://github.com/scroll-tech/tiny-keccak?branch=scroll-patch-v2.
 dependencies = [
  "cfg-if",
  "crunchy",
- "openvm-platform",
+ "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1)",
 ]
 
 [[package]]
@@ -9618,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "zstd"
 version = "1.1.4"
-source = "git+https://github.com/scroll-tech//reth?branch=fix%2Fscroll-zkvm#b2c7c70779050226ac44fddc5b38bafc819be2af"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#9203a55c3521a267737480ea5e1e481e04a5eb9f"
 
 [[package]]
 name = "zstd-sys"

--- a/zkvm-prover/Cargo.toml
+++ b/zkvm-prover/Cargo.toml
@@ -5,38 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-
 [patch.crates-io]
 alloy-primitives = { git = "https://github.com/scroll-tech/alloy-core", branch = "v0.8.21" }
-revm = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-interpreter = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-precompile = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-primitives = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
 ruint = { git = "https://github.com/scroll-tech/uint.git", branch = "v1.12.3" }
 tiny-keccak = { git = "https://github.com/scroll-tech/tiny-keccak", branch = "scroll-patch-v2.0.2-openvm-v1.0.0-rc.1" }
-
-[patch."https://github.com/scroll-tech/revm.git"]
-revm = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-interpreter = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-precompile = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-revm-primitives = { git = "https://github.com/scroll-tech//revm", branch = "scroll-evm-executor/v55" }
-
-[patch."https://github.com/scroll-tech/reth.git"]
-reth-chainspec = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-evm = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-evm-ethereum = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-execution-types = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-primitives = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-primitives-traits = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-storage-errors = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-trie = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-trie-sparse = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-
-reth-scroll-chainspec = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-scroll-evm = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-reth-scroll-primitives = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
-
-scroll-alloy-consensus = { git = "https://github.com/scroll-tech//reth", branch = "fix/scroll-zkvm" }
 
 [dependencies]
 anyhow = "1.0"
@@ -46,13 +18,13 @@ serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 futures = "0.3.30"
 
-scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.0-rc.5" }
+scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.0-rc.6" }
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "eed375d", features = [
+scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "9524a42", features = [
     "openvm",
 ] }
-sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/revm-v55-upgrade", features = [
+sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "zkvm/euclid-v2", features = [
     "scroll",
 ] }
 base64 = "0.13.1"


### PR DESCRIPTION
### Purpose or design rationale of this PR

Related commit in `scroll-proving-sdk`: https://github.com/scroll-tech/scroll-proving-sdk/pull/62/commits/9524a42db51477d1c7658c8f3d192330b449ef21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line interface for the zero-knowledge prover with enhanced configuration options including version reporting.
  - Added new configuration parameters for batch processing in Layer 2 relayer operations.
  - Enabled functionality to dump verification keys for improved diagnostics.

- **Improvements**
  - Upgraded toolchains and updated dependencies across all projects to boost compatibility and performance.
  - Enhanced error handling and logging across verification and task-processing modules.
  - Bumped the release version from v4.4.89 to v4.4.90.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->