### PR TITLE
Adapt to rc11 (unified phase)

### DIFF
--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-12-03
+          toolchain: nightly-2023-12-03
           components: rustfmt
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2

--- a/common/libzkp/impl/Cargo.lock
+++ b/common/libzkp/impl/Cargo.lock
@@ -520,7 +520,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "object",
  "rustc-demangle",
  "serde",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -799,8 +799,22 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18c1406a27371b2f76232a2259df6ab607b91b5a0a7476a7729ff590df5a969a"
 dependencies = [
+ "arrayvec",
+ "bitcode_derive",
  "bytemuck",
+ "glam",
  "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1109,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1437,27 +1451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1800,7 +1793,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1842,6 +1835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3aa70d918d2b234126ff4f850f628f172542bf0603ded26b8ee36e5e22d5f9"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "halo2-axiom"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f81aee7974478f9e3ea0cfd349d2a59a3482f7844386486a98e4af9ed8bada6"
+checksum = "62f0ca78d12ac5c893f286d7cdfe3869290305ab8cac376e2592cdc8396da102"
 dependencies = [
  "blake2b_simd",
  "crossbeam",
@@ -1903,8 +1902,8 @@ dependencies = [
 
 [[package]]
 name = "halo2-base"
-version = "0.4.1"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.4.1-git#2fe813b3ccd4f224da195d61829effb20599dcbd"
+version = "0.5.0"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.0-git#2d4b70b8558439a908dea708f4721394b1ae3ef6"
 dependencies = [
  "getset",
  "halo2-axiom",
@@ -1923,8 +1922,8 @@ dependencies = [
 
 [[package]]
 name = "halo2-ecc"
-version = "0.4.1"
-source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.4.1-git#2fe813b3ccd4f224da195d61829effb20599dcbd"
+version = "0.5.0"
+source = "git+https://github.com/axiom-crypto/halo2-lib.git?tag=v0.5.0-git#2d4b70b8558439a908dea708f4721394b1ae3ef6"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",
@@ -2478,16 +2477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,26 +2877,25 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "bytemuck",
- "hex-literal",
  "num-bigint 0.4.6",
- "num-traits",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-custom-insn",
+ "openvm-platform",
  "openvm-rv32im-guest",
  "serde",
 ]
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-transpiler",
@@ -2926,13 +2914,12 @@ dependencies = [
  "serde-big-array",
  "serde_with",
  "strum 0.26.3",
- "tracing",
 ]
 
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2941,24 +2928,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "halo2curves-axiom 0.5.3",
  "num-bigint 0.4.6",
- "openvm",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-macros",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
- "serde",
  "serde-big-array",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2967,8 +2951,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -2977,13 +2961,12 @@ dependencies = [
  "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
- "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3004,21 +2987,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "openvm",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-platform",
  "serde",
+ "serde-big-array",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3032,27 +3016,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "cargo_metadata",
- "dirs",
  "eyre",
- "hex",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-platform",
  "serde",
  "serde_json",
- "tempfile",
 ]
 
 [[package]]
 name = "openvm-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "async-trait",
  "backtrace",
- "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.6.0",
@@ -3060,10 +3039,8 @@ dependencies = [
  "enum_dispatch",
  "eyre",
  "getset",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
- "metrics-derive",
- "once_cell",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
@@ -3071,72 +3048,69 @@ dependencies = [
  "openvm-poseidon2-air",
  "openvm-stark-backend",
  "p3-baby-bear",
- "p3-symmetric",
  "rand",
- "rayon",
  "rustc-hash 2.1.1",
  "serde",
  "serde-big-array",
  "static_assertions",
  "thiserror 1.0.69",
- "toml",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "itertools 0.13.0",
- "proc-macro2",
+ "itertools 0.14.0",
  "quote",
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
- "itertools 0.13.0",
- "lazy_static",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit-primitives-derive",
  "openvm-stark-backend",
  "rand",
- "serde",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "itertools 0.13.0",
- "proc-macro2",
+ "itertools 0.14.0",
  "quote",
  "syn 2.0.98",
 ]
 
 [[package]]
-name = "openvm-custom-insn"
-version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
+name = "openvm-continuations"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "derivative",
+ "openvm-circuit",
+ "openvm-native-compiler",
+ "openvm-native-recursion",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3145,13 +3119,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -3169,6 +3142,7 @@ dependencies = [
  "openvm-rv32-adapters",
  "openvm-rv32im-circuit",
  "openvm-stark-backend",
+ "rand",
  "serde",
  "serde_with",
  "strum 0.26.3",
@@ -3176,35 +3150,33 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
  "hex-literal",
- "itertools 0.13.0",
  "k256",
  "lazy_static",
  "num-bigint 0.4.6",
- "num-traits",
+ "once_cell",
  "openvm",
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
  "openvm-ecc-sw-macros",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
  "openvm-rv32im-guest",
  "p256",
- "rand",
  "serde",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3213,8 +3185,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -3227,12 +3199,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-instructions-derive",
@@ -3244,25 +3216,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "eyre",
- "hex-literal",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -3283,18 +3251,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
- "serde",
+ "openvm-platform",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3307,18 +3274,18 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit",
@@ -3334,14 +3301,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -3362,11 +3328,11 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "backtrace",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
  "num-bigint 0.4.6",
  "num-integer",
@@ -3386,21 +3352,20 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.98",
 ]
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "cfg-if",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "metrics 0.23.0",
  "once_cell",
@@ -3417,22 +3382,22 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "serde_with",
  "snark-verifier-sdk",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
- "once_cell",
  "openvm-algebra-circuit",
  "openvm-circuit",
  "openvm-circuit-derive",
@@ -3454,13 +3419,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
  "hex-literal",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-traits",
@@ -3468,9 +3433,10 @@ dependencies = [
  "openvm-algebra-complex-macros",
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
  "openvm-ecc-guest",
  "openvm-ecc-sw-macros",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-platform",
  "openvm-rv32im-guest",
  "rand",
  "serde",
@@ -3479,8 +3445,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3493,35 +3459,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1#30576cc6ce838f213bf05b2e4ad035d95498c8b3"
-dependencies = [
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1)",
- "stability",
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "openvm-platform"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
- "stability",
- "strum_macros 0.26.4",
+ "openvm-custom-insn",
+ "openvm-rv32im-guest",
 ]
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derivative",
- "itertools 0.13.0",
  "lazy_static",
- "openvm-circuit-primitives",
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "p3-monty-31",
@@ -3529,17 +3482,16 @@ dependencies = [
  "p3-poseidon2-air",
  "p3-symmetric",
  "rand",
- "tracing",
  "zkhash",
 ]
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
@@ -3551,22 +3503,18 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_with",
- "tracing",
 ]
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
- "once_cell",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -3578,22 +3526,21 @@ dependencies = [
  "serde",
  "serde-big-array",
  "strum 0.26.3",
- "tracing",
 ]
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-custom-insn",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3608,8 +3555,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3619,7 +3566,7 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "getset",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
  "openvm",
  "openvm-algebra-circuit",
@@ -3628,6 +3575,7 @@ dependencies = [
  "openvm-bigint-transpiler",
  "openvm-build",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-keccak256-circuit",
@@ -3644,15 +3592,18 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-transpiler",
+ "p3-fri",
  "serde",
- "static_assertions",
+ "serde_json",
+ "serde_with",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -3662,10 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "openvm-circuit",
@@ -3686,18 +3636,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "openvm",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-platform",
  "sha2",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3710,14 +3659,14 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=bc364134b8315c27bfd29c6e77ac79fe77090137#bc364134b8315c27bfd29c6e77ac79fe77090137"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=4a223981722e75bf97c6807e4d56935196d86edf#4a223981722e75bf97c6807e4d56935196d86edf"
 dependencies = [
- "async-trait",
+ "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.7.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
  "p3-air",
  "p3-challenger",
@@ -3736,13 +3685,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
-version = "1.0.0-rc.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=bc364134b8315c27bfd29c6e77ac79fe77090137#bc364134b8315c27bfd29c6e77ac79fe77090137"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/stark-backend.git?rev=4a223981722e75bf97c6807e4d56935196d86edf#4a223981722e75bf97c6807e4d56935196d86edf"
 dependencies = [
  "derivative",
  "derive_more 0.99.19",
  "ff 0.13.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
  "metrics-tracing-context",
  "metrics-util",
@@ -3771,26 +3720,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "derive_more 1.0.0",
  "elf",
  "eyre",
  "openvm-instructions",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?rev=f1b4844)",
+ "openvm-platform",
  "openvm-stark-backend",
  "rrs-lib",
- "strum 0.26.3",
  "thiserror 1.0.69",
- "tracing",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3822,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3831,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -3845,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -3855,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "ff 0.13.0",
  "halo2curves",
@@ -3870,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -3882,9 +3822,9 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-challenger",
  "p3-dft",
  "p3-field",
@@ -3896,9 +3836,9 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
@@ -3909,9 +3849,9 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -3926,9 +3866,9 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-challenger",
  "p3-commit",
  "p3-dft",
@@ -3945,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft",
@@ -3962,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3973,9 +3913,9 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "p3-symmetric",
  "p3-util",
@@ -3985,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -3999,9 +3939,9 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
@@ -4014,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "rayon",
 ]
@@ -4022,9 +3962,9 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-dft",
  "p3-field",
  "p3-matrix",
@@ -4036,9 +3976,9 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-commit",
  "p3-field",
  "p3-matrix",
@@ -4053,9 +3993,9 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "p3-dft",
  "p3-field",
@@ -4074,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -4085,7 +4025,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "gcd",
  "p3-field",
@@ -4097,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -4113,9 +4053,9 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "serde",
 ]
@@ -4123,9 +4063,9 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-air",
  "p3-challenger",
  "p3-commit",
@@ -4141,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=b0591e9#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/Plonky3/Plonky3.git?rev=88d7f05#88d7f059500fd956a7c1eb121e08653e5974728d"
 dependencies = [
  "serde",
 ]
@@ -4276,9 +4216,9 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "poseidon-primitives"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd95570f7ea849b4187298b5bb229643e44e1d47ddf3979d0db8a1c28be26a8"
+checksum = "6e4aaeda7a092e21165cc5f0cbc738e72a46f31c03c3cbd87b71ceae9d2d93bc"
 dependencies = [
  "bitvec",
  "ff 0.13.0",
@@ -4548,17 +4488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4614,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4633,7 +4562,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4650,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4661,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4674,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4687,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4711,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -4736,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4750,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4766,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -4781,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4801,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4826,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4847,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4861,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4879,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "serde",
  "serde_json",
@@ -4889,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "metrics 0.24.1",
  "metrics-derive",
@@ -4898,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4911,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4928,7 +4857,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -4941,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4970,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -4983,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4998,7 +4927,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5021,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -5029,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5055,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5067,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5091,7 +5020,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -5104,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -5115,7 +5044,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5140,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5155,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "clap",
  "eyre",
@@ -5170,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5192,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5215,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5233,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -5248,7 +5177,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "zstd",
 ]
@@ -5271,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "19.4.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -5310,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "revm-primitives 15.1.0",
  "serde",
@@ -5348,7 +5277,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "16.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -5405,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#562b7c67b8f0c0e4aee4f74fe6c0c983df58790c"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.5.1",
@@ -5610,7 +5539,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5638,21 +5567,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
-name = "sbv"
-version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
-dependencies = [
- "sbv-core",
- "sbv-helpers",
- "sbv-kv",
- "sbv-primitives",
- "sbv-trie",
-]
-
-[[package]]
 name = "sbv-core"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
@@ -5669,7 +5586,7 @@ dependencies = [
 [[package]]
 name = "sbv-helpers"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -5677,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "sbv-kv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "auto_impl",
  "hashbrown 0.15.2",
@@ -5687,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "sbv-primitives"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5718,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "sbv-trie"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "alloy-rlp",
  "alloy-trie",
@@ -5733,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5751,7 +5668,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-network"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5765,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5781,72 +5698,31 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-circuit-input-types"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.6#8adaaf856b00ca992e76c95e657761a5148d6084"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.8.3",
- "openvm",
- "openvm-rv32im-guest",
- "rkyv",
- "sbv",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "scroll-zkvm-circuit-input-types"
-version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.1-rc.3#01fb5e3b8b04f6e8a59056e1741f5d973589e727"
+version = "0.1.0-rc.11"
+source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.11#29a0373dfea03bcd8fd4aa93631ffd76da3d552c"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.8.3",
  "itertools 0.14.0",
  "openvm",
+ "openvm-custom-insn",
  "openvm-rv32im-guest",
  "rkyv",
- "sbv",
+ "sbv-core",
+ "sbv-kv",
+ "sbv-primitives",
+ "sbv-trie",
  "serde",
+ "sha2",
+ "sha3",
  "tiny-keccak",
  "vm-zstd",
 ]
 
 [[package]]
 name = "scroll-zkvm-prover"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.6#8adaaf856b00ca992e76c95e657761a5148d6084"
-dependencies = [
- "alloy-primitives",
- "base64 0.22.1",
- "bincode",
- "git-version",
- "hex",
- "metrics 0.23.0",
- "metrics-util",
- "once_cell",
- "openvm-circuit",
- "openvm-native-circuit",
- "openvm-native-recursion",
- "openvm-sdk",
- "openvm-stark-sdk",
- "revm 19.5.0",
- "rkyv",
- "sbv",
- "scroll-zkvm-circuit-input-types 0.1.0-rc.6",
- "scroll-zkvm-verifier 0.1.0-rc.6",
- "serde",
- "serde_json",
- "serde_stacker",
- "snark-verifier-sdk",
- "thiserror 2.0.11",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "scroll-zkvm-prover"
-version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.1-rc.3#01fb5e3b8b04f6e8a59056e1741f5d973589e727"
+version = "0.1.0-rc.11"
+source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.11#29a0373dfea03bcd8fd4aa93631ffd76da3d552c"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -5855,19 +5731,21 @@ dependencies = [
  "git-version",
  "hex",
  "metrics 0.23.0",
+ "metrics-tracing-context",
  "metrics-util",
  "munge",
  "once_cell",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-native-circuit",
  "openvm-native-recursion",
  "openvm-sdk",
  "openvm-stark-sdk",
  "revm 19.5.0",
  "rkyv",
- "sbv",
- "scroll-zkvm-circuit-input-types 0.1.1-rc.2",
- "scroll-zkvm-verifier 0.1.1-rc.2",
+ "sbv-primitives",
+ "scroll-zkvm-circuit-input-types",
+ "scroll-zkvm-verifier",
  "serde",
  "serde_json",
  "serde_stacker",
@@ -5879,38 +5757,20 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-verifier"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.6#8adaaf856b00ca992e76c95e657761a5148d6084"
+version = "0.1.0-rc.11"
+source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.0-rc.11#29a0373dfea03bcd8fd4aa93631ffd76da3d552c"
 dependencies = [
  "bincode",
  "eyre",
  "itertools 0.14.0",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-native-circuit",
  "openvm-native-recursion",
  "openvm-sdk",
  "openvm-stark-sdk",
  "revm 19.5.0",
- "scroll-zkvm-circuit-input-types 0.1.0-rc.6",
- "serde",
- "snark-verifier-sdk",
-]
-
-[[package]]
-name = "scroll-zkvm-verifier"
-version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover.git?tag=v0.1.1-rc.3#01fb5e3b8b04f6e8a59056e1741f5d973589e727"
-dependencies = [
- "bincode",
- "eyre",
- "itertools 0.14.0",
- "openvm-circuit",
- "openvm-native-circuit",
- "openvm-native-recursion",
- "openvm-sdk",
- "openvm-stark-sdk",
- "revm 19.5.0",
- "scroll-zkvm-circuit-input-types 0.1.1-rc.2",
+ "scroll-zkvm-circuit-input-types",
  "serde",
  "snark-verifier-sdk",
 ]
@@ -6175,8 +6035,8 @@ dependencies = [
 
 [[package]]
 name = "snark-verifier"
-version = "0.1.8"
-source = "git+https://github.com/axiom-crypto/snark-verifier?branch=zkvm-v0.1#ab65fda41b56571aa33dd27f68ef1ea461e3fadc"
+version = "0.2.0"
+source = "git+https://github.com/axiom-crypto/snark-verifier?branch=zkvm-v0.1#9e1c165ff8816b9351791c2f939548beb12c183f"
 dependencies = [
  "halo2-base",
  "halo2-ecc",
@@ -6196,8 +6056,8 @@ dependencies = [
 
 [[package]]
 name = "snark-verifier-sdk"
-version = "0.1.8"
-source = "git+https://github.com/axiom-crypto/snark-verifier?branch=zkvm-v0.1#ab65fda41b56571aa33dd27f68ef1ea461e3fadc"
+version = "0.2.0"
+source = "git+https://github.com/axiom-crypto/snark-verifier?branch=zkvm-v0.1#9e1c165ff8816b9351791c2f939548beb12c183f"
 dependencies = [
  "ark-std 0.3.0",
  "bincode",
@@ -6234,16 +6094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6259,7 +6109,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -6437,7 +6287,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -6599,7 +6449,6 @@ source = "git+https://github.com/scroll-tech/tiny-keccak?branch=scroll-patch-v2.
 dependencies = [
  "cfg-if",
  "crunchy",
- "openvm-platform 1.0.0-rc.1 (git+https://github.com/openvm-org/openvm.git?tag=v1.0.0-rc.1)",
 ]
 
 [[package]]
@@ -7025,7 +6874,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -7041,7 +6890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7050,7 +6899,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7062,7 +6911,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7099,16 +6948,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7117,22 +6957,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -7141,21 +6966,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -7165,21 +6984,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7195,21 +7002,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7219,21 +7014,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7424,10 +7207,8 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "scroll-zkvm-prover 0.1.0-rc.6",
- "scroll-zkvm-prover 0.1.1-rc.2",
- "scroll-zkvm-verifier 0.1.0-rc.6",
- "scroll-zkvm-verifier 0.1.1-rc.2",
+ "scroll-zkvm-prover",
+ "scroll-zkvm-verifier",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7436,4 +7217,4 @@ dependencies = [
 [[package]]
 name = "zstd"
 version = "1.1.4"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"

--- a/common/libzkp/impl/Cargo.toml
+++ b/common/libzkp/impl/Cargo.toml
@@ -14,10 +14,8 @@ ruint = { git = "https://github.com/scroll-tech/uint.git", branch = "v1.12.3" }
 tiny-keccak = { git = "https://github.com/scroll-tech/tiny-keccak", branch = "scroll-patch-v2.0.2-openvm-v1.0.0-rc.1" }
 
 [dependencies]
-euclid_prover = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.6", package = "scroll-zkvm-prover" }
-euclid_verifier = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.6", package = "scroll-zkvm-verifier" }
-euclidv2_prover = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.1-rc.3", package = "scroll-zkvm-prover" }
-euclidv2_verifier = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.1-rc.3", package = "scroll-zkvm-verifier" }
+euclid_prover = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.11", package = "scroll-zkvm-prover" }
+euclid_verifier = { git = "https://github.com/scroll-tech/zkvm-prover.git", tag = "v0.1.0-rc.11", package = "scroll-zkvm-verifier" }
 
 base64 = "0.13.0"
 env_logger = "0.9.0"

--- a/common/libzkp/impl/src/verifier.rs
+++ b/common/libzkp/impl/src/verifier.rs
@@ -49,11 +49,11 @@ static mut VERIFIER_LOW: OnceCell<VerifierPair> = OnceCell::new();
 static mut VERIFIER_HIGH: OnceCell<VerifierPair> = OnceCell::new();
 
 pub fn init(config: VerifierConfig) {
-    let verifier = EuclidVerifier::new(&config.low_version_circuit.assets_path);
+    let verifier = EuclidVerifier::new(&config.high_version_circuit.assets_path);
     unsafe {
         VERIFIER_LOW
             .set(VerifierPair(
-                config.low_version_circuit.fork_name,
+                "euclid".to_string(),
                 Rc::new(Box::new(verifier)),
             ))
             .unwrap_unchecked();
@@ -63,7 +63,7 @@ pub fn init(config: VerifierConfig) {
     unsafe {
         VERIFIER_HIGH
             .set(VerifierPair(
-                config.high_version_circuit.fork_name,
+                "euclidV2".to_string(),
                 Rc::new(Box::new(verifier)),
             ))
             .unwrap_unchecked();

--- a/common/libzkp/impl/src/verifier/euclid.rs
+++ b/common/libzkp/impl/src/verifier/euclid.rs
@@ -4,13 +4,13 @@ use anyhow::Result;
 
 use crate::utils::panic_catch;
 use euclid_prover::{BatchProof, BundleProof, ChunkProof};
-use euclid_verifier::verifier::{BatchVerifier, BundleVerifier, ChunkVerifier};
+use euclid_verifier::verifier::{BatchVerifier, BundleVerifierEuclidV1, ChunkVerifier};
 use std::{fs::File, path::Path};
 
 pub struct EuclidVerifier {
     chunk_verifier: ChunkVerifier,
     batch_verifier: BatchVerifier,
-    bundle_verifier: BundleVerifier,
+    bundle_verifier: BundleVerifierEuclidV1,
 }
 
 impl EuclidVerifier {
@@ -24,7 +24,7 @@ impl EuclidVerifier {
                 .expect("Setting up chunk verifier"),
             batch_verifier: BatchVerifier::setup(&config, &exe, &verifier_bin)
                 .expect("Setting up batch verifier"),
-            bundle_verifier: BundleVerifier::setup(&config, &exe, &verifier_bin)
+            bundle_verifier: BundleVerifierEuclidV1::setup(&config, &exe, &verifier_bin)
                 .expect("Setting up bundle verifier"),
         }
     }

--- a/common/libzkp/impl/src/verifier/euclidv2.rs
+++ b/common/libzkp/impl/src/verifier/euclidv2.rs
@@ -3,14 +3,14 @@ use super::{ProofVerifier, TaskType, VKDump};
 use anyhow::Result;
 
 use crate::utils::panic_catch;
-use euclidv2_prover::{BatchProof, BundleProof, ChunkProof};
-use euclidv2_verifier::verifier::{BatchVerifier, BundleVerifier, ChunkVerifier};
+use euclid_prover::{BatchProof, BundleProof, ChunkProof};
+use euclid_verifier::verifier::{BatchVerifier, BundleVerifierEuclidV2, ChunkVerifier};
 use std::{fs::File, path::Path};
 
 pub struct EuclidV2Verifier {
     chunk_verifier: ChunkVerifier,
     batch_verifier: BatchVerifier,
-    bundle_verifier: BundleVerifier,
+    bundle_verifier: BundleVerifierEuclidV2,
 }
 
 impl EuclidV2Verifier {
@@ -24,7 +24,7 @@ impl EuclidV2Verifier {
                 .expect("Setting up chunk verifier"),
             batch_verifier: BatchVerifier::setup(&config, &exe, &verifier_bin)
                 .expect("Setting up batch verifier"),
-            bundle_verifier: BundleVerifier::setup(&config, &exe, &verifier_bin)
+            bundle_verifier: BundleVerifierEuclidV2::setup(&config, &exe, &verifier_bin)
                 .expect("Setting up bundle verifier"),
         }
     }

--- a/common/types/message/message.go
+++ b/common/types/message/message.go
@@ -13,6 +13,9 @@ import (
 const (
 	EuclidFork   = "euclid"
 	EuclidV2Fork = "euclidV2"
+
+	EuclidForkNameForProver   = "euclidv1"
+	EuclidV2ForkNameForProver = "euclidv2"
 )
 
 // ProofType represents the type of task.

--- a/common/types/message/message.go
+++ b/common/types/message/message.go
@@ -44,6 +44,8 @@ const (
 
 // ChunkTaskDetail is a type containing ChunkTask detail for chunk task.
 type ChunkTaskDetail struct {
+	// use one of the string of EuclidFork / EuclidV2Fork
+	ForkName         string        `json:"fork_name"`
 	BlockHashes      []common.Hash `json:"block_hashes"`
 	PrevMsgQueueHash common.Hash   `json:"prev_msg_queue_hash"`
 }
@@ -93,6 +95,8 @@ func (e *Byte48) UnmarshalJSON(input []byte) error {
 
 // BatchTaskDetail is a type containing BatchTask detail.
 type BatchTaskDetail struct {
+	// use one of the string of EuclidFork / EuclidV2Fork
+	ForkName        string       `json:"fork_name"`
 	ChunkInfos      []*ChunkInfo `json:"chunk_infos"`
 	ChunkProofs     []ChunkProof `json:"chunk_proofs"`
 	BatchHeader     interface{}  `json:"batch_header"`
@@ -104,7 +108,10 @@ type BatchTaskDetail struct {
 
 // BundleTaskDetail consists of all the information required to describe the task to generate a proof for a bundle of batches.
 type BundleTaskDetail struct {
+	// use one of the string of EuclidFork / EuclidV2Fork
+	ForkName    string       `json:"fork_name"`
 	BatchProofs []BatchProof `json:"batch_proofs"`
+	// TODO: add `bundle_info` field for sanity check
 }
 
 // ChunkInfo is for calculating pi_hash for chunk

--- a/common/types/message/message.go
+++ b/common/types/message/message.go
@@ -109,9 +109,9 @@ type BatchTaskDetail struct {
 // BundleTaskDetail consists of all the information required to describe the task to generate a proof for a bundle of batches.
 type BundleTaskDetail struct {
 	// use one of the string of EuclidFork / EuclidV2Fork
-	ForkName    string       `json:"fork_name"`
-	BatchProofs []BatchProof `json:"batch_proofs"`
-	// TODO: add `bundle_info` field for sanity check
+	ForkName    string            `json:"fork_name"`
+	BatchProofs []BatchProof      `json:"batch_proofs"`
+	BundleInfo  *OpenVMBundleInfo `json:"bundle_info,omitempty"`
 }
 
 // ChunkInfo is for calculating pi_hash for chunk

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -265,9 +265,9 @@ func (bp *BatchProverTask) getBatchTaskDetail(dbBatch *orm.Batch, chunkInfos []*
 	}
 
 	if hardForkName == message.EuclidV2Fork {
-		taskDetail.ForkName = "euclidv2"
+		taskDetail.ForkName = message.EuclidV2ForkNameForProver
 	} else if hardForkName == message.EuclidFork {
-		taskDetail.ForkName = "euclidv1"
+		taskDetail.ForkName = message.EuclidForkNameForProver
 	}
 
 	dbBatchCodecVersion := encoding.CodecVersion(dbBatch.CodecVersion)

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -229,7 +229,7 @@ func (bp *BatchProverTask) formatProverTask(ctx context.Context, task *orm.Prove
 		chunkInfos = append(chunkInfos, &chunkInfo)
 	}
 
-	taskDetail, err := bp.getBatchTaskDetail(batch, chunkInfos, chunkProofs)
+	taskDetail, err := bp.getBatchTaskDetail(batch, chunkInfos, chunkProofs, hardForkName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get batch task detail, taskID:%s err:%w", task.TaskID, err)
 	}
@@ -258,10 +258,16 @@ func (bp *BatchProverTask) recoverActiveAttempts(ctx *gin.Context, batchTask *or
 	}
 }
 
-func (bp *BatchProverTask) getBatchTaskDetail(dbBatch *orm.Batch, chunkInfos []*message.ChunkInfo, chunkProofs []message.ChunkProof) (*message.BatchTaskDetail, error) {
+func (bp *BatchProverTask) getBatchTaskDetail(dbBatch *orm.Batch, chunkInfos []*message.ChunkInfo, chunkProofs []message.ChunkProof, hardForkName string) (*message.BatchTaskDetail, error) {
 	taskDetail := &message.BatchTaskDetail{
 		ChunkInfos:  chunkInfos,
 		ChunkProofs: chunkProofs,
+	}
+
+	if hardForkName == message.EuclidV2Fork {
+		taskDetail.ForkName = "euclidv2"
+	} else if hardForkName == message.EuclidFork {
+		taskDetail.ForkName = "euclidv1"
 	}
 
 	dbBatchCodecVersion := encoding.CodecVersion(dbBatch.CodecVersion)

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -214,9 +214,9 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 	}
 
 	if hardForkName == message.EuclidV2Fork {
-		taskDetail.ForkName = "euclidv2"
+		taskDetail.ForkName = message.EuclidV2ForkNameForProver
 	} else if hardForkName == message.EuclidFork {
-		taskDetail.ForkName = "euclidv1"
+		taskDetail.ForkName = message.EuclidForkNameForProver
 	}
 
 	taskDetail.BundleInfo = &message.OpenVMBundleInfo{

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/log"
 	"github.com/scroll-tech/go-ethereum/params"
 	"gorm.io/gorm"
@@ -194,6 +195,11 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 		return nil, fmt.Errorf("failed to get batch proofs for bundle task id:%s, no batch found", task.TaskID)
 	}
 
+	parentBatch, err := bp.batchOrm.GetBatchByHash(ctx, batches[0].ParentBatchHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parent batch for batch task id:%s err:%w", task.TaskID, err)
+	}
+
 	var batchProofs []message.BatchProof
 	for _, batch := range batches {
 		proof := message.NewBatchProof(hardForkName)
@@ -205,6 +211,26 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 
 	taskDetail := message.BundleTaskDetail{
 		BatchProofs: batchProofs,
+	}
+
+	if hardForkName == message.EuclidV2Fork {
+		taskDetail.ForkName = "euclidv2"
+	} else if hardForkName == message.EuclidFork {
+		taskDetail.ForkName = "euclidv1"
+	}
+
+	taskDetail.BundleInfo = &message.OpenVMBundleInfo{
+		ChainID:       bp.cfg.L2.ChainID,
+		PrevStateRoot: common.HexToHash(parentBatch.StateRoot),
+		PostStateRoot: common.HexToHash(batches[len(batches)-1].StateRoot),
+		WithdrawRoot:  common.HexToHash(batches[len(batches)-1].WithdrawRoot),
+		NumBatches:    uint32(len(batches)),
+		PrevBatchHash: common.HexToHash(batches[0].ParentBatchHash),
+		BatchHash:     common.HexToHash(batches[len(batches)-1].Hash),
+	}
+
+	if hardForkName == message.EuclidV2Fork {
+		taskDetail.BundleInfo.MsgQueueHash = common.HexToHash(batches[len(batches)-1].PostL1MessageQueueHash)
 	}
 
 	batchProofsBytes, err := json.Marshal(taskDetail)

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -192,6 +192,13 @@ func (cp *ChunkProverTask) formatProverTask(ctx context.Context, task *orm.Prove
 		BlockHashes:      blockHashes,
 		PrevMsgQueueHash: common.HexToHash(chunk.PrevL1MessageQueueHash),
 	}
+
+	if hardForkName == message.EuclidV2Fork {
+		taskDetail.ForkName = "euclidv2"
+	} else if hardForkName == message.EuclidFork {
+		taskDetail.ForkName = "euclidv1"
+	}
+
 	var err error
 	taskDetailBytes, err = json.Marshal(taskDetail)
 	if err != nil {

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -194,9 +194,9 @@ func (cp *ChunkProverTask) formatProverTask(ctx context.Context, task *orm.Prove
 	}
 
 	if hardForkName == message.EuclidV2Fork {
-		taskDetail.ForkName = "euclidv2"
+		taskDetail.ForkName = message.EuclidV2ForkNameForProver
 	} else if hardForkName == message.EuclidFork {
-		taskDetail.ForkName = "euclidv1"
+		taskDetail.ForkName = message.EuclidForkNameForProver
 	}
 
 	var err error

--- a/coordinator/internal/logic/verifier/verifier.go
+++ b/coordinator/internal/logic/verifier/verifier.go
@@ -99,10 +99,8 @@ func NewVerifier(cfg *config.VerifierConfig) (*Verifier, error) {
 		OpenVMVkMap: make(map[string]struct{}),
 	}
 
-	if cfg.LowVersionCircuit.ForkName == message.EuclidFork {
-		if err := v.loadOpenVMVks(cfg.LowVersionCircuit.ForkName); err != nil {
-			return nil, err
-		}
+	if err := v.loadLowVersionVKs(cfg); err != nil {
+		return nil, err
 	}
 
 	if err := v.loadOpenVMVks(cfg.HighVersionCircuit.ForkName); err != nil {
@@ -203,6 +201,26 @@ func (v *Verifier) readVK(filePat string) (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(byt), nil
+}
+
+// load low version vks, current is darwin
+func (v *Verifier) loadLowVersionVKs(cfg *config.VerifierConfig) error {
+	bundleVK, err := v.readVK(path.Join(cfg.LowVersionCircuit.AssetsPath, "vk_bundle.vkey"))
+	if err != nil {
+		return err
+	}
+	batchVK, err := v.readVK(path.Join(cfg.LowVersionCircuit.AssetsPath, "vk_batch.vkey"))
+	if err != nil {
+		return err
+	}
+	chunkVK, err := v.readVK(path.Join(cfg.LowVersionCircuit.AssetsPath, "vk_chunk.vkey"))
+	if err != nil {
+		return err
+	}
+	v.BundleVkMap[bundleVK] = struct{}{}
+	v.BatchVKMap[batchVK] = struct{}{}
+	v.ChunkVKMap[chunkVK] = struct{}{}
+	return nil
 }
 
 func (v *Verifier) loadOpenVMVks(forkName string) error {

--- a/coordinator/internal/logic/verifier/verifier.go
+++ b/coordinator/internal/logic/verifier/verifier.go
@@ -107,6 +107,8 @@ func NewVerifier(cfg *config.VerifierConfig) (*Verifier, error) {
 		return nil, err
 	}
 
+	v.loadDarwinVKs()
+
 	return v, nil
 }
 
@@ -221,6 +223,12 @@ func (v *Verifier) loadLowVersionVKs(cfg *config.VerifierConfig) error {
 	v.BatchVKMap[batchVK] = struct{}{}
 	v.ChunkVKMap[chunkVK] = struct{}{}
 	return nil
+}
+
+func (v *Verifier) loadDarwinVKs() {
+	v.BundleVkMap["AAAAGgAAAARX2S0K1wF333B1waOsnG/vcASJmWG9YM6SNWCBy1ywD5dsp1rEy7PSqiIFikkkOPqKokLW2mZSwCbtKdkfLQcvTxARUwHSe4iZe27PRJ5WWaLqtRV1+x6+pSVKtcPtaV4kE7v2YJRf0582hxiAF0IBaOoREdpyNfA2a9cvhWb2TMaPrUYP9EDQ7CUiW1FQzxbjGc95ua2htscnpU7d9S5stHWzKb7okkCG7bTIL9aG6qTQo2YXW7n3H3Ir47oVJB7IKrUzKGvI5Wmanh2zpZOJ9Qm4/wY24cT7cJz+Ux6wAg=="] = struct{}{}
+	v.BatchVKMap["AAAAGgAAAARX2S0K1wF333B1waOsnG/vcASJmWG9YM6SNWCBy1ywD1DEjW4Kell67H07wazT5DdzrSh4+amh+cmosQHp9p9snFypyoBGt3UHtoJGQBZlywZWDS9ht5pnaEoGBdaKcQk+lFb+WxTiId0KOAa0mafTZTQw8yToy57Jple64qzlRu1dux30tZZGuerLN1CKzg5Xl2iOpMK+l87jCINwVp5cUtF/XrvhBbU7onKh3KBiy99iUqVyA3Y6iiIZhGKWBSuSA4bNgDYIoVkqjHpdL35aEShoRO6pNXt7rDzxFoPzH0JuPI54nE4OhVrzZXwtkAEosxVa/fszcE092FH+HhhtxZBYe/KEzwdISU9TOPdId3UF/UMYC0MiYOlqffVTgAg="] = struct{}{}
+	v.ChunkVKMap["AAAAGQAAAATyWEABRbJ6hQQ5/zLX1gTasr7349minA9rSgMS6gDeHwZKqikRiO3md+pXjjxMHnKQtmXYgMXhJSvlmZ+Ws+cheuly2X1RuNQzcZuRImaKPR9LJsVZYsXfJbuqdKX8p0Gj8G83wMJOmTzNVUyUol0w0lTU+CEiTpHOnxBsTF3EWaW3s1u4ycOgWt1c9M6s7WmaBZLYgAWYCunO5CLCLApNGbCASeck/LuSoedEri5u6HccCKU2khG6zl6W07jvYSbDVLJktbjRiHv+/HQix+K14j8boo8Z/unhpwXCsPxkQA=="] = struct{}{}
 }
 
 func (v *Verifier) loadOpenVMVks(forkName string) error {

--- a/coordinator/internal/orm/batch.go
+++ b/coordinator/internal/orm/batch.go
@@ -19,20 +19,22 @@ type Batch struct {
 	db *gorm.DB `gorm:"column:-"`
 
 	// batch
-	Index           uint64 `json:"index" gorm:"column:index"`
-	Hash            string `json:"hash" gorm:"column:hash"`
-	DataHash        string `json:"data_hash" gorm:"column:data_hash"`
-	StartChunkIndex uint64 `json:"start_chunk_index" gorm:"column:start_chunk_index"`
-	StartChunkHash  string `json:"start_chunk_hash" gorm:"column:start_chunk_hash"`
-	EndChunkIndex   uint64 `json:"end_chunk_index" gorm:"column:end_chunk_index"`
-	EndChunkHash    string `json:"end_chunk_hash" gorm:"column:end_chunk_hash"`
-	StateRoot       string `json:"state_root" gorm:"column:state_root"`
-	WithdrawRoot    string `json:"withdraw_root" gorm:"column:withdraw_root"`
-	ParentBatchHash string `json:"parent_batch_hash" gorm:"column:parent_batch_hash"`
-	BatchHeader     []byte `json:"batch_header" gorm:"column:batch_header"`
-	CodecVersion    int16  `json:"codec_version" gorm:"column:codec_version"`
-	EnableCompress  bool   `json:"enable_compress" gorm:"column:enable_compress"`
-	BlobBytes       []byte `json:"blob_bytes" gorm:"column:blob_bytes"`
+	Index                  uint64 `json:"index" gorm:"column:index"`
+	Hash                   string `json:"hash" gorm:"column:hash"`
+	DataHash               string `json:"data_hash" gorm:"column:data_hash"`
+	StartChunkIndex        uint64 `json:"start_chunk_index" gorm:"column:start_chunk_index"`
+	StartChunkHash         string `json:"start_chunk_hash" gorm:"column:start_chunk_hash"`
+	EndChunkIndex          uint64 `json:"end_chunk_index" gorm:"column:end_chunk_index"`
+	EndChunkHash           string `json:"end_chunk_hash" gorm:"column:end_chunk_hash"`
+	StateRoot              string `json:"state_root" gorm:"column:state_root"`
+	WithdrawRoot           string `json:"withdraw_root" gorm:"column:withdraw_root"`
+	ParentBatchHash        string `json:"parent_batch_hash" gorm:"column:parent_batch_hash"`
+	BatchHeader            []byte `json:"batch_header" gorm:"column:batch_header"`
+	CodecVersion           int16  `json:"codec_version" gorm:"column:codec_version"`
+	PrevL1MessageQueueHash string `json:"prev_l1_message_queue_hash" gorm:"column:prev_l1_message_queue_hash"`
+	PostL1MessageQueueHash string `json:"post_l1_message_queue_hash" gorm:"column:post_l1_message_queue_hash"`
+	EnableCompress         bool   `json:"enable_compress" gorm:"column:enable_compress"`
+	BlobBytes              []byte `json:"blob_bytes" gorm:"column:blob_bytes"`
 
 	// proof
 	ChunkProofsStatus int16      `json:"chunk_proofs_status" gorm:"column:chunk_proofs_status;default:1"`

--- a/zkvm-prover/Cargo.lock
+++ b/zkvm-prover/Cargo.lock
@@ -1972,15 +1972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4284,13 +4275,12 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "bytemuck",
- "hex-literal",
  "num-bigint 0.4.6",
- "num-traits",
+ "openvm-custom-insn",
  "openvm-platform",
  "openvm-rv32im-guest",
  "serde",
@@ -4298,12 +4288,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-transpiler",
@@ -4322,13 +4312,12 @@ dependencies = [
  "serde-big-array",
  "serde_with",
  "strum 0.26.3",
- "tracing",
 ]
 
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4337,24 +4326,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "halo2curves-axiom 0.5.3",
  "num-bigint 0.4.6",
- "openvm",
  "openvm-algebra-complex-macros",
  "openvm-algebra-moduli-macros",
- "openvm-platform",
- "serde",
  "serde-big-array",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4363,8 +4349,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4373,13 +4359,12 @@ dependencies = [
  "openvm-transpiler",
  "rrs-lib",
  "strum 0.26.3",
- "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4400,21 +4385,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "openvm",
  "openvm-platform",
  "serde",
+ "serde-big-array",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4428,27 +4414,22 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "cargo_metadata",
- "dirs",
  "eyre",
- "hex",
  "openvm-platform",
  "serde",
  "serde_json",
- "tempfile",
 ]
 
 [[package]]
 name = "openvm-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "async-trait",
  "backtrace",
- "bitcode",
  "cfg-if",
  "derivative",
  "derive-new 0.6.0",
@@ -4456,73 +4437,78 @@ dependencies = [
  "enum_dispatch",
  "eyre",
  "getset",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
- "metrics-derive",
- "once_cell",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
  "openvm-instructions",
  "openvm-poseidon2-air",
  "openvm-stark-backend",
- "p3-baby-bear 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-baby-bear",
  "rand 0.8.5",
- "rayon",
  "rustc-hash 2.1.1",
  "serde",
  "serde-big-array",
  "static_assertions",
  "thiserror 1.0.69",
- "toml",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "itertools 0.13.0",
- "proc-macro2",
+ "itertools 0.14.0",
  "quote",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
- "itertools 0.13.0",
- "lazy_static",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit-primitives-derive",
  "openvm-stark-backend",
  "rand 0.8.5",
- "serde",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "itertools 0.13.0",
- "proc-macro2",
+ "itertools 0.14.0",
  "quote",
  "syn 2.0.100",
 ]
 
 [[package]]
+name = "openvm-continuations"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
+dependencies = [
+ "derivative",
+ "openvm-circuit",
+ "openvm-native-compiler",
+ "openvm-native-recursion",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4531,13 +4517,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -4555,6 +4540,7 @@ dependencies = [
  "openvm-rv32-adapters",
  "openvm-rv32im-circuit",
  "openvm-stark-backend",
+ "rand 0.8.5",
  "serde",
  "serde_with",
  "strum 0.26.3",
@@ -4562,35 +4548,33 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
  "hex-literal",
- "itertools 0.13.0",
  "k256",
  "lazy_static",
  "num-bigint 0.4.6",
- "num-traits",
+ "once_cell",
  "openvm",
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
  "openvm-ecc-sw-macros",
- "openvm-platform",
  "openvm-rv32im-guest",
  "p256",
- "rand 0.8.5",
  "serde",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4599,8 +4583,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4613,12 +4597,12 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-instructions-derive",
@@ -4630,25 +4614,21 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "eyre",
- "hex-literal",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -4669,18 +4649,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-platform",
- "serde",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4693,18 +4672,18 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit",
@@ -4720,14 +4699,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -4748,11 +4726,11 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "backtrace",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
  "num-bigint 0.4.6",
  "num-integer",
@@ -4772,21 +4750,20 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "cfg-if",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "metrics 0.23.0",
  "once_cell",
@@ -4796,29 +4773,29 @@ dependencies = [
  "openvm-native-compiler-derive",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-dft",
  "p3-fri",
  "p3-merkle-tree",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-symmetric",
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serde_with",
  "snark-verifier-sdk",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
- "once_cell",
  "openvm-algebra-circuit",
  "openvm-circuit",
  "openvm-circuit-derive",
@@ -4840,13 +4817,13 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom 0.5.3",
  "hex-literal",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-traits",
@@ -4854,6 +4831,7 @@ dependencies = [
  "openvm-algebra-complex-macros",
  "openvm-algebra-guest",
  "openvm-algebra-moduli-macros",
+ "openvm-custom-insn",
  "openvm-ecc-guest",
  "openvm-ecc-sw-macros",
  "openvm-platform",
@@ -4865,8 +4843,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4879,43 +4857,39 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
  "openvm-custom-insn",
- "stability",
- "strum_macros 0.26.4",
+ "openvm-rv32im-guest",
 ]
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derivative",
- "itertools 0.13.0",
  "lazy_static",
- "openvm-circuit-primitives",
  "openvm-stark-backend",
  "openvm-stark-sdk",
- "p3-monty-31 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-monty-31",
+ "p3-poseidon2",
  "p3-poseidon2-air",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-symmetric",
  "rand 0.8.5",
- "tracing",
  "zkhash",
 ]
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "derive-new 0.6.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "openvm-circuit",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
@@ -4927,22 +4901,18 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_with",
- "tracing",
 ]
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-integer",
- "once_cell",
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
@@ -4954,22 +4924,21 @@ dependencies = [
  "serde",
  "serde-big-array",
  "strum 0.26.3",
- "tracing",
 ]
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "openvm-platform",
+ "openvm-custom-insn",
  "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4984,8 +4953,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4995,7 +4964,7 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "getset",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "metrics 0.23.0",
  "openvm",
  "openvm-algebra-circuit",
@@ -5004,6 +4973,7 @@ dependencies = [
  "openvm-bigint-transpiler",
  "openvm-build",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-keccak256-circuit",
@@ -5020,15 +4990,18 @@ dependencies = [
  "openvm-stark-backend",
  "openvm-stark-sdk",
  "openvm-transpiler",
+ "p3-fri",
  "serde",
- "static_assertions",
+ "serde_json",
+ "serde_with",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5038,10 +5011,9 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "bitcode",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "openvm-circuit",
@@ -5062,18 +5034,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "openvm",
  "openvm-platform",
  "sha2",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5096,16 +5067,16 @@ dependencies = [
  "itertools 0.14.0",
  "metrics 0.23.0",
  "p3-air",
- "p3-challenger 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-commit 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-backend 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
+ "p3-challenger",
+ "p3-commit",
+ "p3-field",
+ "p3-gpu-backend",
+ "p3-gpu-base",
  "p3-gpu-module",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-matrix",
+ "p3-maybe-rayon",
  "p3-uni-stark",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-util",
  "rayon",
  "rustc-hash 2.1.1",
  "serde",
@@ -5126,18 +5097,18 @@ dependencies = [
  "metrics-tracing-context",
  "metrics-util",
  "openvm-stark-backend",
- "p3-baby-bear 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-baby-bear",
  "p3-blake3",
  "p3-bn254-fr",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-dft",
  "p3-fri",
  "p3-goldilocks",
- "p3-gpu-backend 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
+ "p3-gpu-backend",
  "p3-keccak",
  "p3-merkle-tree",
  "p3-poseidon",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -5151,19 +5122,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.0.0-rc.1"
-source = "git+https://github.com/openvm-org/openvm.git?rev=f1b4844#f1b484499b9c059d14949cdfaa648906757ca7aa"
+version = "1.0.0-rc.2"
+source = "git+https://github.com/openvm-org/openvm.git?rev=de2d3a0#de2d3a0a111cc2da1a967e8d1271f709b01ba6d2"
 dependencies = [
- "derive_more 1.0.0",
  "elf",
  "eyre",
  "openvm-instructions",
  "openvm-platform",
  "openvm-stark-backend",
  "rrs-lib",
- "strum 0.26.3",
  "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -5202,10 +5170,10 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-matrix",
 ]
 
 [[package]]
@@ -5213,25 +5181,11 @@ name = "p3-baby-bear"
 version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-monty-31 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "rand 0.8.5",
- "serde",
-]
-
-[[package]]
-name = "p3-baby-bear"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-monty-31 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-mds",
+ "p3-monty-31",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.5",
  "serde",
 ]
@@ -5239,24 +5193,24 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "blake3",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-symmetric",
+ "p3-util",
 ]
 
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "ff 0.13.1",
  "halo2curves",
  "num-bigint 0.4.6",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.5",
  "serde",
 ]
@@ -5266,22 +5220,10 @@ name = "p3-challenger"
 version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "tracing",
-]
-
-[[package]]
-name = "p3-challenger"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "tracing",
 ]
 
@@ -5292,28 +5234,12 @@ source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd8
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
- "p3-challenger 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "serde",
-]
-
-[[package]]
-name = "p3-commit"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "p3-challenger 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-gpu-base",
+ "p3-matrix",
+ "p3-util",
  "serde",
 ]
 
@@ -5323,23 +5249,10 @@ version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "tracing",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
 ]
 
@@ -5353,25 +5266,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "nums",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "rand 0.8.5",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "nums",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -5380,21 +5276,21 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
- "p3-challenger 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-commit 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-backend 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-interpolation 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-gpu-backend",
+ "p3-gpu-base",
+ "p3-interpolation",
+ "p3-matrix",
+ "p3-maybe-rayon",
  "p3-merkle-tree",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-util",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -5404,16 +5300,16 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "num-bigint 0.4.6",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-dft",
+ "p3-field",
+ "p3-mds",
  "p3-poseidon",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.5",
  "serde",
 ]
@@ -5433,54 +5329,17 @@ dependencies = [
  "lazy_static",
  "ndarray",
  "once_cell",
- "p3-baby-bear 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-commit 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-gpu-build 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-interpolation 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "parking_lot 0.12.3",
- "paste",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rayon",
- "serde",
- "sppark",
- "tracing",
- "transpose",
-]
-
-[[package]]
-name = "p3-gpu-backend"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "anyhow",
- "bytemuck",
- "cc",
- "cust",
- "cust_raw",
- "ff 0.13.1",
- "itertools 0.13.0",
- "lazy_static",
- "ndarray",
- "once_cell",
- "p3-baby-bear 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-commit 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-build 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-interpolation 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-baby-bear",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-gpu-base",
+ "p3-gpu-build",
+ "p3-interpolation",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-poseidon2",
+ "p3-util",
  "parking_lot 0.12.3",
  "paste",
  "rand 0.8.5",
@@ -5503,25 +5362,8 @@ dependencies = [
  "cust_raw",
  "hex",
  "lazy_static",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "parking_lot 0.12.3",
- "tracing",
-]
-
-[[package]]
-name = "p3-gpu-base"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "anyhow",
- "bytemuck",
- "cust",
- "cust_raw",
- "hex",
- "lazy_static",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-matrix",
  "parking_lot 0.12.3",
  "tracing",
 ]
@@ -5534,20 +5376,7 @@ dependencies = [
  "cc",
  "directories",
  "hex",
- "p3-gpu-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "sha2",
- "tempfile",
-]
-
-[[package]]
-name = "p3-gpu-build"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "cc",
- "directories",
- "hex",
- "p3-gpu-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-gpu-field",
  "sha2",
  "tempfile",
 ]
@@ -5556,11 +5385,6 @@ dependencies = [
 name = "p3-gpu-field"
 version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-
-[[package]]
-name = "p3-gpu-field"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 
 [[package]]
 name = "p3-gpu-module"
@@ -5568,10 +5392,10 @@ version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
+ "p3-field",
+ "p3-gpu-base",
+ "p3-matrix",
+ "p3-util",
  "tracing",
 ]
 
@@ -5580,46 +5404,35 @@ name = "p3-interpolation"
 version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
-]
-
-[[package]]
-name = "p3-interpolation"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
 ]
 
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-symmetric",
+ "p3-util",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "p3-air",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-backend 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-gpu-backend",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.5",
  "tracing",
  "zkhash",
@@ -5631,24 +5444,9 @@ version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "rand 0.8.5",
- "serde",
- "tracing",
- "transpose",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -5664,55 +5462,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "p3-maybe-rayon"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "p3-mds"
 version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "p3-mds"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "itertools 0.14.0",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
- "p3-commit 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-gpu-base 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-commit",
+ "p3-field",
+ "p3-gpu-base",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -5725,35 +5501,14 @@ source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd8
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "rand 0.8.5",
- "serde",
- "tracing",
- "transpose",
-]
-
-[[package]]
-name = "p3-monty-31"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "itertools 0.14.0",
- "num-bigint 0.4.6",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -5763,11 +5518,11 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.8.5",
 ]
 
@@ -5777,35 +5532,23 @@ version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "gcd",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "gcd",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-mds 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-symmetric 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "p3-poseidon2-air"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "p3-air",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-poseidon2 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-poseidon2",
+ "p3-util",
  "rand 0.8.5",
  "tikv-jemallocator",
  "tracing",
@@ -5817,34 +5560,24 @@ version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0)",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "itertools 0.14.0",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-field",
  "serde",
 ]
 
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "itertools 0.14.0",
  "p3-air",
- "p3-challenger 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-commit 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-dft 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-field 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-matrix 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-maybe-rayon 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
- "p3-util 0.1.0 (git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2)",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -5853,14 +5586,6 @@ dependencies = [
 name = "p3-util"
 version = "0.1.0"
 source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.1.0#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?branch=openvm-v2#0cebd85e85ae9fa3ef436fe716a5d10ab1d70aeb"
 dependencies = [
  "serde",
 ]
@@ -6253,8 +5978,7 @@ dependencies = [
  "rlp",
  "sbv-primitives",
  "scroll-proving-sdk",
- "scroll-zkvm-prover 0.1.0-rc.6",
- "scroll-zkvm-prover 0.1.1-rc.2",
+ "scroll-zkvm-prover",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -6727,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6746,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6763,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -6774,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6787,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6800,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6824,7 +6548,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -6849,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6863,7 +6587,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6879,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -6894,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6914,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6939,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6960,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6974,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6992,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "serde",
  "serde_json",
@@ -7002,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "metrics 0.24.1",
  "metrics-derive",
@@ -7011,7 +6735,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7024,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7041,7 +6765,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -7054,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7083,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -7096,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7111,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7134,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -7142,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7168,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7180,7 +6904,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7204,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7217,7 +6941,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "derive_more 1.0.0",
@@ -7228,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7253,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7268,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "clap",
  "eyre",
@@ -7283,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7305,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7328,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7346,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7361,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "zstd",
 ]
@@ -7395,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "19.4.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -7434,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "revm-primitives 15.1.0",
  "serde",
@@ -7472,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "16.0.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "aurora-engine-modexp",
  "c-kzg",
@@ -7529,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "15.1.0"
-source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-v2#6fe1fae6d92f0f6a3ed234a955aca4bdcf864f97"
+source = "git+https://github.com/scroll-tech/revm?branch=scroll-evm-executor%2Ffeat%2Fv55%2Feuclid-upgrade#17dfd866846f0fa19fa04bd6f848fb80cd5d73fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.5.1",
@@ -7919,21 +7643,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sbv"
-version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
-dependencies = [
- "sbv-core",
- "sbv-helpers",
- "sbv-kv",
- "sbv-primitives",
- "sbv-trie",
-]
-
-[[package]]
 name = "sbv-core"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "reth-evm",
  "reth-evm-ethereum",
@@ -7950,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "sbv-helpers"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "revm 19.4.0",
 ]
@@ -7958,7 +7670,7 @@ dependencies = [
 [[package]]
 name = "sbv-kv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "auto_impl",
  "hashbrown 0.15.2",
@@ -7968,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "sbv-primitives"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7999,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "sbv-trie"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "alloy-rlp",
  "alloy-trie",
@@ -8014,7 +7726,7 @@ dependencies = [
 [[package]]
 name = "sbv-utils"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-v2#74d7fb0398b1bc94fe20ac29bdc445634c4bfeea"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=zkvm%2Feuclid-upgrade#6759d7b0893e31782e3a24abaad6be655edffdde"
 dependencies = [
  "alloy-provider",
  "alloy-transport",
@@ -8066,7 +7778,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8084,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-network"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8098,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types"
 version = "1.1.5"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8115,7 +7827,7 @@ dependencies = [
 [[package]]
 name = "scroll-proving-sdk"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/scroll-proving-sdk.git?rev=c81e5f2#c81e5f2e5434f0a38f3cb9288cd6a8940bb246e5"
+source = "git+https://github.com/scroll-tech/scroll-proving-sdk.git?branch=feat%2Fopenvm-euclid-upgrade#48a2df00c7549b8aca4ed2e3b0a54c9943c627fb"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8147,72 +7859,31 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-circuit-input-types"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.6#8adaaf856b00ca992e76c95e657761a5148d6084"
-dependencies = [
- "alloy-primitives",
- "alloy-serde 0.8.3",
- "openvm",
- "openvm-rv32im-guest",
- "rkyv",
- "sbv",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "scroll-zkvm-circuit-input-types"
-version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#0f251ba4541e2d136b953f10dae163686c0e815d"
+version = "0.1.0-rc.11"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.11#29a0373dfea03bcd8fd4aa93631ffd76da3d552c"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 0.8.3",
  "itertools 0.14.0",
  "openvm",
+ "openvm-custom-insn",
  "openvm-rv32im-guest",
  "rkyv",
- "sbv",
+ "sbv-core",
+ "sbv-kv",
+ "sbv-primitives",
+ "sbv-trie",
  "serde",
+ "sha2",
+ "sha3",
  "tiny-keccak",
  "vm-zstd",
 ]
 
 [[package]]
 name = "scroll-zkvm-prover"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.6#8adaaf856b00ca992e76c95e657761a5148d6084"
-dependencies = [
- "alloy-primitives",
- "base64 0.22.1",
- "bincode",
- "git-version",
- "hex",
- "metrics 0.23.0",
- "metrics-util",
- "once_cell",
- "openvm-circuit",
- "openvm-native-circuit",
- "openvm-native-recursion",
- "openvm-sdk",
- "openvm-stark-sdk",
- "revm 19.6.0",
- "rkyv",
- "sbv",
- "scroll-zkvm-circuit-input-types 0.1.0-rc.6",
- "scroll-zkvm-verifier 0.1.0-rc.6",
- "serde",
- "serde_json",
- "serde_stacker",
- "snark-verifier-sdk",
- "thiserror 2.0.12",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "scroll-zkvm-prover"
-version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#0f251ba4541e2d136b953f10dae163686c0e815d"
+version = "0.1.0-rc.11"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.11#29a0373dfea03bcd8fd4aa93631ffd76da3d552c"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8221,19 +7892,21 @@ dependencies = [
  "git-version",
  "hex",
  "metrics 0.23.0",
+ "metrics-tracing-context",
  "metrics-util",
  "munge",
  "once_cell",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-native-circuit",
  "openvm-native-recursion",
  "openvm-sdk",
  "openvm-stark-sdk",
  "revm 19.6.0",
  "rkyv",
- "sbv",
- "scroll-zkvm-circuit-input-types 0.1.1-rc.2",
- "scroll-zkvm-verifier 0.1.1-rc.2",
+ "sbv-primitives",
+ "scroll-zkvm-circuit-input-types",
+ "scroll-zkvm-verifier",
  "serde",
  "serde_json",
  "serde_stacker",
@@ -8245,38 +7918,20 @@ dependencies = [
 
 [[package]]
 name = "scroll-zkvm-verifier"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.6#8adaaf856b00ca992e76c95e657761a5148d6084"
+version = "0.1.0-rc.11"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.0-rc.11#29a0373dfea03bcd8fd4aa93631ffd76da3d552c"
 dependencies = [
  "bincode",
  "eyre",
  "itertools 0.14.0",
  "openvm-circuit",
+ "openvm-continuations",
  "openvm-native-circuit",
  "openvm-native-recursion",
  "openvm-sdk",
  "openvm-stark-sdk",
  "revm 19.6.0",
- "scroll-zkvm-circuit-input-types 0.1.0-rc.6",
- "serde",
- "snark-verifier-sdk",
-]
-
-[[package]]
-name = "scroll-zkvm-verifier"
-version = "0.1.1-rc.2"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.1.1-rc.3#0f251ba4541e2d136b953f10dae163686c0e815d"
-dependencies = [
- "bincode",
- "eyre",
- "itertools 0.14.0",
- "openvm-circuit",
- "openvm-native-circuit",
- "openvm-native-recursion",
- "openvm-sdk",
- "openvm-stark-sdk",
- "revm 19.6.0",
- "scroll-zkvm-circuit-input-types 0.1.1-rc.2",
+ "scroll-zkvm-circuit-input-types",
  "serde",
  "snark-verifier-sdk",
 ]
@@ -8749,16 +8404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9183,7 +8828,6 @@ source = "git+https://github.com/scroll-tech/tiny-keccak?branch=scroll-patch-v2.
 dependencies = [
  "cfg-if",
  "crunchy",
- "openvm-platform",
 ]
 
 [[package]]
@@ -10495,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "zstd"
 version = "1.1.4"
-source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-v2#b037c98a5a3462526829179f58cd67f51511f227"
+source = "git+https://github.com/scroll-tech/reth?branch=zkvm%2Feuclid-upgrade#eb41a605a7efd77c2292a110745179d7d1a5b1de"
 
 [[package]]
 name = "zstd-sys"

--- a/zkvm-prover/Cargo.toml
+++ b/zkvm-prover/Cargo.toml
@@ -18,14 +18,16 @@ serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 futures = "0.3.30"
 
-scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.0-rc.6", package = "scroll-zkvm-prover" }
-scroll-zkvm-prover-euclidv2 = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.1-rc.3", package = "scroll-zkvm-prover" }
+scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", branch = "feat/phase1-stable", package = "scroll-zkvm-prover" }
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "c81e5f2", features = [
+#scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "c81e5f2", features = [
+#    "openvm",
+#] }
+scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", branch = "feat/openvm-euclid-upgrade", features = [
     "openvm",
 ] }
-sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "zkvm/euclid-v2", features = [
+sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "zkvm/euclid-upgrade", features = [
     "scroll",
 ] }
 base64 = "0.13.1"
@@ -47,33 +49,33 @@ ctor = "0.2.8"
 url = "2.5.4"
 serde_bytes = "0.11.15"
 
-[patch."https://github.com/openvm-org/stark-backend.git"]
-openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
-openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+#[patch."https://github.com/openvm-org/stark-backend.git"]
+#openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+#openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
 
-[patch."https://github.com/Plonky3/Plonky3.git"]
-p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
-    "nightly-features",
-], branch = "openvm-v2" }
-p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
-p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# [patch."https://github.com/Plonky3/Plonky3.git"]
+# p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
+#     "nightly-features",
+# ], branch = "openvm-v2" }
+# p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+# p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+# p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }

--- a/zkvm-prover/Cargo.toml
+++ b/zkvm-prover/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.198", features = ["derive"] }
 serde_json = "1.0.116"
 futures = "0.3.30"
 
-scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", branch = "feat/phase1-stable", package = "scroll-zkvm-prover" }
+scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.1.0-rc.11", package = "scroll-zkvm-prover" }
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
 #scroll-proving-sdk = { git = "https://github.com/scroll-tech/scroll-proving-sdk.git", rev = "c81e5f2", features = [

--- a/zkvm-prover/Cargo.toml
+++ b/zkvm-prover/Cargo.toml
@@ -49,33 +49,33 @@ ctor = "0.2.8"
 url = "2.5.4"
 serde_bytes = "0.11.15"
 
-#[patch."https://github.com/openvm-org/stark-backend.git"]
-#openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
-#openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+[patch."https://github.com/openvm-org/stark-backend.git"]
+openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
 
-# [patch."https://github.com/Plonky3/Plonky3.git"]
-# p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
-#     "nightly-features",
-# ], branch = "openvm-v2" }
-# p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
-# p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
-# p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", branch = "openvm-v2" }
+[patch."https://github.com/Plonky3/Plonky3.git"]
+p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
+    "nightly-features",
+], tag = "v0.1.0" }
+p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }
+p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.1.0" }

--- a/zkvm-prover/src/zk_circuits_handler/euclid.rs
+++ b/zkvm-prover/src/zk_circuits_handler/euclid.rs
@@ -33,10 +33,7 @@ impl Phase {
         let dir_cache = Some(workspace_path.join("cache"));
         let path_app_exe = workspace_path.join("chunk/app.vmexe");
         let path_app_config = workspace_path.join("chunk/openvm.toml");
-        let segment_len = match self {
-            Phase::EuclidV1 => None,
-            Phase::EuclidV2 => Some((1 << 22) - 100),
-        };
+        let segment_len = Some((1 << 22) - 100);
         ProverConfig {
             dir_cache,
             path_app_config,
@@ -50,10 +47,7 @@ impl Phase {
         let dir_cache = Some(workspace_path.join("cache"));
         let path_app_exe = workspace_path.join("batch/app.vmexe");
         let path_app_config = workspace_path.join("batch/openvm.toml");
-        let segment_len = match self {
-            Phase::EuclidV1 => None,
-            Phase::EuclidV2 => Some((1 << 22) - 100),
-        };
+        let segment_len = Some((1 << 22) - 100);
         ProverConfig {
             dir_cache,
             path_app_config,
@@ -66,18 +60,20 @@ impl Phase {
     pub fn phase_spec_bundle(&self, workspace_path: &Path) -> ProverConfig {
         let dir_cache = Some(workspace_path.join("cache"));
         let path_app_config = workspace_path.join("bundle/openvm.toml");
+        let segment_len = Some((1 << 22) - 100);
         match self {
             Phase::EuclidV1 => ProverConfig {
                 dir_cache,
                 path_app_config,
+                segment_len,
                 path_app_exe: workspace_path.join("bundle/app_euclidv1.vmexe"),
                 ..Default::default()
             },
             Phase::EuclidV2 => ProverConfig {
                 dir_cache,
                 path_app_config,
+                segment_len,
                 path_app_exe: workspace_path.join("bundle/app.vmexe"),
-                segment_len: Some((1 << 22) - 100),
                 ..Default::default()
             },
         }

--- a/zkvm-prover/src/zk_circuits_handler/euclid.rs
+++ b/zkvm-prover/src/zk_circuits_handler/euclid.rs
@@ -6,35 +6,97 @@ use async_trait::async_trait;
 use scroll_proving_sdk::prover::{proving_service::ProveRequest, ProofType};
 use scroll_zkvm_prover_euclid::{
     task::{batch::BatchProvingTask, bundle::BundleProvingTask, chunk::ChunkProvingTask},
-    BatchProver, BundleProver, ChunkProver,
+    BatchProver, BundleProverEuclidV1, ChunkProver, ProverConfig,
 };
 use tokio::sync::Mutex;
 pub struct EuclidHandler {
     chunk_prover: ChunkProver,
     batch_prover: BatchProver,
-    bundle_prover: BundleProver,
+    bundle_prover: BundleProverEuclidV1,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Phase {
+    EuclidV1,
+    EuclidV2,
+}
+
+impl Phase {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Phase::EuclidV1 => "euclidv1",
+            Phase::EuclidV2 => "euclidv2",
+        }
+    }
+
+    pub fn phase_spec_chunk(&self, workspace_path: &Path) -> ProverConfig {
+        let dir_cache = Some(workspace_path.join("cache"));
+        let path_app_exe = workspace_path.join("chunk/app.vmexe");
+        let path_app_config = workspace_path.join("chunk/openvm.toml");
+        let segment_len = match self {
+            Phase::EuclidV1 => None,
+            Phase::EuclidV2 => Some((1 << 22) - 100),
+        };
+        ProverConfig {
+            dir_cache,
+            path_app_config,
+            path_app_exe,
+            segment_len,
+            ..Default::default()
+        }
+    }
+
+    pub fn phase_spec_batch(&self, workspace_path: &Path) -> ProverConfig {
+        let dir_cache = Some(workspace_path.join("cache"));
+        let path_app_exe = workspace_path.join("batch/app.vmexe");
+        let path_app_config = workspace_path.join("batch/openvm.toml");
+        let segment_len = match self {
+            Phase::EuclidV1 => None,
+            Phase::EuclidV2 => Some((1 << 22) - 100),
+        };
+        ProverConfig {
+            dir_cache,
+            path_app_config,
+            path_app_exe,
+            segment_len,
+            ..Default::default()
+        }
+    }
+
+    pub fn phase_spec_bundle(&self, workspace_path: &Path) -> ProverConfig {
+        let dir_cache = Some(workspace_path.join("cache"));
+        let path_app_config = workspace_path.join("bundle/openvm.toml");
+        match self {
+            Phase::EuclidV1 => ProverConfig {
+                dir_cache,
+                path_app_config,
+                path_app_exe: workspace_path.join("bundle/app_euclidv1.vmexe"),
+                ..Default::default()
+            },
+            Phase::EuclidV2 => ProverConfig {
+                dir_cache,
+                path_app_config,
+                path_app_exe: workspace_path.join("bundle/app.vmexe"),
+                segment_len: Some((1 << 22) - 100),
+                ..Default::default()
+            },
+        }
+    }
 }
 
 unsafe impl Send for EuclidHandler {}
 
 impl EuclidHandler {
     pub fn new(workspace_path: &str) -> Self {
+        let p = Phase::EuclidV1;
         let workspace_path = Path::new(workspace_path);
-
-        let cache_dir = workspace_path.join("cache");
-        let chunk_exe = workspace_path.join("chunk/app.vmexe");
-        let chunk_app_config = workspace_path.join("chunk/openvm.toml");
-        let chunk_prover = ChunkProver::setup(chunk_exe, chunk_app_config, Some(cache_dir.clone()))
+        let chunk_prover = ChunkProver::setup(p.phase_spec_chunk(workspace_path))
             .expect("Failed to setup chunk prover");
 
-        let batch_exe = workspace_path.join("batch/app.vmexe");
-        let batch_app_config = workspace_path.join("batch/openvm.toml");
-        let batch_prover = BatchProver::setup(batch_exe, batch_app_config, Some(cache_dir.clone()))
+        let batch_prover = BatchProver::setup(p.phase_spec_batch(workspace_path))
             .expect("Failed to setup batch prover");
 
-        let bundle_exe = workspace_path.join("bundle/app.vmexe");
-        let bundle_app_config = workspace_path.join("bundle/openvm.toml");
-        let bundle_prover = BundleProver::setup(bundle_exe, bundle_app_config, Some(cache_dir))
+        let bundle_prover = BundleProverEuclidV1::setup(p.phase_spec_bundle(workspace_path))
             .expect("Failed to setup bundle prover");
 
         Self {
@@ -68,6 +130,8 @@ impl CircuitsHandler for Arc<Mutex<EuclidHandler>> {
                     .chunk_prover
                     .gen_proof(&ChunkProvingTask {
                         block_witnesses: witnesses,
+                        prev_msg_queue_hash: Default::default(),
+                        fork_name: Phase::EuclidV1.as_str().to_string(),
                     })?;
 
                 Ok(serde_json::to_string(&proof)?)

--- a/zkvm-prover/src/zk_circuits_handler/euclidV2.rs
+++ b/zkvm-prover/src/zk_circuits_handler/euclidV2.rs
@@ -1,62 +1,34 @@
 use std::{path::Path, sync::Arc};
 
-use super::CircuitsHandler;
+use super::{euclid::Phase, CircuitsHandler};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use scroll_proving_sdk::prover::{proving_service::ProveRequest, ProofType};
-use scroll_zkvm_prover_euclidv2::{
+use scroll_zkvm_prover_euclid::{
     task::{batch::BatchProvingTask, bundle::BundleProvingTask, chunk::ChunkProvingTask},
-    BatchProver, BundleProver, ChunkProver, ProverConfig,
+    BatchProver, BundleProverEuclidV2, ChunkProver,
 };
 use tokio::sync::Mutex;
 pub struct EuclidV2Handler {
     chunk_prover: ChunkProver,
     batch_prover: BatchProver,
-    bundle_prover: BundleProver,
+    bundle_prover: BundleProverEuclidV2,
 }
 
 unsafe impl Send for EuclidV2Handler {}
 
 impl EuclidV2Handler {
     pub fn new(workspace_path: &str) -> Self {
+        let p = Phase::EuclidV2;
         let workspace_path = Path::new(workspace_path);
+        let chunk_prover = ChunkProver::setup(p.phase_spec_chunk(workspace_path))
+            .expect("Failed to setup chunk prover");
 
-        let cache_dir = workspace_path.join("cache");
-        let chunk_exe = workspace_path.join("chunk/app.vmexe");
-        let chunk_app_config = workspace_path.join("chunk/openvm.toml");
-        let chunk_prover = ChunkProver::setup(
-            chunk_exe,
-            chunk_app_config,
-            Some(cache_dir.clone()),
-            ProverConfig {
-                segment_len: Some((1 << 22) - 100),
-            },
-        )
-        .expect("Failed to setup chunk prover");
+        let batch_prover = BatchProver::setup(p.phase_spec_batch(workspace_path))
+            .expect("Failed to setup batch prover");
 
-        let batch_exe = workspace_path.join("batch/app.vmexe");
-        let batch_app_config = workspace_path.join("batch/openvm.toml");
-        let batch_prover = BatchProver::setup(
-            batch_exe,
-            batch_app_config,
-            Some(cache_dir.clone()),
-            ProverConfig {
-                segment_len: Some((1 << 22) - 100),
-            },
-        )
-        .expect("Failed to setup batch prover");
-
-        let bundle_exe = workspace_path.join("bundle/app.vmexe");
-        let bundle_app_config = workspace_path.join("bundle/openvm.toml");
-        let bundle_prover = BundleProver::setup(
-            bundle_exe,
-            bundle_app_config,
-            Some(cache_dir),
-            ProverConfig {
-                segment_len: Some((1 << 22) - 100),
-            },
-        )
-        .expect("Failed to setup bundle prover");
+        let bundle_prover = BundleProverEuclidV2::setup(p.phase_spec_bundle(workspace_path))
+            .expect("Failed to setup bundle prover");
 
         Self {
             chunk_prover,


### PR DESCRIPTION
This PR upgrade euclid dependings for rc11 with quite a few breaking changes:

+ The messages of ProvingTask need upgrade, a new fork_name field is required now

+ The deployment asset is updated, now there would be two bundle exe is packed in the released assets, one named "app.vmexe" and another named "app_euclidv1.vmexe", they have to be both deployed and loaded while creating the corresponding prover instance