### PR TITLE
feat: use specific go version for builder images

### DIFF
--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -9,9 +9,13 @@ on:
         type: choice
         options:
           - "1.20"
+          - "1.20.14"
           - "1.21"
+          - "1.21.13"
           - "1.22"
+          - "1.22.12"
           - "1.23"
+          - "1.23.7"
         default: "1.21"
       RUST_VERSION:
         description: "Rust toolchain version"

--- a/build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/cuda-go-rust-builder.Dockerfile
@@ -1,5 +1,5 @@
 ARG CUDA_VERSION=11.7.1
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22.12
 ARG RUST_VERSION=nightly-2023-12-03
 ARG CARGO_CHEF_TAG=0.1.41
 
@@ -36,7 +36,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     else \
     echo "Unsupported architecture"; exit 1; \
     fi
-RUN wget https://go.dev/dl/go${GO_VERSION}.1.linux-$(cat /tmp/arch).tar.gz
-RUN tar -C /usr/local -xzf go${GO_VERSION}.1.linux-$(cat /tmp/arch).tar.gz
-RUN rm go${GO_VERSION}.1.linux-$(cat /tmp/arch).tar.gz && rm /tmp/arch
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-$(cat /tmp/arch).tar.gz
+RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-$(cat /tmp/arch).tar.gz
+RUN rm go${GO_VERSION}.linux-$(cat /tmp/arch).tar.gz && rm /tmp/arch
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/build/dockerfiles/intermediate/go-rust-builder.Dockerfile
+++ b/build/dockerfiles/intermediate/go-rust-builder.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22.12
 ARG RUST_VERSION=nightly-2023-12-03
 ARG CARGO_CHEF_TAG=0.1.41
 
@@ -32,7 +32,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     else \
     echo "Unsupported architecture"; exit 1; \
     fi
-RUN wget https://go.dev/dl/go${GO_VERSION}.1.linux-$(cat /tmp/arch).tar.gz
-RUN tar -C /usr/local -xzf go${GO_VERSION}.1.linux-$(cat /tmp/arch).tar.gz
-RUN rm go${GO_VERSION}.1.linux-$(cat /tmp/arch).tar.gz && rm /tmp/arch
+RUN wget https://go.dev/dl/go${GO_VERSION}.linux-$(cat /tmp/arch).tar.gz
+RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-$(cat /tmp/arch).tar.gz
+RUN rm go${GO_VERSION}.linux-$(cat /tmp/arch).tar.gz && rm /tmp/arch
 ENV PATH="/usr/local/go/bin:${PATH}"


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

Allow using latest go patch version for builder images.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [X] No, this PR doesn't involve a new deployment, git tag, docker image tag


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded manual workflow options to include four additional Go version choices, giving users a broader selection for triggering processes.

- **Chores**
  - Updated container configurations to use Go version 1.22.12, with adjustments to ensure the correct retrieval and setup of the Go binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->