### PR TITLE
fix coordiantor assign bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ fmt: ## Format the code
 	cd $(PWD)/rollup/ && go mod tidy
 	cd $(PWD)/tests/integration-test/ && go mod tidy
 
-	goimports -local $(PWD)/bridge-history-api/ -w .
-	goimports -local $(PWD)/common/ -w .
-	goimports -local $(PWD)/coordinator/ -w .
-	goimports -local $(PWD)/database/ -w .
-	goimports -local $(PWD)/rollup/ -w .
-	goimports -local $(PWD)/tests/integration-test/ -w .
+	goimports -local scroll-tech/bridge-history-api/ -w .
+	goimports -local scroll-tech/common/ -w .
+	goimports -local scroll-tech/coordinator/ -w .
+	goimports -local scroll-tech/database/ -w .
+	goimports -local scroll-tech/rollup/ -w .
+	goimports -local scroll-tech/tests/integration-test/ -w .
 
 dev_docker: ## Build docker images for development/testing usages
 	docker pull postgres

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.95"
+var tag = "v4.4.96"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/controller/api/auth.go
+++ b/coordinator/internal/controller/api/auth.go
@@ -46,7 +46,7 @@ func (a *AuthController) Login(c *gin.Context) (interface{}, error) {
 
 	hardForkNames, err := a.loginLogic.ProverHardForkName(&login)
 	if err != nil {
-		return "", fmt.Errorf("prover hard name failure:%w", err)
+		return "", fmt.Errorf("prover hard fork name failure:%w", err)
 	}
 
 	// check the challenge is used, if used, return failure

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -3,6 +3,7 @@ package provertask
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -55,6 +56,20 @@ func NewBatchProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *go
 	return bp
 }
 
+// proverHardForkSanityCheck check the prover task's hard-fork name
+// and prover-task's hard-fork name is the same
+func (bp *BatchProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext, batchTask *orm.Batch) (string, error) {
+	hardForkName, getHardForkErr := bp.hardForkName(ctx, batchTask)
+	if getHardForkErr != nil {
+		return "", getHardForkErr
+	}
+
+	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
+		return "", errors.New("hard-fork name is not the same as the batch's hard-fork name")
+	}
+	return hardForkName, nil
+}
+
 // Assign load and assign batch tasks
 func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinatorType.GetTaskParameter) (*coordinatorType.GetTaskSchema, error) {
 	taskCtx, err := bp.checkParameter(ctx)
@@ -77,6 +92,7 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}
 
 	var batchTask *orm.Batch
+	var hardForkName string
 	for i := 0; i < 5; i++ {
 		var getTaskError error
 		var tmpBatchTask *orm.Batch
@@ -101,10 +117,17 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 			return nil, nil
 		}
 
+		var checkErr error
+		hardForkName, checkErr = bp.hardForkSanityCheck(ctx, taskCtx, tmpBatchTask)
+		if checkErr != nil {
+			log.Debug("hard fork sanity check failed", "height", getTaskParameter.ProverHeight, "err", checkErr)
+			return nil, nil
+		}
+
 		// Don't dispatch the same failing job to the same prover
-		proverTasks, getTaskError := bp.proverTaskOrm.GetFailedProverTasksByHash(ctx.Copy(), message.ProofTypeBatch, tmpBatchTask.Hash, 2)
-		if getTaskError != nil {
-			log.Error("failed to get prover tasks", "proof type", message.ProofTypeBatch.String(), "task ID", tmpBatchTask.Hash, "error", getTaskError)
+		proverTasks, getFailedTaskError := bp.proverTaskOrm.GetFailedProverTasksByHash(ctx.Copy(), message.ProofTypeBatch, tmpBatchTask.Hash, 2)
+		if getFailedTaskError != nil {
+			log.Error("failed to get prover tasks", "proof type", message.ProofTypeBatch.String(), "task ID", tmpBatchTask.Hash, "error", getFailedTaskError)
 			return nil, ErrCoordinatorInternalFailure
 		}
 		for i := 0; i < len(proverTasks); i++ {
@@ -132,22 +155,6 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 
 	if batchTask == nil {
 		log.Debug("get empty unassigned batch after retry 5 times", "height", getTaskParameter.ProverHeight)
-		return nil, nil
-	}
-
-	hardForkName, getHardForkErr := bp.hardForkName(ctx, batchTask)
-	if getHardForkErr != nil {
-		bp.recoverActiveAttempts(ctx, batchTask)
-		log.Error("retrieve hard fork name by batch failed", "task_id", batchTask.Hash, "err", getHardForkErr)
-		return nil, ErrCoordinatorInternalFailure
-	}
-
-	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
-		bp.recoverActiveAttempts(ctx, batchTask)
-		log.Debug("incompatible prover version",
-			"requisite hard fork name", hardForkName,
-			"prover hard fork name", taskCtx.HardForkNames,
-			"task_id", batchTask.Hash)
 		return nil, nil
 	}
 

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -3,7 +3,6 @@ package provertask
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,20 +55,6 @@ func NewBatchProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *go
 	return bp
 }
 
-// proverHardForkSanityCheck check the prover task's hard-fork name
-// and prover-task's hard-fork name is the same
-func (bp *BatchProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext, batchTask *orm.Batch) (string, error) {
-	hardForkName, getHardForkErr := bp.hardForkName(ctx, batchTask)
-	if getHardForkErr != nil {
-		return "", getHardForkErr
-	}
-
-	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
-		return "", errors.New("hard-fork name is not the same as the batch's hard-fork name")
-	}
-	return hardForkName, nil
-}
-
 // Assign load and assign batch tasks
 func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinatorType.GetTaskParameter) (*coordinatorType.GetTaskSchema, error) {
 	taskCtx, err := bp.checkParameter(ctx)
@@ -117,8 +102,11 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 			return nil, nil
 		}
 
+		taskCtx.taskType = message.ProofTypeBatch
+		taskCtx.batchTask = tmpBatchTask
+
 		var checkErr error
-		hardForkName, checkErr = bp.hardForkSanityCheck(ctx, taskCtx, tmpBatchTask)
+		hardForkName, checkErr = bp.hardForkSanityCheck(ctx, taskCtx)
 		if checkErr != nil {
 			log.Debug("hard fork sanity check failed", "height", getTaskParameter.ProverHeight, "err", checkErr)
 			return nil, nil
@@ -193,20 +181,6 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}).Inc()
 
 	return taskMsg, nil
-}
-
-func (bp *BatchProverTask) hardForkName(ctx *gin.Context, batchTask *orm.Batch) (string, error) {
-	startChunk, getChunkErr := bp.chunkOrm.GetChunkByHash(ctx, batchTask.StartChunkHash)
-	if getChunkErr != nil {
-		return "", getChunkErr
-	}
-
-	l2Block, getBlockErr := bp.blockOrm.GetL2BlockByNumber(ctx.Copy(), startChunk.StartBlockNumber)
-	if getBlockErr != nil {
-		return "", getBlockErr
-	}
-	hardForkName := encoding.GetHardforkName(bp.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
-	return hardForkName, nil
 }
 
 func (bp *BatchProverTask) formatProverTask(ctx context.Context, task *orm.ProverTask, batch *orm.Batch, hardForkName string) (*coordinatorType.GetTaskSchema, error) {

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -13,14 +13,14 @@ import (
 	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
 
-	"scroll-tech/common/types"
-	"scroll-tech/common/types/message"
-	"scroll-tech/common/utils"
-
 	"scroll-tech/coordinator/internal/config"
 	"scroll-tech/coordinator/internal/orm"
 	coordinatorType "scroll-tech/coordinator/internal/types"
 	cutils "scroll-tech/coordinator/internal/utils"
+
+	"scroll-tech/common/types"
+	"scroll-tech/common/types/message"
+	"scroll-tech/common/utils"
 )
 
 // BundleProverTask is prover task implement for bundle proof

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -3,14 +3,12 @@ package provertask
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/log"
 	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
@@ -54,20 +52,6 @@ func NewBundleProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *g
 		bundleTaskGetTaskProver: newGetTaskCounterVec(promauto.With(reg), "bundle"),
 	}
 	return bp
-}
-
-// proverHardForkSanityCheck check the prover task's hard-fork name
-// and prover-task's hard-fork name is the same
-func (bp *BundleProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext, bundleTask *orm.Bundle) (string, error) {
-	hardForkName, getHardForkErr := bp.hardForkName(ctx, bundleTask)
-	if getHardForkErr != nil {
-		return "", getHardForkErr
-	}
-
-	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
-		return "", errors.New("prover task's hard-fork name is not the same as the bundle's hard-fork name")
-	}
-	return hardForkName, nil
 }
 
 // Assign load and assign batch tasks
@@ -117,8 +101,11 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 			return nil, nil
 		}
 
+		taskCtx.taskType = message.ProofTypeBundle
+		taskCtx.bundleTask = tmpBundleTask
+
 		var checkErr error
-		hardForkName, checkErr = bp.hardForkSanityCheck(ctx, taskCtx, tmpBundleTask)
+		hardForkName, checkErr = bp.hardForkSanityCheck(ctx, taskCtx)
 		if checkErr != nil {
 			log.Debug("hard fork sanity check failed", "height", getTaskParameter.ProverHeight, "err", checkErr)
 			return nil, nil
@@ -193,26 +180,6 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 	}).Inc()
 
 	return taskMsg, nil
-}
-
-func (bp *BundleProverTask) hardForkName(ctx *gin.Context, bundleTask *orm.Bundle) (string, error) {
-	startBatch, getBatchErr := bp.batchOrm.GetBatchByHash(ctx, bundleTask.StartBatchHash)
-	if getBatchErr != nil {
-		return "", getBatchErr
-	}
-
-	startChunk, getChunkErr := bp.chunkOrm.GetChunkByHash(ctx, startBatch.StartChunkHash)
-	if getChunkErr != nil {
-		return "", getChunkErr
-	}
-
-	l2Block, getBlockErr := bp.blockOrm.GetL2BlockByNumber(ctx.Copy(), startChunk.StartBlockNumber)
-	if getBlockErr != nil {
-		return "", getBlockErr
-	}
-
-	hardForkName := encoding.GetHardforkName(bp.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
-	return hardForkName, nil
 }
 
 func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.ProverTask, hardForkName string) (*coordinatorType.GetTaskSchema, error) {

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -3,6 +3,7 @@ package provertask
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -55,6 +56,20 @@ func NewBundleProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *g
 	return bp
 }
 
+// proverHardForkSanityCheck check the prover task's hard-fork name
+// and prover-task's hard-fork name is the same
+func (bp *BundleProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext, bundleTask *orm.Bundle) (string, error) {
+	hardForkName, getHardForkErr := bp.hardForkName(ctx, bundleTask)
+	if getHardForkErr != nil {
+		return "", getHardForkErr
+	}
+
+	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
+		return "", errors.New("prover task's hard-fork name is not the same as the bundle's hard-fork name")
+	}
+	return hardForkName, nil
+}
+
 // Assign load and assign batch tasks
 func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinatorType.GetTaskParameter) (*coordinatorType.GetTaskSchema, error) {
 	taskCtx, err := bp.checkParameter(ctx)
@@ -77,6 +92,7 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 	}
 
 	var bundleTask *orm.Bundle
+	var hardForkName string
 	for i := 0; i < 5; i++ {
 		var getTaskError error
 		var tmpBundleTask *orm.Bundle
@@ -98,6 +114,13 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 
 		if tmpBundleTask == nil {
 			log.Debug("get empty bundle", "height", getTaskParameter.ProverHeight)
+			return nil, nil
+		}
+
+		var checkErr error
+		hardForkName, checkErr = bp.hardForkSanityCheck(ctx, taskCtx, tmpBundleTask)
+		if checkErr != nil {
+			log.Debug("hard fork sanity check failed", "height", getTaskParameter.ProverHeight, "err", checkErr)
 			return nil, nil
 		}
 
@@ -132,22 +155,6 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 
 	if bundleTask == nil {
 		log.Debug("get empty unassigned bundle after retry 5 times", "height", getTaskParameter.ProverHeight)
-		return nil, nil
-	}
-
-	hardForkName, getHardForkErr := bp.hardForkName(ctx, bundleTask)
-	if getHardForkErr != nil {
-		bp.recoverActiveAttempts(ctx, bundleTask)
-		log.Error("retrieve hard fork name by bundle failed", "task_id", bundleTask.Hash, "err", getHardForkErr)
-		return nil, ErrCoordinatorInternalFailure
-	}
-
-	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
-		bp.recoverActiveAttempts(ctx, bundleTask)
-		log.Debug("incompatible prover version",
-			"requisite hard fork name", hardForkName,
-			"prover hard fork name", taskCtx.HardForkNames,
-			"task_id", bundleTask.Hash)
 		return nil, nil
 	}
 

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -101,6 +101,7 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 
 		taskCtx.taskType = message.ProofTypeChunk
 		taskCtx.chunkTask = tmpChunkTask
+
 		var checkErr error
 		hardForkName, checkErr = cp.hardForkSanityCheck(ctx, taskCtx)
 		if checkErr != nil {

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -3,6 +3,7 @@ package provertask
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -53,6 +54,20 @@ func NewChunkProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *go
 	return cp
 }
 
+// proverHardForkSanityCheck check the prover task's hard-fork name
+// and prover-task's hard-fork name is the same
+func (cp *ChunkProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext, chunkTask *orm.Chunk) (string, error) {
+	hardForkName, getHardForkErr := cp.hardForkName(ctx, chunkTask)
+	if getHardForkErr != nil {
+		return "", getHardForkErr
+	}
+
+	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
+		return "", errors.New("prover task's hard-fork name is not the same as the chunk's hard-fork name")
+	}
+	return hardForkName, nil
+}
+
 // Assign the chunk proof which need to prove
 func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinatorType.GetTaskParameter) (*coordinatorType.GetTaskSchema, error) {
 	taskCtx, err := cp.checkParameter(ctx)
@@ -75,6 +90,7 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}
 
 	var chunkTask *orm.Chunk
+	var hardForkName string
 	for i := 0; i < 5; i++ {
 		var getTaskError error
 		var tmpChunkTask *orm.Chunk
@@ -99,10 +115,17 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 			return nil, nil
 		}
 
+		var checkErr error
+		hardForkName, checkErr = cp.hardForkSanityCheck(ctx, taskCtx, tmpChunkTask)
+		if checkErr != nil {
+			log.Debug("hard fork sanity check failed", "height", getTaskParameter.ProverHeight, "err", checkErr)
+			return nil, nil
+		}
+
 		// Don't dispatch the same failing job to the same prover
-		proverTasks, getTaskError := cp.proverTaskOrm.GetFailedProverTasksByHash(ctx.Copy(), message.ProofTypeChunk, tmpChunkTask.Hash, 2)
-		if getTaskError != nil {
-			log.Error("failed to get prover tasks", "proof type", message.ProofTypeChunk.String(), "task ID", tmpChunkTask.Hash, "error", getTaskError)
+		proverTasks, getFailedTaskError := cp.proverTaskOrm.GetFailedProverTasksByHash(ctx.Copy(), message.ProofTypeChunk, tmpChunkTask.Hash, 2)
+		if getFailedTaskError != nil {
+			log.Error("failed to get prover tasks", "proof type", message.ProofTypeChunk.String(), "task ID", tmpChunkTask.Hash, "error", getFailedTaskError)
 			return nil, ErrCoordinatorInternalFailure
 		}
 		for i := 0; i < len(proverTasks); i++ {
@@ -130,22 +153,6 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 
 	if chunkTask == nil {
 		log.Debug("get empty unassigned chunk after retry 5 times", "height", getTaskParameter.ProverHeight)
-		return nil, nil
-	}
-
-	hardForkName, getHardForkErr := cp.hardForkName(ctx, chunkTask)
-	if getHardForkErr != nil {
-		cp.recoverActiveAttempts(ctx, chunkTask)
-		log.Error("retrieve hard fork name by chunk failed", "task_id", chunkTask.Hash, "err", getHardForkErr)
-		return nil, ErrCoordinatorInternalFailure
-	}
-
-	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
-		cp.recoverActiveAttempts(ctx, chunkTask)
-		log.Debug("incompatible prover version",
-			"requisite hard fork name", hardForkName,
-			"prover hard fork name", taskCtx.HardForkNames,
-			"task_id", chunkTask.Hash)
 		return nil, nil
 	}
 

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -3,14 +3,12 @@ package provertask
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/log"
 	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
@@ -52,20 +50,6 @@ func NewChunkProverTask(cfg *config.Config, chainCfg *params.ChainConfig, db *go
 		chunkTaskGetTaskProver: newGetTaskCounterVec(promauto.With(reg), "chunk"),
 	}
 	return cp
-}
-
-// proverHardForkSanityCheck check the prover task's hard-fork name
-// and prover-task's hard-fork name is the same
-func (cp *ChunkProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext, chunkTask *orm.Chunk) (string, error) {
-	hardForkName, getHardForkErr := cp.hardForkName(ctx, chunkTask)
-	if getHardForkErr != nil {
-		return "", getHardForkErr
-	}
-
-	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
-		return "", errors.New("prover task's hard-fork name is not the same as the chunk's hard-fork name")
-	}
-	return hardForkName, nil
 }
 
 // Assign the chunk proof which need to prove
@@ -115,8 +99,10 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 			return nil, nil
 		}
 
+		taskCtx.taskType = message.ProofTypeChunk
+		taskCtx.chunkTask = tmpChunkTask
 		var checkErr error
-		hardForkName, checkErr = cp.hardForkSanityCheck(ctx, taskCtx, tmpChunkTask)
+		hardForkName, checkErr = cp.hardForkSanityCheck(ctx, taskCtx)
 		if checkErr != nil {
 			log.Debug("hard fork sanity check failed", "height", getTaskParameter.ProverHeight, "err", checkErr)
 			return nil, nil
@@ -190,15 +176,6 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	}).Inc()
 
 	return taskMsg, nil
-}
-
-func (cp *ChunkProverTask) hardForkName(ctx *gin.Context, chunkTask *orm.Chunk) (string, error) {
-	l2Block, getBlockErr := cp.blockOrm.GetL2BlockByNumber(ctx.Copy(), chunkTask.StartBlockNumber)
-	if getBlockErr != nil {
-		return "", getBlockErr
-	}
-	hardForkName := encoding.GetHardforkName(cp.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
-	return hardForkName, nil
 }
 
 func (cp *ChunkProverTask) formatProverTask(ctx context.Context, task *orm.ProverTask, hardForkName string) (*coordinatorType.GetTaskSchema, error) {

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/gorm"
 
 	"scroll-tech/common/types/message"
+
 	"scroll-tech/coordinator/internal/config"
 	"scroll-tech/coordinator/internal/orm"
 	coordinatorType "scroll-tech/coordinator/internal/types"

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -74,7 +74,7 @@ func (b *BaseProverTask) hardForkName(ctx *gin.Context, taskCtx *proverTaskConte
 		}
 		hardForkName := encoding.GetHardforkName(b.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
 		return hardForkName, nil
-		
+
 	case taskCtx.taskType == message.ProofTypeBatch:
 		if taskCtx.batchTask == nil {
 			return "", errors.New("batch task is nil")
@@ -113,7 +113,7 @@ func (b *BaseProverTask) hardForkName(ctx *gin.Context, taskCtx *proverTaskConte
 	}
 }
 
-// and prover-task's hard-fork name is the same
+// hardForkSanityCheck check the task's hard fork name is the same as prover
 func (b *BaseProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext) (string, error) {
 	hardForkName, getHardForkErr := b.hardForkName(ctx, taskCtx)
 	if getHardForkErr != nil {

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -9,9 +9,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
 
+	"scroll-tech/common/types/message"
 	"scroll-tech/coordinator/internal/config"
 	"scroll-tech/coordinator/internal/orm"
 	coordinatorType "scroll-tech/coordinator/internal/types"
@@ -52,6 +54,76 @@ type proverTaskContext struct {
 	ProverVersion      string
 	ProverProviderType uint8
 	HardForkNames      map[string]struct{}
+
+	taskType   message.ProofType
+	chunkTask  *orm.Chunk
+	batchTask  *orm.Batch
+	bundleTask *orm.Bundle
+}
+
+// hardForkName get the chunk/batch/bundle hard fork name
+func (b *BaseProverTask) hardForkName(ctx *gin.Context, taskCtx *proverTaskContext) (string, error) {
+	switch {
+	case taskCtx.taskType == message.ProofTypeChunk:
+		if taskCtx.chunkTask == nil {
+			return "", errors.New("chunk task is nil")
+		}
+		l2Block, getBlockErr := b.blockOrm.GetL2BlockByNumber(ctx.Copy(), taskCtx.chunkTask.StartBlockNumber)
+		if getBlockErr != nil {
+			return "", getBlockErr
+		}
+		hardForkName := encoding.GetHardforkName(b.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
+		return hardForkName, nil
+		
+	case taskCtx.taskType == message.ProofTypeBatch:
+		if taskCtx.batchTask == nil {
+			return "", errors.New("batch task is nil")
+		}
+		startChunk, getChunkErr := b.chunkOrm.GetChunkByHash(ctx, taskCtx.batchTask.StartChunkHash)
+		if getChunkErr != nil {
+			return "", getChunkErr
+		}
+		l2Block, getBlockErr := b.blockOrm.GetL2BlockByNumber(ctx.Copy(), startChunk.StartBlockNumber)
+		if getBlockErr != nil {
+			return "", getBlockErr
+		}
+		hardForkName := encoding.GetHardforkName(b.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
+		return hardForkName, nil
+
+	case taskCtx.taskType == message.ProofTypeBundle:
+		if taskCtx.bundleTask == nil {
+			return "", errors.New("bundle task is nil")
+		}
+		startBatch, getBatchErr := b.batchOrm.GetBatchByHash(ctx, taskCtx.bundleTask.StartBatchHash)
+		if getBatchErr != nil {
+			return "", getBatchErr
+		}
+		startChunk, getChunkErr := b.chunkOrm.GetChunkByHash(ctx, startBatch.StartChunkHash)
+		if getChunkErr != nil {
+			return "", getChunkErr
+		}
+		l2Block, getBlockErr := b.blockOrm.GetL2BlockByNumber(ctx.Copy(), startChunk.StartBlockNumber)
+		if getBlockErr != nil {
+			return "", getBlockErr
+		}
+		hardForkName := encoding.GetHardforkName(b.chainCfg, l2Block.Number, l2Block.BlockTimestamp)
+		return hardForkName, nil
+	default:
+		return "", errors.New("illegal task type")
+	}
+}
+
+// and prover-task's hard-fork name is the same
+func (b *BaseProverTask) hardForkSanityCheck(ctx *gin.Context, taskCtx *proverTaskContext) (string, error) {
+	hardForkName, getHardForkErr := b.hardForkName(ctx, taskCtx)
+	if getHardForkErr != nil {
+		return "", getHardForkErr
+	}
+
+	if _, ok := taskCtx.HardForkNames[hardForkName]; !ok {
+		return "", errors.New("to be assigned prover task's hard-fork name is not the same as prover")
+	}
+	return hardForkName, nil
 }
 
 // checkParameter check the prover task parameter illegal

--- a/coordinator/internal/orm/orm_test.go
+++ b/coordinator/internal/orm/orm_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/testcontainers"
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
 	"scroll-tech/common/utils"
-	"scroll-tech/database/migrate"
 )
 
 var (

--- a/coordinator/test/api_test.go
+++ b/coordinator/test/api_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/testcontainers"
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
 	"scroll-tech/common/version"
-	"scroll-tech/database/migrate"
 
 	"scroll-tech/coordinator/internal/config"
 	"scroll-tech/coordinator/internal/controller/api"

--- a/rollup/internal/config/config.go
+++ b/rollup/internal/config/config.go
@@ -3,8 +3,9 @@ package config
 import (
 	"fmt"
 	"reflect"
-	"scroll-tech/common/database"
 	"strings"
+
+	"scroll-tech/common/database"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/scroll-tech/go-ethereum/common"

--- a/rollup/internal/controller/sender/sender_test.go
+++ b/rollup/internal/controller/sender/sender_test.go
@@ -27,9 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/testcontainers"
 	"scroll-tech/common/types"
-	"scroll-tech/database/migrate"
 
 	bridgeAbi "scroll-tech/rollup/abi"
 	"scroll-tech/rollup/internal/config"

--- a/rollup/internal/controller/watcher/watcher_test.go
+++ b/rollup/internal/controller/watcher/watcher_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/database"
 	"scroll-tech/common/testcontainers"
-	"scroll-tech/database/migrate"
 
 	"scroll-tech/rollup/internal/config"
 )

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/testcontainers"
 	"scroll-tech/common/types"
 	"scroll-tech/common/types/message"
-	"scroll-tech/database/migrate"
 
 	"scroll-tech/rollup/internal/utils"
 )

--- a/rollup/tests/bridge_test.go
+++ b/rollup/tests/bridge_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/database"
 	tc "scroll-tech/common/testcontainers"
 	"scroll-tech/common/utils"
-	"scroll-tech/database/migrate"
 
 	bcmd "scroll-tech/rollup/cmd"
 	"scroll-tech/rollup/mock_bridge"

--- a/tests/integration-test/integration_test.go
+++ b/tests/integration-test/integration_test.go
@@ -12,11 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
+	"scroll-tech/integration-test/orm"
+
+	"scroll-tech/database/migrate"
+
 	"scroll-tech/common/testcontainers"
 	"scroll-tech/common/utils"
 	"scroll-tech/common/version"
-	"scroll-tech/database/migrate"
-	"scroll-tech/integration-test/orm"
 
 	capp "scroll-tech/coordinator/cmd/api/app"
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

The bug:

when provers try it more concurrently, there is no time for the coordinator to recover the attempts. 


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Updated the application version to v4.4.96.
- **New Features**
  - Introduced new methods for hard-fork validation in task management, enhancing error handling and task processing capabilities.
  - Added new fields to manage different task types within the task context.
- **Bug Fixes**
  - Clarified error message in the Login function to specify "fork" in case of prover hard fork name failure.
- **Style**
  - Reorganized import statements across various files for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->