### PR TITLE
fix(rollup-relayer): update commit status logic

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.7"
+var tag = "v4.5.8"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/orm/batch.go
+++ b/rollup/internal/orm/batch.go
@@ -386,7 +386,12 @@ func (o *Batch) UpdateRollupStatus(ctx context.Context, hash string, status type
 func (o *Batch) UpdateCommitTxHashAndRollupStatus(ctx context.Context, hash string, commitTxHash string, status types.RollupStatus, dbTX ...*gorm.DB) error {
 	updateFields := make(map[string]interface{})
 	updateFields["commit_tx_hash"] = commitTxHash
-	updateFields["rollup_status"] = int(status)
+	updateFields["rollup_status"] = gorm.Expr(
+		`CASE
+			WHEN rollup_status NOT IN (?, ?) THEN ?
+			ELSE rollup_status
+		END`,
+		types.RollupFinalizing, types.RollupFinalized, int(status))
 	if status == types.RollupCommitted {
 		updateFields["committed_at"] = utils.NowUTC()
 	}
@@ -396,15 +401,6 @@ func (o *Batch) UpdateCommitTxHashAndRollupStatus(ctx context.Context, hash stri
 		db = dbTX[0]
 	}
 	db = db.WithContext(ctx)
-
-	var currentBatch Batch
-	if err := db.Where("hash", hash).First(&currentBatch).Error; err != nil {
-		return fmt.Errorf("Batch.UpdateCommitTxHashAndRollupStatus error when querying current status: %w, batch hash: %v", err, hash)
-	}
-
-	if types.RollupStatus(currentBatch.RollupStatus) == types.RollupFinalizing || types.RollupStatus(currentBatch.RollupStatus) == types.RollupFinalized {
-		return nil
-	}
 
 	db = db.Model(&Batch{})
 	db = db.Where("hash", hash)

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -314,7 +314,7 @@ func TestBatchOrm(t *testing.T) {
 		updatedBatch, err = batchOrm.GetLatestBatch(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, updatedBatch)
-		assert.Equal(t, "", updatedBatch.CommitTxHash)
+		assert.Equal(t, "commitTxHash", updatedBatch.CommitTxHash)
 		assert.Equal(t, types.RollupFinalized, types.RollupStatus(updatedBatch.RollupStatus))
 
 		err = batchOrm.UpdateFinalizeTxHashAndRollupStatus(context.Background(), batchHash2, "finalizeTxHash", types.RollupFinalizeFailed)


### PR DESCRIPTION
### Purpose or design rationale of this PR

When the status is "finalizing" or "finalized", other info fields of the commit status should still be updated.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated version number to v4.5.8.

- **Bug Fixes**
	- Improved the handling of rollup status updates to prevent overwriting finalizing or finalized states.
	- Adjusted commit transaction hash handling to reflect updated batch state expectations in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->