### PR TITLE
fix(gas-oracle): nil pointer error and allow update gas price when no diff

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.8"
+var tag = "v4.5.9"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -283,7 +283,7 @@ func (r *Layer1Relayer) commitBatchReachTimeout() (bool, error) {
 	}
 	// len(batches) == 0 probably shouldn't ever happen, but need to check this
 	// Also, we should check if it's a genesis batch. If so, skip the timeout check.
-	// If finalized/finalizing status is updated before committed status, skip the timeout check of this round.
+	// If finalizing/finalized status is updated before committed status, skip the timeout check of this round.
 	// Because batches[0].CommittedAt is nil in this case, this will only continue for a short time window.
 	return len(batches) == 0 || (batches[0].Index != 0 && batches[0].CommittedAt != nil && utils.NowUTC().Sub(*batches[0].CommittedAt) > time.Duration(r.cfg.GasOracleConfig.CheckCommittedBatchesWindowMinutes)*time.Minute), nil
 }

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -251,7 +251,11 @@ func (r *Layer1Relayer) shouldUpdateGasOracle(baseFee uint64, blobBaseFee uint64
 		return true
 	}
 
-	expectedBaseFeeDelta := r.lastBaseFee*r.gasPriceDiff/gasPriceDiffPrecision + 1
+	expectedBaseFeeDelta := r.lastBaseFee * r.gasPriceDiff / gasPriceDiffPrecision
+	// Allowing a minimum of 0 wei if the gas price diff config is 0, this will be used to let the gas oracle send transactions continuously.
+	if r.gasPriceDiff > 0 {
+		expectedBaseFeeDelta += 1
+	}
 	if baseFee >= r.minGasPrice && math.Abs(float64(baseFee)-float64(r.lastBaseFee)) >= float64(expectedBaseFeeDelta) {
 		return true
 	}
@@ -279,5 +283,7 @@ func (r *Layer1Relayer) commitBatchReachTimeout() (bool, error) {
 	}
 	// len(batches) == 0 probably shouldn't ever happen, but need to check this
 	// Also, we should check if it's a genesis batch. If so, skip the timeout check.
-	return len(batches) == 0 || (batches[0].Index != 0 && utils.NowUTC().Sub(*batches[0].CommittedAt) > time.Duration(r.cfg.GasOracleConfig.CheckCommittedBatchesWindowMinutes)*time.Minute), nil
+	// If finalized/finalizing status is updated before committed status, skip the timeout check of this round.
+	// Because batches[0].CommittedAt is nil in this case, this will only continue for a short time window.
+	return len(batches) == 0 || (batches[0].Index != 0 && batches[0].CommittedAt != nil && utils.NowUTC().Sub(*batches[0].CommittedAt) > time.Duration(r.cfg.GasOracleConfig.CheckCommittedBatchesWindowMinutes)*time.Minute), nil
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

* If `finalizing`/`finalized` status is updated before `committed` status, skip the timeout check of this round. Because `batches[0].CommittedAt` is `nil` in this case, this will only continue for a short time window.
* Allowing a minimum of `0` wei if the gas price diff config is `0`, this will be used to let the gas oracle send transactions continuously.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gas oracle update logic to allow continuous updates when gas price difference is zero.
  - Added safeguards to prevent errors when batch commit timestamps are missing.

- **Chores**
  - Updated version number to v4.5.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->