### PR TITLE
Fix typos in error messages

### DIFF
--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -11,7 +11,7 @@ impl AssetsDirEnvConfig {
         let value = std::env::var(SCROLL_PROVER_ASSETS_DIR_ENV_NAME)?;
         let dirs: Vec<&str> = value.split(',').collect();
         if dirs.len() != 2 {
-            bail!("env variable SCROLL_PROVER_ASSETS_DIR value must be 2 parts seperated by comma.")
+            bail!("env variable SCROLL_PROVER_ASSETS_DIR value must be 2 parts separated by comma.")
         }
         unsafe {
             SCROLL_PROVER_ASSETS_DIRS = dirs.into_iter().map(|s| s.to_string()).collect();

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -613,7 +613,7 @@ func (r *Layer2Relayer) ProcessPendingBundles() {
 
 			firstUnfinalizedChunk, err := r.chunkOrm.GetChunkByIndex(r.ctx, firstUnfinalizedBatch.StartChunkIndex)
 			if err != nil {
-				log.Error("failed to get firsr unfinalized chunk", "chunk index", firstUnfinalizedBatch.StartChunkIndex)
+				log.Error("failed to get first unfinalized chunk", "chunk index", firstUnfinalizedBatch.StartChunkIndex)
 				return
 			}
 


### PR DESCRIPTION


**Description:** 
This PR fixes typos in error messages:
1. Corrected "seperated" to "separated" in the SCROLL_PROVER_ASSETS_DIR validation error message
2. Fixed formatting in the "failed to get first unfinalized chunk" error message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typos in error and log messages for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->