### PR TITLE
fix(zkvm-prover): fix clap deprecated warnings

### DIFF
--- a/zkvm-prover/src/main.rs
+++ b/zkvm-prover/src/main.rs
@@ -10,7 +10,7 @@ use scroll_proving_sdk::{
 };
 
 #[derive(Parser, Debug)]
-#[clap(disable_version_flag = true)]
+#[command(disable_version_flag = true)]
 struct Args {
     /// Path of config file
     #[arg(long = "config", default_value = "conf/config.json")]


### PR DESCRIPTION
### Purpose or design rationale of this PR

similar to: https://github.com/scroll-tech/scroll/pull/1632

```
warning: use of deprecated function `<Args as clap::Args>::augment_args::old_attribute`: Attribute `#[clap(...)]` has been deprecated in favor of `#[command(...)]`
  --> src/main.rs:13:3
   |
13 | #[clap(disable_version_flag = true)]
   |   ^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `prover` (bin "prover") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 16s
```


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the command-line interface configuration to align with the latest parsing library standards while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->