### PR TITLE
Adapt to rc11 (unified phase)

### DIFF
--- a/zkvm-prover/Cargo.toml
+++ b/zkvm-prover/Cargo.toml
@@ -18,14 +18,16 @@ serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 futures = "0.3.30"
 
-scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.0-rc.6", package = "scroll-zkvm-prover" }
-scroll-zkvm-prover-euclidv2 = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.1-rc.3", package = "scroll-zkvm-prover" }
+scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", branch = "feat/phase1-stable", package = "scroll-zkvm-prover" }
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "c81e5f2", features = [
+#scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "c81e5f2", features = [
+#    "openvm",
+#] }
+scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", branch = "feat/openvm-euclid-upgrade", features = [
     "openvm",
 ] }
-sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "zkvm/euclid-v2", features = [
+sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "zkvm/euclid-upgrade", features = [
     "scroll",
 ] }
 base64 = "0.13.1"
@@ -47,33 +49,33 @@ ctor = "0.2.8"
 url = "2.5.4"
 serde_bytes = "0.11.15"
 
-[patch."https://github.com/openvm-org/stark-backend.git"]
-openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
-openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+#[patch."https://github.com/openvm-org/stark-backend.git"]
+#openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+#openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
 
-[patch."https://github.com/Plonky3/Plonky3.git"]
-p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
-    "nightly-features",
-], branch = "openvm-v2" }
-p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
-p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# [patch."https://github.com/Plonky3/Plonky3.git"]
+# p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
+#     "nightly-features",
+# ], branch = "openvm-v2" }
+# p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+# p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }

--- a/zkvm-prover/src/zk_circuits_handler/euclid.rs
+++ b/zkvm-prover/src/zk_circuits_handler/euclid.rs
@@ -6,35 +6,97 @@ use async_trait::async_trait;
 use scroll_proving_sdk::prover::{proving_service::ProveRequest, ProofType};
 use scroll_zkvm_prover_euclid::{
     task::{batch::BatchProvingTask, bundle::BundleProvingTask, chunk::ChunkProvingTask},
-    BatchProver, BundleProver, ChunkProver,
+    BatchProver, BundleProverEuclidV1, ChunkProver, ProverConfig,
 };
 use tokio::sync::Mutex;
 pub struct EuclidHandler {
     chunk_prover: ChunkProver,
     batch_prover: BatchProver,
-    bundle_prover: BundleProver,
+    bundle_prover: BundleProverEuclidV1,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Phase {
+    EuclidV1,
+    EuclidV2,
+}
+
+impl Phase {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Phase::EuclidV1 => "euclidv1",
+            Phase::EuclidV2 => "euclidv2",
+        }
+    }
+
+    pub fn phase_spec_chunk(&self, workspace_path: &Path) -> ProverConfig {
+        let dir_cache = Some(workspace_path.join("cache"));
+        let path_app_exe = workspace_path.join("chunk/app.vmexe");
+        let path_app_config = workspace_path.join("chunk/openvm.toml");
+        let segment_len = match self {
+            Phase::EuclidV1 => None,
+            Phase::EuclidV2 => Some((1 << 22) - 100),
+        };
+        ProverConfig {
+            dir_cache,
+            path_app_config,
+            path_app_exe,
+            segment_len,
+            ..Default::default()
+        }
+    }
+
+    pub fn phase_spec_batch(&self, workspace_path: &Path) -> ProverConfig {
+        let dir_cache = Some(workspace_path.join("cache"));
+        let path_app_exe = workspace_path.join("batch/app.vmexe");
+        let path_app_config = workspace_path.join("batch/openvm.toml");
+        let segment_len = match self {
+            Phase::EuclidV1 => None,
+            Phase::EuclidV2 => Some((1 << 22) - 100),
+        };
+        ProverConfig {
+            dir_cache,
+            path_app_config,
+            path_app_exe,
+            segment_len,
+            ..Default::default()
+        }
+    }
+
+    pub fn phase_spec_bundle(&self, workspace_path: &Path) -> ProverConfig {
+        let dir_cache = Some(workspace_path.join("cache"));
+        let path_app_config = workspace_path.join("bundle/openvm.toml");
+        match self {
+            Phase::EuclidV1 => ProverConfig {
+                dir_cache,
+                path_app_config,
+                path_app_exe: workspace_path.join("bundle/app_euclidv1.vmexe"),
+                ..Default::default()
+            },
+            Phase::EuclidV2 => ProverConfig {
+                dir_cache,
+                path_app_config,
+                path_app_exe: workspace_path.join("bundle/app.vmexe"),
+                segment_len: Some((1 << 22) - 100),
+                ..Default::default()
+            },
+        }
+    }
 }
 
 unsafe impl Send for EuclidHandler {}
 
 impl EuclidHandler {
     pub fn new(workspace_path: &str) -> Self {
+        let p = Phase::EuclidV1;
         let workspace_path = Path::new(workspace_path);
-
-        let cache_dir = workspace_path.join("cache");
-        let chunk_exe = workspace_path.join("chunk/app.vmexe");
-        let chunk_app_config = workspace_path.join("chunk/openvm.toml");
-        let chunk_prover = ChunkProver::setup(chunk_exe, chunk_app_config, Some(cache_dir.clone()))
+        let chunk_prover = ChunkProver::setup(p.phase_spec_chunk(workspace_path))
             .expect("Failed to setup chunk prover");
 
-        let batch_exe = workspace_path.join("batch/app.vmexe");
-        let batch_app_config = workspace_path.join("batch/openvm.toml");
-        let batch_prover = BatchProver::setup(batch_exe, batch_app_config, Some(cache_dir.clone()))
+        let batch_prover = BatchProver::setup(p.phase_spec_batch(workspace_path))
             .expect("Failed to setup batch prover");
 
-        let bundle_exe = workspace_path.join("bundle/app.vmexe");
-        let bundle_app_config = workspace_path.join("bundle/openvm.toml");
-        let bundle_prover = BundleProver::setup(bundle_exe, bundle_app_config, Some(cache_dir))
+        let bundle_prover = BundleProverEuclidV1::setup(p.phase_spec_bundle(workspace_path))
             .expect("Failed to setup bundle prover");
 
         Self {
@@ -68,6 +130,8 @@ impl CircuitsHandler for Arc<Mutex<EuclidHandler>> {
                     .chunk_prover
                     .gen_proof(&ChunkProvingTask {
                         block_witnesses: witnesses,
+                        prev_msg_queue_hash: Default::default(),
+                        fork_name: Phase::EuclidV1.as_str().to_string(),
                     })?;
 
                 Ok(serde_json::to_string(&proof)?)

--- a/zkvm-prover/src/zk_circuits_handler/euclidV2.rs
+++ b/zkvm-prover/src/zk_circuits_handler/euclidV2.rs
@@ -1,62 +1,34 @@
 use std::{path::Path, sync::Arc};
 
-use super::CircuitsHandler;
+use super::{euclid::Phase, CircuitsHandler};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use scroll_proving_sdk::prover::{proving_service::ProveRequest, ProofType};
-use scroll_zkvm_prover_euclidv2::{
+use scroll_zkvm_prover_euclid::{
     task::{batch::BatchProvingTask, bundle::BundleProvingTask, chunk::ChunkProvingTask},
-    BatchProver, BundleProver, ChunkProver, ProverConfig,
+    BatchProver, BundleProverEuclidV2, ChunkProver,
 };
 use tokio::sync::Mutex;
 pub struct EuclidV2Handler {
     chunk_prover: ChunkProver,
     batch_prover: BatchProver,
-    bundle_prover: BundleProver,
+    bundle_prover: BundleProverEuclidV2,
 }
 
 unsafe impl Send for EuclidV2Handler {}
 
 impl EuclidV2Handler {
     pub fn new(workspace_path: &str) -> Self {
+        let p = Phase::EuclidV2;
         let workspace_path = Path::new(workspace_path);
+        let chunk_prover = ChunkProver::setup(p.phase_spec_chunk(workspace_path))
+            .expect("Failed to setup chunk prover");
 
-        let cache_dir = workspace_path.join("cache");
-        let chunk_exe = workspace_path.join("chunk/app.vmexe");
-        let chunk_app_config = workspace_path.join("chunk/openvm.toml");
-        let chunk_prover = ChunkProver::setup(
-            chunk_exe,
-            chunk_app_config,
-            Some(cache_dir.clone()),
-            ProverConfig {
-                segment_len: Some((1 << 22) - 100),
-            },
-        )
-        .expect("Failed to setup chunk prover");
+        let batch_prover = BatchProver::setup(p.phase_spec_batch(workspace_path))
+            .expect("Failed to setup batch prover");
 
-        let batch_exe = workspace_path.join("batch/app.vmexe");
-        let batch_app_config = workspace_path.join("batch/openvm.toml");
-        let batch_prover = BatchProver::setup(
-            batch_exe,
-            batch_app_config,
-            Some(cache_dir.clone()),
-            ProverConfig {
-                segment_len: Some((1 << 22) - 100),
-            },
-        )
-        .expect("Failed to setup batch prover");
-
-        let bundle_exe = workspace_path.join("bundle/app.vmexe");
-        let bundle_app_config = workspace_path.join("bundle/openvm.toml");
-        let bundle_prover = BundleProver::setup(
-            bundle_exe,
-            bundle_app_config,
-            Some(cache_dir),
-            ProverConfig {
-                segment_len: Some((1 << 22) - 100),
-            },
-        )
-        .expect("Failed to setup bundle prover");
+        let bundle_prover = BundleProverEuclidV2::setup(p.phase_spec_bundle(workspace_path))
+            .expect("Failed to setup bundle prover");
 
         Self {
             chunk_prover,


### PR DESCRIPTION
This PR upgrade euclid dependings for rc11 with quite a few breaking changes:

+ The messages of ProvingTask need upgrade, a new `fork_name` field is required now
+ The deployment asset is updated, now there would be two bundle exe is packed in the released assets, one named "app.vmexe" and another named "app_euclidv1.vmexe", they have to be both deployed and loaded while creating the corresponding prover instance