### PR TITLE
chore(gas-oracle): remove unused code

### DIFF
--- a/common/types/db.go
+++ b/common/types/db.go
@@ -276,8 +276,8 @@ const (
 	SenderTypeFinalizeBatch
 	// SenderTypeL1GasOracle indicates a sender from L2 responsible for updating L1 gas prices.
 	SenderTypeL1GasOracle
-	// SenderTypeL2GasOracle indicates a sender from L1 responsible for updating L2 gas prices.
-	SenderTypeL2GasOracle
+	// SenderTypeL2GasOracleDeprecated indicates a sender from L1 responsible for updating L2 gas prices.
+	SenderTypeL2GasOracleDeprecated
 )
 
 // String returns a string representation of the SenderType.
@@ -289,8 +289,8 @@ func (t SenderType) String() string {
 		return "SenderTypeFinalizeBatch"
 	case SenderTypeL1GasOracle:
 		return "SenderTypeL1GasOracle"
-	case SenderTypeL2GasOracle:
-		return "SenderTypeL2GasOracle"
+	case SenderTypeL2GasOracleDeprecated:
+		return "SenderTypeL2GasOracleDeprecated"
 	default:
 		return fmt.Sprintf("Unknown SenderType (%d)", int32(t))
 	}

--- a/common/types/db.go
+++ b/common/types/db.go
@@ -276,7 +276,7 @@ const (
 	SenderTypeFinalizeBatch
 	// SenderTypeL1GasOracle indicates a sender from L2 responsible for updating L1 gas prices.
 	SenderTypeL1GasOracle
-	// SenderTypeL2GasOracleDeprecated indicates a sender from L1 responsible for updating L2 gas prices.
+	// SenderTypeL2GasOracleDeprecated indicates a sender from L1 responsible for updating L2 gas prices, which is deprecated.
 	SenderTypeL2GasOracleDeprecated
 )
 

--- a/common/types/db_test.go
+++ b/common/types/db_test.go
@@ -173,9 +173,9 @@ func TestSenderType(t *testing.T) {
 			"SenderTypeL1GasOracle",
 		},
 		{
-			"SenderTypeL2GasOracle",
-			SenderTypeL2GasOracle,
-			"SenderTypeL2GasOracle",
+			"SenderTypeL2GasOracleDeprecated",
+			SenderTypeL2GasOracleDeprecated,
+			"SenderTypeL2GasOracleDeprecated",
 		},
 		{
 			"Invalid Value",

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.3"
+var tag = "v4.5.4"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -930,22 +930,6 @@ func (r *Layer2Relayer) handleConfirmation(cfm *sender.Confirmation) {
 		if err != nil {
 			log.Warn("UpdateFinalizeTxHashAndRollupStatus failed", "confirmation", cfm, "err", err)
 		}
-	case types.SenderTypeL2GasOracle:
-		batchHash := cfm.ContextID
-		var status types.GasOracleStatus
-		if cfm.IsSuccessful {
-			status = types.GasOracleImported
-			r.metrics.rollupL2UpdateGasOracleConfirmedTotal.Inc()
-		} else {
-			status = types.GasOracleImportedFailed
-			r.metrics.rollupL2UpdateGasOracleConfirmedFailedTotal.Inc()
-			log.Warn("UpdateGasOracleTxType transaction confirmed but failed in layer1", "confirmation", cfm)
-		}
-
-		err := r.batchOrm.UpdateL2GasOracleStatusAndOracleTxHash(r.ctx, batchHash, status, cfm.TxHash.String())
-		if err != nil {
-			log.Warn("UpdateL2GasOracleStatusAndOracleTxHash failed", "confirmation", cfm, "err", err)
-		}
 	default:
 		log.Warn("Unknown transaction type", "confirmation", cfm)
 	}

--- a/rollup/internal/controller/relayer/l2_relayer_metrics.go
+++ b/rollup/internal/controller/relayer/l2_relayer_metrics.go
@@ -12,14 +12,10 @@ type l2RelayerMetrics struct {
 	rollupL2RelayerProcessPendingBatchTotal                         prometheus.Counter
 	rollupL2RelayerProcessPendingBatchSuccessTotal                  prometheus.Counter
 	rollupL2RelayerProcessPendingBatchErrTooManyPendingBlobTxsTotal prometheus.Counter
-	rollupL2RelayerGasPriceOraclerRunTotal                          prometheus.Counter
-	rollupL2RelayerLastGasPrice                                     prometheus.Gauge
 	rollupL2BatchesCommittedConfirmedTotal                          prometheus.Counter
 	rollupL2BatchesCommittedConfirmedFailedTotal                    prometheus.Counter
 	rollupL2BatchesFinalizedConfirmedTotal                          prometheus.Counter
 	rollupL2BatchesFinalizedConfirmedFailedTotal                    prometheus.Counter
-	rollupL2UpdateGasOracleConfirmedTotal                           prometheus.Counter
-	rollupL2UpdateGasOracleConfirmedFailedTotal                     prometheus.Counter
 	rollupL2ChainMonitorLatestFailedCall                            prometheus.Counter
 	rollupL2ChainMonitorLatestFailedBatchStatus                     prometheus.Counter
 	rollupL2RelayerProcessPendingBundlesTotal                       prometheus.Counter
@@ -56,14 +52,6 @@ func initL2RelayerMetrics(reg prometheus.Registerer) *l2RelayerMetrics {
 				Name: "rollup_layer2_process_pending_batch_err_too_many_pending_blob_txs_total",
 				Help: "The total number of layer2 process pending batch failed on too many pending blob txs",
 			}),
-			rollupL2RelayerGasPriceOraclerRunTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "rollup_layer2_gas_price_oracler_total",
-				Help: "The total number of layer2 gas price oracler run total",
-			}),
-			rollupL2RelayerLastGasPrice: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-				Name: "rollup_layer2_gas_price_latest_gas_price",
-				Help: "The latest gas price of rollup relayer l2",
-			}),
 			rollupL2BatchesCommittedConfirmedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 				Name: "rollup_layer2_process_committed_batches_confirmed_total",
 				Help: "The total number of layer2 process committed batches confirmed total",
@@ -79,14 +67,6 @@ func initL2RelayerMetrics(reg prometheus.Registerer) *l2RelayerMetrics {
 			rollupL2BatchesFinalizedConfirmedFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 				Name: "rollup_layer2_process_finalized_batches_confirmed_failed_total",
 				Help: "The total number of layer2 process finalized batches confirmed failed total",
-			}),
-			rollupL2UpdateGasOracleConfirmedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "rollup_layer2_update_layer1_gas_oracle_confirmed_total",
-				Help: "The total number of updating layer2 gas oracle confirmed",
-			}),
-			rollupL2UpdateGasOracleConfirmedFailedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "rollup_layer2_update_layer1_gas_oracle_confirmed_failed_total",
-				Help: "The total number of updating layer2 gas oracle confirmed failed",
 			}),
 			rollupL2ChainMonitorLatestFailedCall: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 				Name: "rollup_layer2_chain_monitor_latest_failed_batch_call",

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -56,10 +56,6 @@ type Batch struct {
 	FinalizeTxHash string     `json:"finalize_tx_hash" gorm:"column:finalize_tx_hash;default:NULL"`
 	FinalizedAt    *time.Time `json:"finalized_at" gorm:"column:finalized_at;default:NULL"`
 
-	// gas oracle
-	OracleStatus int16  `json:"oracle_status" gorm:"column:oracle_status;default:1"`
-	OracleTxHash string `json:"oracle_tx_hash" gorm:"column:oracle_tx_hash;default:NULL"`
-
 	// blob
 	BlobDataProof []byte `json:"blob_data_proof" gorm:"column:blob_data_proof"`
 	BlobSize      uint64 `json:"blob_size" gorm:"column:blob_size"`
@@ -310,7 +306,6 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVer
 		ChunkProofsStatus:         int16(types.ChunkProofsStatusPending),
 		ProvingStatus:             int16(types.ProvingTaskUnassigned),
 		RollupStatus:              int16(types.RollupPending),
-		OracleStatus:              int16(types.GasOraclePending),
 		TotalL1CommitGas:          metrics.L1CommitGas,
 		TotalL1CommitCalldataSize: metrics.L1CommitCalldataSize,
 		BlobDataProof:             batchMeta.BatchBlobDataProof,
@@ -329,22 +324,6 @@ func (o *Batch) InsertBatch(ctx context.Context, batch *encoding.Batch, codecVer
 		return nil, fmt.Errorf("Batch.InsertBatch error: %w", err)
 	}
 	return &newBatch, nil
-}
-
-// UpdateL2GasOracleStatusAndOracleTxHash updates the L2 gas oracle status and transaction hash for a batch.
-func (o *Batch) UpdateL2GasOracleStatusAndOracleTxHash(ctx context.Context, hash string, status types.GasOracleStatus, txHash string) error {
-	updateFields := make(map[string]interface{})
-	updateFields["oracle_status"] = int(status)
-	updateFields["oracle_tx_hash"] = txHash
-
-	db := o.db.WithContext(ctx)
-	db = db.Model(&Batch{})
-	db = db.Where("hash", hash)
-
-	if err := db.Updates(updateFields).Error; err != nil {
-		return fmt.Errorf("Batch.UpdateL2GasOracleStatusAndOracleTxHash error: %w, batch hash: %v, status: %v, txHash: %v", err, hash, status.String(), txHash)
-	}
-	return nil
 }
 
 // UpdateProvingStatus updates the proving status of a batch.

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -300,16 +300,12 @@ func TestBatchOrm(t *testing.T) {
 		assert.NoError(t, err)
 		err = batchOrm.UpdateRollupStatus(context.Background(), batchHash2, types.RollupFinalized)
 		assert.NoError(t, err)
-		err = batchOrm.UpdateL2GasOracleStatusAndOracleTxHash(context.Background(), batchHash2, types.GasOracleImported, "oracleTxHash")
-		assert.NoError(t, err)
 
 		updatedBatch, err := batchOrm.GetLatestBatch(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedBatch)
 		assert.Equal(t, types.ProvingTaskVerified, types.ProvingStatus(updatedBatch.ProvingStatus))
 		assert.Equal(t, types.RollupFinalized, types.RollupStatus(updatedBatch.RollupStatus))
-		assert.Equal(t, types.GasOracleImported, types.GasOracleStatus(updatedBatch.OracleStatus))
-		assert.Equal(t, "oracleTxHash", updatedBatch.OracleTxHash)
 
 		err = batchOrm.UpdateCommitTxHashAndRollupStatus(context.Background(), batchHash1, "commitTxHash", types.RollupCommitted)
 		assert.NoError(t, err)


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR removes unused code related to gas-oracle.

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Deprecated legacy gas tracking functionality by renaming outdated identifiers and removing related transaction processing and internal metrics.
  
- **Chores**
  - Upgraded the software version from v4.5.3 to v4.5.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->