### PR TITLE
fix(rollup-relayer): rollup status overwrite

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.4.98"
+var tag = "v4.4.99"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -419,7 +419,7 @@ func (o *Batch) UpdateCommitTxHashAndRollupStatus(ctx context.Context, hash stri
 		return fmt.Errorf("Batch.UpdateCommitTxHashAndRollupStatus error when querying current status: %w, batch hash: %v", err, hash)
 	}
 
-	if types.RollupStatus(currentBatch.RollupStatus) == types.RollupFinalized {
+	if types.RollupStatus(currentBatch.RollupStatus) == types.RollupFinalizing || types.RollupStatus(currentBatch.RollupStatus) == types.RollupFinalized {
 		return nil
 	}
 

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -413,6 +413,16 @@ func (o *Batch) UpdateCommitTxHashAndRollupStatus(ctx context.Context, hash stri
 		db = dbTX[0]
 	}
 	db = db.WithContext(ctx)
+
+	var currentBatch Batch
+	if err := db.Where("hash", hash).First(&currentBatch).Error; err != nil {
+		return fmt.Errorf("Batch.UpdateCommitTxHashAndRollupStatus error when querying current status: %w, batch hash: %v", err, hash)
+	}
+
+	if types.RollupStatus(currentBatch.RollupStatus) == types.RollupFinalized {
+		return nil
+	}
+
 	db = db.Model(&Batch{})
 	db = db.Where("hash", hash)
 

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -318,8 +318,8 @@ func TestBatchOrm(t *testing.T) {
 		updatedBatch, err = batchOrm.GetLatestBatch(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedBatch)
-		assert.Equal(t, "commitTxHash", updatedBatch.CommitTxHash)
-		assert.Equal(t, types.RollupCommitted, types.RollupStatus(updatedBatch.RollupStatus))
+		assert.Equal(t, "", updatedBatch.CommitTxHash)
+		assert.Equal(t, types.RollupFinalized, types.RollupStatus(updatedBatch.RollupStatus))
 
 		err = batchOrm.UpdateFinalizeTxHashAndRollupStatus(context.Background(), batchHash2, "finalizeTxHash", types.RollupFinalizeFailed)
 		assert.NoError(t, err)
@@ -332,9 +332,8 @@ func TestBatchOrm(t *testing.T) {
 
 		batches, err := batchOrm.GetCommittedBatchesGEIndexGECodecVersion(context.Background(), 0, codecVersion, 0)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(batches))
+		assert.Equal(t, 1, len(batches))
 		assert.Equal(t, batchHash1, batches[0].Hash)
-		assert.Equal(t, batchHash2, batches[1].Hash)
 
 		batches, err = batchOrm.GetCommittedBatchesGEIndexGECodecVersion(context.Background(), 0, codecVersion, 1)
 		assert.NoError(t, err)
@@ -343,8 +342,7 @@ func TestBatchOrm(t *testing.T) {
 
 		batches, err = batchOrm.GetCommittedBatchesGEIndexGECodecVersion(context.Background(), 1, codecVersion, 0)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(batches))
-		assert.Equal(t, batchHash2, batches[0].Hash)
+		assert.Equal(t, 0, len(batches))
 
 		batches, err = batchOrm.GetCommittedBatchesGEIndexGECodecVersion(context.Background(), 0, codecVersion+1, 0)
 		assert.NoError(t, err)
@@ -361,13 +359,10 @@ func TestBatchOrm(t *testing.T) {
 
 		batches, err = batchOrm.GetCommittedBatchesGEIndexGECodecVersion(context.Background(), 0, codecVersion, 0)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(batches))
+		assert.Equal(t, 1, len(batches))
 		assert.Equal(t, batchHash1, batches[0].Hash)
-		assert.Equal(t, batchHash2, batches[1].Hash)
 		assert.Equal(t, types.ProvingTaskFailed, types.ProvingStatus(batches[0].ProvingStatus))
 		assert.Equal(t, types.RollupCommitFailed, types.RollupStatus(batches[0].RollupStatus))
-		assert.Equal(t, types.ProvingTaskVerified, types.ProvingStatus(batches[1].ProvingStatus))
-		assert.Equal(t, types.RollupFinalizeFailed, types.RollupStatus(batches[1].RollupStatus))
 	}
 }
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

![image](https://github.com/user-attachments/assets/3abd9afd-28e9-43ad-b25b-a421a375222c)

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the software version to v4.4.99.

- **Bug Fixes**
  - Enhanced the update process for batch operations by preventing modifications to entries that have been finalized, ensuring improved data consistency and stability.
  - Adjusted test assertions to reflect changes in expected outcomes regarding rollup statuses and the number of batches retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->