### PR TITLE
fix(coordinator): prover type string

### DIFF
--- a/coordinator/internal/types/prover.go
+++ b/coordinator/internal/types/prover.go
@@ -25,6 +25,8 @@ func (r ProverType) String() string {
 		return "prover type chunk"
 	case ProverTypeBatch:
 		return "prover type batch"
+	case ProverTypeOpenVM:
+		return "prover type openvm"
 	default:
 		return fmt.Sprintf("illegal prover type: %d", r)
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR

Avoid printing misleading "illegal prover type" for openvm provers.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix
