### PR TITLE
fix: reduce segment len in prover config

### DIFF
--- a/zkvm-prover/Cargo.lock
+++ b/zkvm-prover/Cargo.lock
@@ -1495,7 +1495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2075,7 +2075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5842,7 +5842,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6830,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "19.4.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -6869,7 +6869,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
 dependencies = [
  "revm-primitives 15.1.0",
  "serde",
@@ -6907,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "16.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -6964,7 +6964,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.5.1",
@@ -7220,7 +7220,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-circuit-input-types"
 version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#01fb5e3b8b04f6e8a59056e1741f5d973589e727"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#0f251ba4541e2d136b953f10dae163686c0e815d"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.8.3",
@@ -7634,7 +7634,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#01fb5e3b8b04f6e8a59056e1741f5d973589e727"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#0f251ba4541e2d136b953f10dae163686c0e815d"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#01fb5e3b8b04f6e8a59056e1741f5d973589e727"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#0f251ba4541e2d136b953f10dae163686c0e815d"
 dependencies = [
  "bincode",
  "eyre",
@@ -8187,7 +8187,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8444,7 +8444,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/zkvm-prover/src/prover.rs
+++ b/zkvm-prover/src/prover.rs
@@ -190,7 +190,10 @@ impl LocalProver {
         // if we got assigned a task for an unknown hard fork, there is something wrong in the
         // coordinator
         let config = self.config.circuits.get(hard_fork_name).unwrap();
-        println!("config workspace path for hard-fork {:?} = {:?}", hard_fork_name, config.workspace_path);
+        println!(
+            "config workspace path for hard-fork {:?} = {:?}",
+            hard_fork_name, config.workspace_path
+        );
 
         match hard_fork_name {
             "euclid" => Arc::new(Arc::new(Mutex::new(EuclidHandler::new(

--- a/zkvm-prover/src/zk_circuits_handler/euclidV2.rs
+++ b/zkvm-prover/src/zk_circuits_handler/euclidV2.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use scroll_proving_sdk::prover::{proving_service::ProveRequest, ProofType};
 use scroll_zkvm_prover_euclidv2::{
     task::{batch::BatchProvingTask, bundle::BundleProvingTask, chunk::ChunkProvingTask},
-    BatchProver, BundleProver, ChunkProver,
+    BatchProver, BundleProver, ChunkProver, ProverConfig,
 };
 use tokio::sync::Mutex;
 pub struct EuclidV2Handler {
@@ -29,7 +29,9 @@ impl EuclidV2Handler {
             chunk_exe,
             chunk_app_config,
             Some(cache_dir.clone()),
-            Default::default(),
+            ProverConfig {
+                segment_len: Some((1 << 22) - 100),
+            },
         )
         .expect("Failed to setup chunk prover");
         println!("ok 2");
@@ -40,7 +42,9 @@ impl EuclidV2Handler {
             batch_exe,
             batch_app_config,
             Some(cache_dir.clone()),
-            Default::default(),
+            ProverConfig {
+                segment_len: Some((1 << 22) - 100),
+            },
         )
         .expect("Failed to setup batch prover");
         println!("ok 3");
@@ -51,7 +55,9 @@ impl EuclidV2Handler {
             bundle_exe,
             bundle_app_config,
             Some(cache_dir),
-            Default::default(),
+            ProverConfig {
+                segment_len: Some((1 << 22) - 100),
+            },
         )
         .expect("Failed to setup bundle prover");
         println!("ok 4");


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

reduced segment length so GPU prover can function well without falling back to CPU prover always

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes
