### PR TITLE
fix(bridge-history): overwrite l2geth dependency by replace

### DIFF
--- a/bridge-history-api/go.mod
+++ b/bridge-history-api/go.mod
@@ -11,12 +11,14 @@ require (
 	github.com/pressly/goose/v3 v3.16.0
 	github.com/prometheus/client_golang v1.19.0
 	github.com/scroll-tech/da-codec v0.1.3-0.20250226072559-f8a8d3898f54
-	github.com/scroll-tech/go-ethereum v1.10.14-0.20250305084331-57148478e950 // It's a hotfix for the header hash compatibility issue, pls change this with caution
+	github.com/scroll-tech/go-ethereum v1.10.14-0.20250305084331-57148478e950
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/sync v0.11.0
 	gorm.io/gorm v1.25.7-0.20240204074919-46816ad31dde
 )
+
+replace github.com/scroll-tech/go-ethereum => github.com/scroll-tech/go-ethereum v1.10.14-0.20250305084331-57148478e950 // It's a hotfix for the header hash incompatibility issue, pls change this with caution
 
 require (
 	dario.cat/mergo v1.0.0 // indirect


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR overwrites l2geth dependency by `replace`, the dependency is a hotfix commit.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved internal dependency configuration to ensure better compatibility and stability. The update refines how the system manages its integrations, contributing to a smoother experience without altering end-user functionality.
  
- **Version Update**
  - Updated software version from v4.4.94 to v4.4.95, reflecting the latest changes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->