### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/docker-coordinator-api-arm64.yml
+++ b/.github/workflows/docker-coordinator-api-arm64.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up QEMU
         run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to use a newer version of the checkout action when building and pushing the ARM64 Docker image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->