### PR TITLE
chore(gas-oracle): decommission L2 gas price oracle

### DIFF
--- a/common/utils/flags.go
+++ b/common/utils/flags.go
@@ -20,7 +20,6 @@ var (
 	}
 	// RollupRelayerFlags contains flags only used in rollup-relayer
 	RollupRelayerFlags = []cli.Flag{
-		&ImportGenesisFlag,
 		&MinCodecVersionFlag,
 	}
 	// ConfigFileFlag load json type config file.

--- a/common/utils/flags.go
+++ b/common/utils/flags.go
@@ -73,12 +73,6 @@ var (
 		Category: "METRICS",
 		Value:    6060,
 	}
-	// ImportGenesisFlag import genesis batch during startup
-	ImportGenesisFlag = cli.BoolFlag{
-		Name:  "import-genesis",
-		Usage: "Import genesis batch into L1 contract during startup",
-		Value: false,
-	}
 	// ServicePortFlag is the port the service will listen on
 	ServicePortFlag = cli.IntFlag{
 		Name:  "service.port",

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.2"
+var tag = "v4.5.3"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/cmd/gas_oracle/app/app.go
+++ b/rollup/cmd/gas_oracle/app/app.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/log"
-	"github.com/scroll-tech/go-ethereum/params"
 	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
 
@@ -72,21 +71,11 @@ func action(ctx *cli.Context) error {
 		log.Crit("failed to connect l1 geth", "config file", cfgFile, "error", err)
 	}
 
-	// Init l2geth connection
-	l2client, err := ethclient.Dial(cfg.L2Config.Endpoint)
-	if err != nil {
-		log.Crit("failed to connect l2 geth", "config file", cfgFile, "error", err)
-	}
-
 	l1watcher := watcher.NewL1WatcherClient(ctx.Context, l1client, cfg.L1Config.StartHeight, db, registry)
 
 	l1relayer, err := relayer.NewLayer1Relayer(ctx.Context, db, cfg.L1Config.RelayerConfig, relayer.ServiceTypeL1GasOracle, registry)
 	if err != nil {
 		log.Crit("failed to create new l1 relayer", "config file", cfgFile, "error", err)
-	}
-	l2relayer, err := relayer.NewLayer2Relayer(ctx.Context, l2client, db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, false /* initGenesis */, relayer.ServiceTypeL2GasOracle, registry)
-	if err != nil {
-		log.Crit("failed to create new l2 relayer", "config file", cfgFile, "error", err)
 	}
 	// Start l1 watcher process
 	go utils.LoopWithContext(subCtx, 10*time.Second, func(ctx context.Context) {
@@ -106,7 +95,6 @@ func action(ctx *cli.Context) error {
 
 	// Start l1relayer process
 	go utils.Loop(subCtx, 10*time.Second, l1relayer.ProcessGasPriceOracle)
-	go utils.Loop(subCtx, 2*time.Second, l2relayer.ProcessGasPriceOracle)
 
 	// Finish start all message relayer functions
 	log.Info("Start gas-oracle successfully", "version", version.Version)

--- a/rollup/cmd/rollup_relayer/app/app.go
+++ b/rollup/cmd/rollup_relayer/app/app.go
@@ -79,8 +79,6 @@ func action(ctx *cli.Context) error {
 		log.Crit("failed to read genesis", "genesis file", genesisPath, "error", err)
 	}
 
-	initGenesis := ctx.Bool(utils.ImportGenesisFlag.Name)
-
 	// sanity check config
 	if cfg.L2Config.RelayerConfig.BatchSubmission == nil {
 		log.Crit("cfg.L2Config.RelayerConfig.BatchSubmission must not be nil")
@@ -98,7 +96,7 @@ func action(ctx *cli.Context) error {
 		log.Crit("cfg.L2Config.ChunkProposerConfig.MaxL2GasPerChunk must be greater than 0")
 	}
 
-	l2relayer, err := relayer.NewLayer2Relayer(ctx.Context, l2client, db, cfg.L2Config.RelayerConfig, genesis.Config, initGenesis, relayer.ServiceTypeL2RollupRelayer, registry)
+	l2relayer, err := relayer.NewLayer2Relayer(ctx.Context, l2client, db, cfg.L2Config.RelayerConfig, genesis.Config, relayer.ServiceTypeL2RollupRelayer, registry)
 	if err != nil {
 		log.Crit("failed to create l2 relayer", "config file", cfgFile, "error", err)
 	}

--- a/rollup/internal/controller/relayer/common.go
+++ b/rollup/internal/controller/relayer/common.go
@@ -25,6 +25,6 @@ const (
 	ServiceTypeL2RollupRelayer
 	// ServiceTypeL1GasOracle indicates the service is a Layer 1 gas oracle.
 	ServiceTypeL1GasOracle
-	// ServiceTypeL2GasOracle indicates the service is a Layer 2 gas oracle.
-	ServiceTypeL2GasOracle
+	// ServiceTypeL2GasOracleDeprecated indicates the service is a Layer 2 gas oracle, which is deprecated.
+	ServiceTypeL2GasOracleDeprecated
 )

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -64,7 +64,7 @@ type Layer2Relayer struct {
 }
 
 // NewLayer2Relayer will return a new instance of Layer2RelayerClient
-func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.DB, cfg *config.RelayerConfig, chainCfg *params.ChainConfig, initGenesis bool, serviceType ServiceType, reg prometheus.Registerer) (*Layer2Relayer, error) {
+func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.DB, cfg *config.RelayerConfig, chainCfg *params.ChainConfig, serviceType ServiceType, reg prometheus.Registerer) (*Layer2Relayer, error) {
 	var commitSender, finalizeSender *sender.Sender
 
 	switch serviceType {
@@ -129,10 +129,8 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 	}
 
 	// Initialize genesis before we do anything else
-	if initGenesis {
-		if err := layer2Relayer.initializeGenesis(); err != nil {
-			return nil, fmt.Errorf("failed to initialize and commit genesis batch, err: %v", err)
-		}
+	if err := layer2Relayer.initializeGenesis(); err != nil {
+		return nil, fmt.Errorf("failed to initialize and commit genesis batch, err: %v", err)
 	}
 	layer2Relayer.metrics = initL2RelayerMetrics(reg)
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"sort"
 	"strings"
@@ -54,12 +53,7 @@ type Layer2Relayer struct {
 	finalizeSender *sender.Sender
 	l1RollupABI    *abi.ABI
 
-	gasOracleSender *sender.Sender
-	l2GasOracleABI  *abi.ABI
-
-	lastGasPrice uint64
-	minGasPrice  uint64
-	gasPriceDiff uint64
+	l2GasOracleABI *abi.ABI
 
 	// Used to get batch status from chain_monitor api.
 	chainMonitorClient *resty.Client
@@ -71,21 +65,9 @@ type Layer2Relayer struct {
 
 // NewLayer2Relayer will return a new instance of Layer2RelayerClient
 func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.DB, cfg *config.RelayerConfig, chainCfg *params.ChainConfig, initGenesis bool, serviceType ServiceType, reg prometheus.Registerer) (*Layer2Relayer, error) {
-	var gasOracleSender, commitSender, finalizeSender *sender.Sender
-	var err error
+	var commitSender, finalizeSender *sender.Sender
 
 	switch serviceType {
-	case ServiceTypeL2GasOracle:
-		gasOracleSender, err = sender.NewSender(ctx, cfg.SenderConfig, cfg.GasOracleSenderSignerConfig, "l2_relayer", "gas_oracle_sender", types.SenderTypeL2GasOracle, db, reg)
-		if err != nil {
-			return nil, fmt.Errorf("new gas oracle sender failed, err: %w", err)
-		}
-
-		// Ensure test features aren't enabled on the ethereum mainnet.
-		if gasOracleSender.GetChainID().Cmp(big.NewInt(1)) == 0 && cfg.EnableTestEnvBypassFeatures {
-			return nil, errors.New("cannot enable test env features in mainnet")
-		}
-
 	case ServiceTypeL2RollupRelayer:
 		commitSenderAddr, err := addrFromSignerConfig(cfg.CommitSenderSignerConfig)
 		if err != nil {
@@ -118,16 +100,6 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 		return nil, fmt.Errorf("invalid service type for l2_relayer: %v", serviceType)
 	}
 
-	var minGasPrice uint64
-	var gasPriceDiff uint64
-	if cfg.GasOracleConfig != nil {
-		minGasPrice = cfg.GasOracleConfig.MinGasPrice
-		gasPriceDiff = cfg.GasOracleConfig.GasPriceDiff
-	} else {
-		minGasPrice = 0
-		gasPriceDiff = defaultGasPriceDiff
-	}
-
 	layer2Relayer := &Layer2Relayer{
 		ctx: ctx,
 		db:  db,
@@ -143,11 +115,7 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 		finalizeSender: finalizeSender,
 		l1RollupABI:    bridgeAbi.ScrollChainABI,
 
-		gasOracleSender: gasOracleSender,
-		l2GasOracleABI:  bridgeAbi.L2GasPriceOracleABI,
-
-		minGasPrice:  minGasPrice,
-		gasPriceDiff: gasPriceDiff,
+		l2GasOracleABI: bridgeAbi.L2GasPriceOracleABI,
 
 		cfg:      cfg,
 		chainCfg: chainCfg,
@@ -169,8 +137,6 @@ func NewLayer2Relayer(ctx context.Context, l2Client *ethclient.Client, db *gorm.
 	layer2Relayer.metrics = initL2RelayerMetrics(reg)
 
 	switch serviceType {
-	case ServiceTypeL2GasOracle:
-		go layer2Relayer.handleL2GasOracleConfirmLoop(ctx)
 	case ServiceTypeL2RollupRelayer:
 		go layer2Relayer.handleL2RollupRelayerConfirmLoop(ctx)
 	default:
@@ -297,80 +263,6 @@ func (r *Layer2Relayer) commitGenesisBatch(batchHash string, batchHeader []byte,
 			}
 			log.Info("Successfully committed genesis batch on L1", "txHash", confirmation.TxHash.String())
 			return nil
-		}
-	}
-}
-
-// ProcessGasPriceOracle imports gas price to layer1
-func (r *Layer2Relayer) ProcessGasPriceOracle() {
-	r.metrics.rollupL2RelayerGasPriceOraclerRunTotal.Inc()
-	batch, err := r.batchOrm.GetLatestBatch(r.ctx)
-	if err != nil {
-		log.Error("Failed to GetLatestBatch", "err", err)
-		return
-	}
-
-	if types.GasOracleStatus(batch.OracleStatus) == types.GasOraclePending {
-		suggestGasPrice, err := r.l2Client.SuggestGasPrice(r.ctx)
-		if err != nil {
-			log.Error("Failed to fetch SuggestGasPrice from l2geth", "err", err)
-			return
-		}
-		suggestGasPriceUint64 := uint64(suggestGasPrice.Int64())
-
-		// include the token exchange rate in the fee data if alternative gas token enabled
-		if r.cfg.GasOracleConfig.AlternativeGasTokenConfig != nil && r.cfg.GasOracleConfig.AlternativeGasTokenConfig.Enabled {
-			// The exchange rate represent the number of native token on L1 required to exchange for 1 native token on L2.
-			var exchangeRate float64
-			switch r.cfg.GasOracleConfig.AlternativeGasTokenConfig.Mode {
-			case "Fixed":
-				exchangeRate = r.cfg.GasOracleConfig.AlternativeGasTokenConfig.FixedExchangeRate
-			case "BinanceApi":
-				exchangeRate, err = rutils.GetExchangeRateFromBinanceApi(r.cfg.GasOracleConfig.AlternativeGasTokenConfig.TokenSymbolPair, 5)
-				if err != nil {
-					log.Error("Failed to get gas token exchange rate from Binance api", "tokenSymbolPair", r.cfg.GasOracleConfig.AlternativeGasTokenConfig.TokenSymbolPair, "err", err)
-					return
-				}
-			default:
-				log.Error("Invalid alternative gas token mode", "mode", r.cfg.GasOracleConfig.AlternativeGasTokenConfig.Mode)
-				return
-			}
-			if exchangeRate == 0 {
-				log.Error("Invalid exchange rate", "exchangeRate", exchangeRate)
-				return
-			}
-			suggestGasPriceUint64 = uint64(math.Ceil(float64(suggestGasPriceUint64) * exchangeRate))
-			suggestGasPrice = new(big.Int).SetUint64(suggestGasPriceUint64)
-		}
-
-		expectedDelta := r.lastGasPrice * r.gasPriceDiff / gasPriceDiffPrecision
-		if r.lastGasPrice > 0 && expectedDelta == 0 {
-			expectedDelta = 1
-		}
-
-		// last is undefined or (suggestGasPriceUint64 >= minGasPrice && exceed diff)
-		if r.lastGasPrice == 0 || (suggestGasPriceUint64 >= r.minGasPrice &&
-			(math.Abs(float64(suggestGasPriceUint64)-float64(r.lastGasPrice)) >= float64(expectedDelta))) {
-			data, err := r.l2GasOracleABI.Pack("setL2BaseFee", suggestGasPrice)
-			if err != nil {
-				log.Error("Failed to pack setL2BaseFee", "batch.Hash", batch.Hash, "GasPrice", suggestGasPrice.Uint64(), "err", err)
-				return
-			}
-
-			hash, err := r.gasOracleSender.SendTransaction(batch.Hash, &r.cfg.GasPriceOracleContractAddress, data, nil, 0)
-			if err != nil {
-				log.Error("Failed to send setL2BaseFee tx to layer2 ", "batch.Hash", batch.Hash, "err", err)
-				return
-			}
-
-			err = r.batchOrm.UpdateL2GasOracleStatusAndOracleTxHash(r.ctx, batch.Hash, types.GasOracleImporting, hash.String())
-			if err != nil {
-				log.Error("UpdateGasOracleStatusAndOracleTxHash failed", "batch.Hash", batch.Hash, "err", err)
-				return
-			}
-			r.lastGasPrice = suggestGasPriceUint64
-			r.metrics.rollupL2RelayerLastGasPrice.Set(float64(r.lastGasPrice))
-			log.Info("Update l2 gas price", "txHash", hash.String(), "GasPrice", suggestGasPrice)
 		}
 	}
 }
@@ -1063,17 +955,6 @@ func (r *Layer2Relayer) handleConfirmation(cfm *sender.Confirmation) {
 	log.Info("Transaction confirmed in layer1", "confirmation", cfm)
 }
 
-func (r *Layer2Relayer) handleL2GasOracleConfirmLoop(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case cfm := <-r.gasOracleSender.ConfirmChan():
-			r.handleConfirmation(cfm)
-		}
-	}
-}
-
 func (r *Layer2Relayer) handleL2RollupRelayerConfirmLoop(ctx context.Context) {
 	for {
 		select {
@@ -1248,10 +1129,6 @@ func (r *Layer2Relayer) constructFinalizeBundlePayloadCodecV7(dbBatch *orm.Batch
 // StopSenders stops the senders of the rollup-relayer to prevent querying the removed pending_transaction table in unit tests.
 // for unit test
 func (r *Layer2Relayer) StopSenders() {
-	if r.gasOracleSender != nil {
-		r.gasOracleSender.Stop()
-	}
-
 	if r.commitSender != nil {
 		r.commitSender.Stop()
 	}

--- a/rollup/internal/controller/relayer/l2_relayer_test.go
+++ b/rollup/internal/controller/relayer/l2_relayer_test.go
@@ -2,7 +2,6 @@ package relayer
 
 import (
 	"context"
-	"errors"
 	"math/big"
 	"net/http"
 	"strings"
@@ -14,9 +13,7 @@ import (
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/common"
 	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
-	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
 	"github.com/scroll-tech/go-ethereum/params"
-	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
@@ -372,149 +369,6 @@ func testL2RelayerFinalizeBundleConfirm(t *testing.T) {
 
 		return true
 	}, 5*time.Second, 100*time.Millisecond, "Bundle or Batch status did not update as expected")
-}
-
-func testL2RelayerGasOracleConfirm(t *testing.T) {
-	db := setupL2RelayerDB(t)
-	defer database.CloseDB(db)
-
-	batch1 := &encoding.Batch{
-		Index:                      0,
-		TotalL1MessagePoppedBefore: 0,
-		ParentBatchHash:            common.Hash{},
-		Chunks:                     []*encoding.Chunk{chunk1},
-	}
-
-	batchOrm := orm.NewBatch(db)
-	dbBatch1, err := batchOrm.InsertBatch(context.Background(), batch1, encoding.CodecV0, rutils.BatchMetrics{})
-	assert.NoError(t, err)
-
-	batch2 := &encoding.Batch{
-		Index:                      batch1.Index + 1,
-		TotalL1MessagePoppedBefore: batch1.TotalL1MessagePoppedBefore,
-		ParentBatchHash:            common.HexToHash(dbBatch1.Hash),
-		Chunks:                     []*encoding.Chunk{chunk2},
-	}
-
-	dbBatch2, err := batchOrm.InsertBatch(context.Background(), batch2, encoding.CodecV0, rutils.BatchMetrics{})
-	assert.NoError(t, err)
-
-	// Create and set up the Layer2 Relayer.
-	l2Cfg := cfg.L2Config
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	l2Relayer, err := NewLayer2Relayer(ctx, l2Cli, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, false, ServiceTypeL2GasOracle, nil)
-	assert.NoError(t, err)
-	defer l2Relayer.StopSenders()
-
-	// Simulate message confirmations.
-	type BatchConfirmation struct {
-		batchHash    string
-		isSuccessful bool
-	}
-
-	confirmations := []BatchConfirmation{
-		{batchHash: dbBatch1.Hash, isSuccessful: true},
-		{batchHash: dbBatch2.Hash, isSuccessful: false},
-	}
-
-	for _, confirmation := range confirmations {
-		l2Relayer.gasOracleSender.SendConfirmation(&sender.Confirmation{
-			ContextID:    confirmation.batchHash,
-			IsSuccessful: confirmation.isSuccessful,
-			SenderType:   types.SenderTypeL2GasOracle,
-		})
-	}
-	// Check the database for the updated status using TryTimes.
-	ok := utils.TryTimes(5, func() bool {
-		expectedStatuses := []types.GasOracleStatus{types.GasOracleImported, types.GasOracleImportedFailed}
-		for i, confirmation := range confirmations {
-			gasOracle, err := batchOrm.GetBatches(context.Background(), map[string]interface{}{"hash": confirmation.batchHash}, nil, 0)
-			if err != nil || len(gasOracle) != 1 || types.GasOracleStatus(gasOracle[0].OracleStatus) != expectedStatuses[i] {
-				return false
-			}
-		}
-		return true
-	})
-	assert.True(t, ok)
-}
-
-func testLayer2RelayerProcessGasPriceOracle(t *testing.T) {
-	db := setupL2RelayerDB(t)
-	defer database.CloseDB(db)
-
-	relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, false, ServiceTypeL2GasOracle, nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, relayer)
-	defer relayer.StopSenders()
-
-	var batchOrm *orm.Batch
-	convey.Convey("Failed to GetLatestBatch", t, func() {
-		targetErr := errors.New("GetLatestBatch error")
-		patchGuard := gomonkey.ApplyMethodFunc(batchOrm, "GetLatestBatch", func(context.Context) (*orm.Batch, error) {
-			return nil, targetErr
-		})
-		defer patchGuard.Reset()
-		relayer.ProcessGasPriceOracle()
-	})
-
-	patchGuard := gomonkey.ApplyMethodFunc(batchOrm, "GetLatestBatch", func(context.Context) (*orm.Batch, error) {
-		batch := orm.Batch{
-			OracleStatus: int16(types.GasOraclePending),
-			Hash:         "0x0000000000000000000000000000000000000000",
-		}
-		return &batch, nil
-	})
-	defer patchGuard.Reset()
-
-	convey.Convey("Failed to fetch SuggestGasPrice from l2geth", t, func() {
-		targetErr := errors.New("SuggestGasPrice error")
-		patchGuard.ApplyMethodFunc(relayer.l2Client, "SuggestGasPrice", func(ctx context.Context) (*big.Int, error) {
-			return nil, targetErr
-		})
-		relayer.ProcessGasPriceOracle()
-	})
-
-	patchGuard.ApplyMethodFunc(relayer.l2Client, "SuggestGasPrice", func(ctx context.Context) (*big.Int, error) {
-		return big.NewInt(100), nil
-	})
-
-	convey.Convey("Failed to pack setL2BaseFee", t, func() {
-		targetErr := errors.New("setL2BaseFee error")
-		patchGuard.ApplyMethodFunc(relayer.l2GasOracleABI, "Pack", func(name string, args ...interface{}) ([]byte, error) {
-			return nil, targetErr
-		})
-		relayer.ProcessGasPriceOracle()
-	})
-
-	patchGuard.ApplyMethodFunc(relayer.l2GasOracleABI, "Pack", func(name string, args ...interface{}) ([]byte, error) {
-		return nil, nil
-	})
-
-	convey.Convey("Failed to send setL2BaseFee tx to layer2", t, func() {
-		targetErr := errors.New("failed to send setL2BaseFee tx to layer2 error")
-		patchGuard.ApplyMethodFunc(relayer.gasOracleSender, "SendTransaction", func(ContextID string, target *common.Address, data []byte, blob *kzg4844.Blob, fallbackGasLimit uint64) (hash common.Hash, err error) {
-			return common.Hash{}, targetErr
-		})
-		relayer.ProcessGasPriceOracle()
-	})
-
-	patchGuard.ApplyMethodFunc(relayer.gasOracleSender, "SendTransaction", func(ContextID string, target *common.Address, data []byte, blob *kzg4844.Blob, fallbackGasLimit uint64) (hash common.Hash, err error) {
-		return common.HexToHash("0x56789abcdef1234"), nil
-	})
-
-	convey.Convey("UpdateGasOracleStatusAndOracleTxHash failed", t, func() {
-		targetErr := errors.New("UpdateL2GasOracleStatusAndOracleTxHash error")
-		patchGuard.ApplyMethodFunc(batchOrm, "UpdateL2GasOracleStatusAndOracleTxHash", func(ctx context.Context, hash string, status types.GasOracleStatus, txHash string) error {
-			return targetErr
-		})
-		relayer.ProcessGasPriceOracle()
-	})
-
-	patchGuard.ApplyMethodFunc(batchOrm, "UpdateL2GasOracleStatusAndOracleTxHash", func(ctx context.Context, hash string, status types.GasOracleStatus, txHash string) error {
-		return nil
-	})
-	relayer.ProcessGasPriceOracle()
 }
 
 func mockChainMonitorServer(baseURL string) (*http.Server, error) {

--- a/rollup/internal/controller/relayer/l2_relayer_test.go
+++ b/rollup/internal/controller/relayer/l2_relayer_test.go
@@ -41,7 +41,7 @@ func setupL2RelayerDB(t *testing.T) *gorm.DB {
 func testCreateNewRelayer(t *testing.T) {
 	db := setupL2RelayerDB(t)
 	defer database.CloseDB(db)
-	relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, true, ServiceTypeL2RollupRelayer, nil)
+	relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, ServiceTypeL2RollupRelayer, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, relayer)
 	defer relayer.StopSenders()
@@ -61,7 +61,7 @@ func testL2RelayerProcessPendingBatches(t *testing.T) {
 			assert.Fail(t, "unsupported codec version, expected CodecV4")
 		}
 
-		relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, l2Cfg.RelayerConfig, chainConfig, true, ServiceTypeL2RollupRelayer, nil)
+		relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, l2Cfg.RelayerConfig, chainConfig, ServiceTypeL2RollupRelayer, nil)
 		assert.NoError(t, err)
 
 		patchGuard := gomonkey.ApplyMethodFunc(l2Cli, "SendTransaction", func(_ context.Context, _ *gethTypes.Transaction) error {
@@ -110,7 +110,7 @@ func testL2RelayerProcessPendingBundles(t *testing.T) {
 		if codecVersion == encoding.CodecV4 {
 			chainConfig = &params.ChainConfig{LondonBlock: big.NewInt(0), BernoulliBlock: big.NewInt(0), CurieBlock: big.NewInt(0), DarwinTime: new(uint64), DarwinV2Time: new(uint64)}
 		}
-		relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, l2Cfg.RelayerConfig, chainConfig, true, ServiceTypeL2RollupRelayer, nil)
+		relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, l2Cfg.RelayerConfig, chainConfig, ServiceTypeL2RollupRelayer, nil)
 		assert.NoError(t, err)
 
 		batch := &encoding.Batch{
@@ -178,7 +178,7 @@ func testL2RelayerFinalizeTimeoutBundles(t *testing.T) {
 		if codecVersion == encoding.CodecV4 {
 			chainConfig = &params.ChainConfig{LondonBlock: big.NewInt(0), BernoulliBlock: big.NewInt(0), CurieBlock: big.NewInt(0), DarwinTime: new(uint64), DarwinV2Time: new(uint64)}
 		}
-		relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, l2Cfg.RelayerConfig, chainConfig, true, ServiceTypeL2RollupRelayer, nil)
+		relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, l2Cfg.RelayerConfig, chainConfig, ServiceTypeL2RollupRelayer, nil)
 		assert.NoError(t, err)
 
 		l2BlockOrm := orm.NewL2Block(db)
@@ -254,7 +254,7 @@ func testL2RelayerCommitConfirm(t *testing.T) {
 	l2Cfg := cfg.L2Config
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	l2Relayer, err := NewLayer2Relayer(ctx, l2Cli, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, true, ServiceTypeL2RollupRelayer, nil)
+	l2Relayer, err := NewLayer2Relayer(ctx, l2Cli, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, ServiceTypeL2RollupRelayer, nil)
 	assert.NoError(t, err)
 	defer l2Relayer.StopSenders()
 
@@ -310,7 +310,7 @@ func testL2RelayerFinalizeBundleConfirm(t *testing.T) {
 	l2Cfg := cfg.L2Config
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	l2Relayer, err := NewLayer2Relayer(ctx, l2Cli, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, true, ServiceTypeL2RollupRelayer, nil)
+	l2Relayer, err := NewLayer2Relayer(ctx, l2Cli, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, ServiceTypeL2RollupRelayer, nil)
 	assert.NoError(t, err)
 	defer l2Relayer.StopSenders()
 
@@ -393,7 +393,7 @@ func testGetBatchStatusByIndex(t *testing.T) {
 	defer database.CloseDB(db)
 
 	cfg.L2Config.RelayerConfig.ChainMonitor.Enabled = true
-	relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, true, ServiceTypeL2RollupRelayer, nil)
+	relayer, err := NewLayer2Relayer(context.Background(), l2Cli, db, cfg.L2Config.RelayerConfig, &params.ChainConfig{}, ServiceTypeL2RollupRelayer, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, relayer)
 	defer relayer.StopSenders()

--- a/rollup/internal/controller/relayer/relayer_test.go
+++ b/rollup/internal/controller/relayer/relayer_test.go
@@ -128,8 +128,6 @@ func TestFunctions(t *testing.T) {
 	t.Run("TestL2RelayerFinalizeTimeoutBundles", testL2RelayerFinalizeTimeoutBundles)
 	t.Run("TestL2RelayerCommitConfirm", testL2RelayerCommitConfirm)
 	t.Run("TestL2RelayerFinalizeBundleConfirm", testL2RelayerFinalizeBundleConfirm)
-	t.Run("TestL2RelayerGasOracleConfirm", testL2RelayerGasOracleConfirm)
-	t.Run("TestLayer2RelayerProcessGasPriceOracle", testLayer2RelayerProcessGasPriceOracle)
 
 	// test getBatchStatusByIndex
 	t.Run("TestGetBatchStatusByIndex", testGetBatchStatusByIndex)

--- a/rollup/tests/bridge_test.go
+++ b/rollup/tests/bridge_test.go
@@ -211,8 +211,7 @@ func TestFunction(t *testing.T) {
 	t.Run("testCommitBatchAndFinalizeBundleCodecV4V5V6", testCommitBatchAndFinalizeBundleCodecV4V5V6)
 	t.Run("TestCommitBatchAndFinalizeBundleCodecV7", testCommitBatchAndFinalizeBundleCodecV7)
 
-	// l1/l2 gas oracle
+	// l1 gas oracle
 	t.Run("TestImportL1GasPrice", testImportL1GasPrice)
 	t.Run("TestImportDefaultL1GasPriceDueToL1GasPriceSpike", testImportDefaultL1GasPriceDueToL1GasPriceSpike)
-	t.Run("TestImportL2GasPrice", testImportL2GasPrice)
 }

--- a/rollup/tests/gas_oracle_test.go
+++ b/rollup/tests/gas_oracle_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/common"
 	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
-	"github.com/scroll-tech/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 
 	"scroll-tech/common/database"
@@ -200,57 +199,4 @@ func testImportDefaultL1GasPriceDueToL1GasPriceSpike(t *testing.T) {
 	assert.Equal(t, len(blocks), 1)
 	assert.Empty(t, blocks[0].OracleTxHash)
 	assert.Equal(t, types.GasOracleStatus(blocks[0].GasOracleStatus), types.GasOraclePending)
-}
-
-func testImportL2GasPrice(t *testing.T) {
-	db := setupDB(t)
-	defer database.CloseDB(db)
-	prepareContracts(t)
-
-	l2Cfg := rollupApp.Config.L2Config
-	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, false, relayer.ServiceTypeL2GasOracle, nil)
-	assert.NoError(t, err)
-	defer l2Relayer.StopSenders()
-
-	// add fake chunk
-	chunk := &encoding.Chunk{
-		Blocks: []*encoding.Block{
-			{
-				Header: &gethTypes.Header{
-					Number:     big.NewInt(1),
-					ParentHash: common.Hash{},
-					Difficulty: big.NewInt(0),
-					BaseFee:    big.NewInt(0),
-				},
-				Transactions:   nil,
-				WithdrawRoot:   common.Hash{},
-				RowConsumption: &gethTypes.RowConsumption{},
-			},
-		},
-	}
-	batch := &encoding.Batch{
-		Index:                      0,
-		TotalL1MessagePoppedBefore: 0,
-		ParentBatchHash:            common.Hash{},
-		Chunks:                     []*encoding.Chunk{chunk},
-	}
-
-	batchOrm := orm.NewBatch(db)
-	_, err = batchOrm.InsertBatch(context.Background(), batch, encoding.CodecV0, utils.BatchMetrics{})
-	assert.NoError(t, err)
-
-	// check db status
-	dbBatch, err := batchOrm.GetLatestBatch(context.Background())
-	assert.NoError(t, err)
-	assert.NotNil(t, batch)
-	assert.Empty(t, dbBatch.OracleTxHash)
-	assert.Equal(t, types.GasOracleStatus(dbBatch.OracleStatus), types.GasOraclePending)
-
-	// relay gas price
-	l2Relayer.ProcessGasPriceOracle()
-	dbBatch, err = batchOrm.GetLatestBatch(context.Background())
-	assert.NoError(t, err)
-	assert.NotNil(t, batch)
-	assert.NotEmpty(t, dbBatch.OracleTxHash)
-	assert.Equal(t, types.GasOracleStatus(dbBatch.OracleStatus), types.GasOracleImporting)
 }

--- a/rollup/tests/rollup_test.go
+++ b/rollup/tests/rollup_test.go
@@ -33,7 +33,7 @@ func testCommitAndFinalizeGenesisBatch(t *testing.T) {
 	prepareContracts(t)
 
 	l2Cfg := rollupApp.Config.L2Config
-	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, true, relayer.ServiceTypeL2RollupRelayer, nil)
+	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, &params.ChainConfig{}, relayer.ServiceTypeL2RollupRelayer, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, l2Relayer)
 	defer l2Relayer.StopSenders()
@@ -65,7 +65,7 @@ func testCommitBatchAndFinalizeBundleCodecV4V5V6(t *testing.T) {
 
 	// Create L2Relayer
 	l2Cfg := rollupApp.Config.L2Config
-	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, chainConfig, true, relayer.ServiceTypeL2RollupRelayer, nil)
+	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, chainConfig, relayer.ServiceTypeL2RollupRelayer, nil)
 	assert.NoError(t, err)
 
 	// add some blocks to db
@@ -236,7 +236,7 @@ func testCommitBatchAndFinalizeBundleCodecV7(t *testing.T) {
 
 	// Create L2Relayer
 	l2Cfg := rollupApp.Config.L2Config
-	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, chainConfig, true, relayer.ServiceTypeL2RollupRelayer, nil)
+	l2Relayer, err := relayer.NewLayer2Relayer(context.Background(), l2Client, db, l2Cfg.RelayerConfig, chainConfig, relayer.ServiceTypeL2RollupRelayer, nil)
 	require.NoError(t, err)
 
 	defer l2Relayer.StopSenders()


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR decommissions L2 gas price oracle, since in the message queue v2, the gas price ground-truth is fetched from `block.basefee` directly.

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated application version to v4.5.3.
- **Refactor**
	- Streamlined relayer operations by removing legacy support for startup genesis batch import.
	- Eliminated deprecated Layer 2 gas pricing functionality for a simpler, more focused configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->