### PR TITLE
refactor(sender): remove fallback gas limit

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.13"
+var tag = "v4.5.14"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -88,8 +88,7 @@
         "private_key_signer_config": {
           "private_key": "1515151515151515151515151515151515151515151515151515151515151515"
         }
-      },
-      "l1_commit_gas_limit_multiplier": 1.2
+      }
     },
     "chunk_proposer_config": {
       "propose_interval_milliseconds": 100,

--- a/rollup/internal/config/relayer.go
+++ b/rollup/internal/config/relayer.go
@@ -65,8 +65,6 @@ type RelayerConfig struct {
 	GasOracleConfig *GasOracleConfig `json:"gas_oracle_config"`
 	// ChainMonitor config of monitoring service
 	ChainMonitor *ChainMonitor `json:"chain_monitor"`
-	// L1CommitGasLimitMultiplier multiplier for fallback gas limit in commitBatch txs
-	L1CommitGasLimitMultiplier float64 `json:"l1_commit_gas_limit_multiplier,omitempty"`
 
 	// Configs of transaction signers (GasOracle, Commit, Finalize)
 	GasOracleSenderSignerConfig *SignerConfig `json:"gas_oracle_sender_signer_config"`

--- a/rollup/internal/controller/relayer/l1_relayer.go
+++ b/rollup/internal/controller/relayer/l1_relayer.go
@@ -179,7 +179,7 @@ func (r *Layer1Relayer) ProcessGasPriceOracle() {
 				return
 			}
 
-			hash, err := r.gasOracleSender.SendTransaction(block.Hash, &r.cfg.GasPriceOracleContractAddress, data, nil, 0)
+			hash, err := r.gasOracleSender.SendTransaction(block.Hash, &r.cfg.GasPriceOracleContractAddress, data, nil)
 			if err != nil {
 				log.Error("Failed to send gas oracle update tx to layer2", "block.Hash", block.Hash, "block.Height", block.Number, "block.BaseFee", baseFee, "block.BlobBaseFee", blobBaseFee, "err", err)
 				return

--- a/rollup/internal/controller/relayer/l1_relayer_test.go
+++ b/rollup/internal/controller/relayer/l1_relayer_test.go
@@ -146,13 +146,13 @@ func testL1RelayerProcessGasPriceOracle(t *testing.T) {
 
 	convey.Convey("send transaction failure", t, func() {
 		targetErr := errors.New("send transaction failure")
-		patchGuard.ApplyMethodFunc(l1Relayer.gasOracleSender, "SendTransaction", func(string, *common.Address, []byte, *kzg4844.Blob, uint64) (hash common.Hash, err error) {
+		patchGuard.ApplyMethodFunc(l1Relayer.gasOracleSender, "SendTransaction", func(string, *common.Address, []byte, *kzg4844.Blob) (hash common.Hash, err error) {
 			return common.Hash{}, targetErr
 		})
 		l1Relayer.ProcessGasPriceOracle()
 	})
 
-	patchGuard.ApplyMethodFunc(l1Relayer.gasOracleSender, "SendTransaction", func(string, *common.Address, []byte, *kzg4844.Blob, uint64) (hash common.Hash, err error) {
+	patchGuard.ApplyMethodFunc(l1Relayer.gasOracleSender, "SendTransaction", func(string, *common.Address, []byte, *kzg4844.Blob) (hash common.Hash, err error) {
 		return common.Hash{}, nil
 	})
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -271,7 +271,7 @@ func (r *Layer2Relayer) commitGenesisBatch(batchHash string, batchHeader []byte,
 	}
 
 	// submit genesis batch to L1 rollup contract
-	txHash, err := r.commitSender.SendTransaction(batchHash, &r.cfg.RollupContractAddress, calldata, nil, 0)
+	txHash, err := r.commitSender.SendTransaction(batchHash, &r.cfg.RollupContractAddress, calldata, nil)
 	if err != nil {
 		return fmt.Errorf("failed to send import genesis batch tx to L1, error: %v", err)
 	}
@@ -452,7 +452,7 @@ func (r *Layer2Relayer) ProcessPendingBatches() {
 		return
 	}
 
-	txHash, err := r.commitSender.SendTransaction(r.contextIDFromBatches(batchesToSubmit), &r.cfg.RollupContractAddress, calldata, blobs, 0)
+	txHash, err := r.commitSender.SendTransaction(r.contextIDFromBatches(batchesToSubmit), &r.cfg.RollupContractAddress, calldata, blobs)
 	if err != nil {
 		if errors.Is(err, sender.ErrTooManyPendingBlobTxs) {
 			r.metrics.rollupL2RelayerProcessPendingBatchErrTooManyPendingBlobTxsTotal.Inc()
@@ -675,7 +675,7 @@ func (r *Layer2Relayer) finalizeBundle(bundle *orm.Bundle, withProof bool) error
 		return fmt.Errorf("unsupported codec version in finalizeBundle, bundle index: %v, version: %d", bundle.Index, bundle.CodecVersion)
 	}
 
-	txHash, err := r.finalizeSender.SendTransaction("finalizeBundle-"+bundle.Hash, &r.cfg.RollupContractAddress, calldata, nil, 0)
+	txHash, err := r.finalizeSender.SendTransaction("finalizeBundle-"+bundle.Hash, &r.cfg.RollupContractAddress, calldata, nil)
 	if err != nil {
 		log.Error("finalizeBundle in layer1 failed", "with proof", withProof, "index", bundle.Index,
 			"start batch index", bundle.StartBatchIndex, "end batch index", bundle.EndBatchIndex,

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -7,11 +7,10 @@ import (
 	"github.com/scroll-tech/go-ethereum"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
-	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/log"
 )
 
-func (s *Sender) estimateLegacyGas(to *common.Address, data []byte, fallbackGasLimit uint64) (*FeeData, error) {
+func (s *Sender) estimateLegacyGas(to *common.Address, data []byte) (*FeeData, error) {
 	gasPrice, err := s.client.SuggestGasPrice(s.ctx)
 	if err != nil {
 		log.Error("estimateLegacyGas SuggestGasPrice failure", "error", err)
@@ -26,21 +25,17 @@ func (s *Sender) estimateLegacyGas(to *common.Address, data []byte, fallbackGasL
 	gasLimit, _, err := s.estimateGasLimit(to, data, nil, gasPrice, nil, nil, nil)
 	if err != nil {
 		log.Error("estimateLegacyGas estimateGasLimit failure", "gas price", gasPrice, "from", s.transactionSigner.GetAddr().String(),
-			"nonce", s.transactionSigner.GetNonce(), "to address", to.String(), "fallback gas limit", fallbackGasLimit, "error", err)
-		if fallbackGasLimit == 0 {
-			return nil, err
-		}
-		gasLimit = fallbackGasLimit
-	} else {
-		gasLimit = gasLimit * 12 / 10 // 20% extra gas to avoid out of gas error
+			"nonce", s.transactionSigner.GetNonce(), "to address", to.String(), "error", err)
+		return nil, err
 	}
+
 	return &FeeData{
 		gasPrice: gasPrice,
-		gasLimit: gasLimit,
+		gasLimit: gasLimit * 12 / 10, // 20% extra gas to avoid out of gas error
 	}, nil
 }
 
-func (s *Sender) estimateDynamicGas(to *common.Address, data []byte, baseFee uint64, fallbackGasLimit uint64) (*FeeData, error) {
+func (s *Sender) estimateDynamicGas(to *common.Address, data []byte, baseFee uint64) (*FeeData, error) {
 	gasTipCap, err := s.client.SuggestGasTipCap(s.ctx)
 	if err != nil {
 		log.Error("estimateDynamicGas SuggestGasTipCap failure", "error", err)
@@ -57,16 +52,12 @@ func (s *Sender) estimateDynamicGas(to *common.Address, data []byte, baseFee uin
 	if err != nil {
 		log.Error("estimateDynamicGas estimateGasLimit failure",
 			"from", s.transactionSigner.GetAddr().String(), "nonce", s.transactionSigner.GetNonce(), "to address", to.String(),
-			"fallback gas limit", fallbackGasLimit, "error", err)
-		if fallbackGasLimit == 0 {
-			return nil, err
-		}
-		gasLimit = fallbackGasLimit
-	} else {
-		gasLimit = gasLimit * 12 / 10 // 20% extra gas to avoid out of gas error
+			"fallback gas limit", "error", err)
+		return nil, err
 	}
+
 	feeData := &FeeData{
-		gasLimit:  gasLimit,
+		gasLimit:  gasLimit * 12 / 10, // 20% extra gas to avoid out of gas error,
 		gasTipCap: gasTipCap,
 		gasFeeCap: gasFeeCap,
 	}
@@ -76,7 +67,7 @@ func (s *Sender) estimateDynamicGas(to *common.Address, data []byte, baseFee uin
 	return feeData, nil
 }
 
-func (s *Sender) estimateBlobGas(to *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, baseFee, blobBaseFee uint64, fallbackGasLimit uint64) (*FeeData, error) {
+func (s *Sender) estimateBlobGas(to *common.Address, data []byte, sidecar *types.BlobTxSidecar, baseFee, blobBaseFee uint64) (*FeeData, error) {
 	gasTipCap, err := s.client.SuggestGasTipCap(s.ctx)
 	if err != nil {
 		log.Error("estimateBlobGas SuggestGasTipCap failure", "error", err)
@@ -93,17 +84,12 @@ func (s *Sender) estimateBlobGas(to *common.Address, data []byte, sidecar *gethT
 	gasLimit, accessList, err := s.estimateGasLimit(to, data, sidecar, nil, gasTipCap, gasFeeCap, blobGasFeeCap)
 	if err != nil {
 		log.Error("estimateBlobGas estimateGasLimit failure",
-			"from", s.transactionSigner.GetAddr().String(), "nonce", s.transactionSigner.GetNonce(), "to address", to.String(),
-			"fallback gas limit", fallbackGasLimit, "error", err)
-		if fallbackGasLimit == 0 {
-			return nil, err
-		}
-		gasLimit = fallbackGasLimit
-	} else {
-		gasLimit = gasLimit * 12 / 10 // 20% extra gas to avoid out of gas error
+			"from", s.transactionSigner.GetAddr().String(), "nonce", s.transactionSigner.GetNonce(), "to address", to.String(), "error", err)
+		return nil, err
 	}
+
 	feeData := &FeeData{
-		gasLimit:      gasLimit,
+		gasLimit:      gasLimit * 12 / 10, // 20% extra gas to avoid out of gas error
 		gasTipCap:     gasTipCap,
 		gasFeeCap:     gasFeeCap,
 		blobGasFeeCap: blobGasFeeCap,
@@ -115,7 +101,7 @@ func (s *Sender) estimateBlobGas(to *common.Address, data []byte, sidecar *gethT
 	return feeData, nil
 }
 
-func (s *Sender) estimateGasLimit(to *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, gasPrice, gasTipCap, gasFeeCap, blobGasFeeCap *big.Int) (uint64, *types.AccessList, error) {
+func (s *Sender) estimateGasLimit(to *common.Address, data []byte, sidecar *types.BlobTxSidecar, gasPrice, gasTipCap, gasFeeCap, blobGasFeeCap *big.Int) (uint64, *types.AccessList, error) {
 	msg := ethereum.CallMsg{
 		From:      s.transactionSigner.GetAddr(),
 		To:        to,

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -156,22 +156,22 @@ func (s *Sender) SendConfirmation(cfm *Confirmation) {
 	s.confirmCh <- cfm
 }
 
-func (s *Sender) getFeeData(target *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, baseFee, blobBaseFee uint64, fallbackGasLimit uint64) (*FeeData, error) {
+func (s *Sender) getFeeData(target *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, baseFee, blobBaseFee uint64) (*FeeData, error) {
 	switch s.config.TxType {
 	case LegacyTxType:
-		return s.estimateLegacyGas(target, data, fallbackGasLimit)
+		return s.estimateLegacyGas(target, data)
 	case DynamicFeeTxType:
 		if sidecar == nil {
-			return s.estimateDynamicGas(target, data, baseFee, fallbackGasLimit)
+			return s.estimateDynamicGas(target, data, baseFee)
 		}
-		return s.estimateBlobGas(target, data, sidecar, baseFee, blobBaseFee, fallbackGasLimit)
+		return s.estimateBlobGas(target, data, sidecar, baseFee, blobBaseFee)
 	default:
 		return nil, fmt.Errorf("unsupported transaction type: %s", s.config.TxType)
 	}
 }
 
 // SendTransaction send a signed L2tL1 transaction.
-func (s *Sender) SendTransaction(contextID string, target *common.Address, data []byte, blobs []*kzg4844.Blob, fallbackGasLimit uint64) (common.Hash, error) {
+func (s *Sender) SendTransaction(contextID string, target *common.Address, data []byte, blobs []*kzg4844.Blob) (common.Hash, error) {
 	s.metrics.sendTransactionTotal.WithLabelValues(s.service, s.name).Inc()
 	var (
 		feeData *FeeData
@@ -210,9 +210,9 @@ func (s *Sender) SendTransaction(contextID string, target *common.Address, data 
 		return common.Hash{}, fmt.Errorf("failed to get block number and base fee, err: %w", err)
 	}
 
-	if feeData, err = s.getFeeData(target, data, sidecar, baseFee, blobBaseFee, fallbackGasLimit); err != nil {
+	if feeData, err = s.getFeeData(target, data, sidecar, baseFee, blobBaseFee); err != nil {
 		s.metrics.sendTransactionFailureGetFee.WithLabelValues(s.service, s.name).Inc()
-		log.Error("failed to get fee data", "from", s.transactionSigner.GetAddr().String(), "nonce", s.transactionSigner.GetNonce(), "fallback gas limit", fallbackGasLimit, "err", err)
+		log.Error("failed to get fee data", "from", s.transactionSigner.GetAddr().String(), "nonce", s.transactionSigner.GetNonce(), "err", err)
 		return common.Hash{}, fmt.Errorf("failed to get fee data, err: %w", err)
 	}
 

--- a/rollup/internal/controller/sender/sender_test.go
+++ b/rollup/internal/controller/sender/sender_test.go
@@ -21,7 +21,6 @@ import (
 	gethTypes "github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
-	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/log"
 	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +33,6 @@ import (
 
 	bridgeAbi "scroll-tech/rollup/abi"
 	"scroll-tech/rollup/internal/config"
-	"scroll-tech/rollup/internal/orm"
 	"scroll-tech/rollup/mock_bridge"
 )
 
@@ -136,7 +134,6 @@ func TestSender(t *testing.T) {
 	setupEnv(t)
 	t.Run("test new sender", testNewSender)
 	t.Run("test send and retrieve transaction", testSendAndRetrieveTransaction)
-	t.Run("test fallback gas limit", testFallbackGasLimit)
 	t.Run("test access list transaction gas limit", testAccessListTransactionGasLimit)
 	t.Run("test resubmit zero gas price transaction", testResubmitZeroGasPriceTransaction)
 	t.Run("test resubmit non-zero gas price transaction", testResubmitNonZeroGasPriceTransaction)
@@ -190,7 +187,7 @@ func testSendAndRetrieveTransaction(t *testing.T) {
 		if txBlob[i] != nil {
 			blobs = []*kzg4844.Blob{txBlob[i]}
 		}
-		hash, err := s.SendTransaction("0", &common.Address{}, nil, blobs, 0)
+		hash, err := s.SendTransaction("0", &common.Address{}, nil, blobs)
 		assert.NoError(t, err)
 		txs, err := s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 1)
 		assert.NoError(t, err)
@@ -211,63 +208,6 @@ func testSendAndRetrieveTransaction(t *testing.T) {
 		}, 30*time.Second, time.Second)
 
 		s.Stop()
-	}
-}
-
-func testFallbackGasLimit(t *testing.T) {
-	for i, txType := range txTypes {
-		sqlDB, err := db.DB()
-		assert.NoError(t, err)
-		assert.NoError(t, migrate.ResetDB(sqlDB))
-
-		cfgCopy := *cfg.L2Config.RelayerConfig.SenderConfig
-		cfgCopy.TxType = txType
-		cfgCopy.Confirmations = rpc.LatestBlockNumber
-		s, err := NewSender(context.Background(), &cfgCopy, signerConfig, "test", "test", types.SenderTypeUnknown, db, nil)
-		assert.NoError(t, err)
-
-		client, err := ethclient.Dial(cfgCopy.Endpoint)
-		assert.NoError(t, err)
-
-		var blobs []*kzg4844.Blob
-		if txBlob[i] != nil {
-			blobs = []*kzg4844.Blob{txBlob[i]}
-		}
-		// FallbackGasLimit = 0
-		txHash0, err := s.SendTransaction("0", &common.Address{}, nil, blobs, 0)
-		assert.NoError(t, err)
-		tx0, _, err := client.TransactionByHash(context.Background(), txHash0)
-		assert.NoError(t, err)
-		assert.Greater(t, tx0.Gas(), uint64(0))
-
-		assert.Eventually(t, func() bool {
-			var txs []orm.PendingTransaction
-			txs, err = s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 100)
-			assert.NoError(t, err)
-			return len(txs) == 0
-		}, 30*time.Second, time.Second)
-
-		// FallbackGasLimit = 100000
-		patchGuard := gomonkey.ApplyPrivateMethod(s, "estimateGasLimit",
-			func(contract *common.Address, data []byte, sidecar *gethTypes.BlobTxSidecar, gasPrice, gasTipCap, gasFeeCap, blobGasFeeCap *big.Int) (uint64, *gethTypes.AccessList, error) {
-				return 0, nil, errors.New("estimateGasLimit error")
-			},
-		)
-
-		txHash1, err := s.SendTransaction("1", &common.Address{}, nil, blobs, 100000)
-		assert.NoError(t, err)
-		tx1, _, err := client.TransactionByHash(context.Background(), txHash1)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(100000), tx1.Gas())
-
-		assert.Eventually(t, func() bool {
-			txs, err := s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 100)
-			assert.NoError(t, err)
-			return len(txs) == 0
-		}, 30*time.Second, time.Second)
-
-		s.Stop()
-		patchGuard.Reset()
 	}
 }
 
@@ -605,10 +545,10 @@ func testResubmitNonceGappedTransaction(t *testing.T) {
 		if txBlob[i] != nil {
 			blobs = []*kzg4844.Blob{txBlob[i]}
 		}
-		_, err = s.SendTransaction("test-1", &common.Address{}, nil, blobs, 0)
+		_, err = s.SendTransaction("test-1", &common.Address{}, nil, blobs)
 		assert.NoError(t, err)
 
-		_, err = s.SendTransaction("test-2", &common.Address{}, nil, blobs, 0)
+		_, err = s.SendTransaction("test-2", &common.Address{}, nil, blobs)
 		assert.NoError(t, err)
 
 		s.checkPendingTransaction()
@@ -649,7 +589,7 @@ func testCheckPendingTransactionTxConfirmed(t *testing.T) {
 			return nil
 		})
 
-		_, err = s.SendTransaction("test", &common.Address{}, nil, randBlobs(1), 0)
+		_, err = s.SendTransaction("test", &common.Address{}, nil, randBlobs(1))
 		assert.NoError(t, err)
 
 		txs, err := s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 1)
@@ -691,7 +631,7 @@ func testCheckPendingTransactionResubmitTxConfirmed(t *testing.T) {
 			return nil
 		})
 
-		originTxHash, err := s.SendTransaction("test", &common.Address{}, nil, randBlobs(1), 0)
+		originTxHash, err := s.SendTransaction("test", &common.Address{}, nil, randBlobs(1))
 		assert.NoError(t, err)
 
 		txs, err := s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 1)
@@ -751,7 +691,7 @@ func testCheckPendingTransactionReplacedTxConfirmed(t *testing.T) {
 			return nil
 		})
 
-		txHash, err := s.SendTransaction("test", &common.Address{}, nil, randBlobs(1), 0)
+		txHash, err := s.SendTransaction("test", &common.Address{}, nil, randBlobs(1))
 		assert.NoError(t, err)
 
 		txs, err := s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 1)
@@ -821,7 +761,7 @@ func testCheckPendingTransactionTxMultipleTimesWithOnlyOneTxPending(t *testing.T
 			return nil
 		})
 
-		_, err = s.SendTransaction("test", &common.Address{}, nil, randBlobs(1), 0)
+		_, err = s.SendTransaction("test", &common.Address{}, nil, randBlobs(1))
 		assert.NoError(t, err)
 
 		txs, err := s.pendingTransactionOrm.GetPendingOrReplacedTransactionsBySenderType(context.Background(), s.senderType, 1)
@@ -895,7 +835,7 @@ func testBlobTransactionWithBlobhashOpContractCall(t *testing.T) {
 	assert.NoError(t, err)
 	defer s.Stop()
 
-	_, err = s.SendTransaction("0", &testContractsAddress, data, blobs, 0)
+	_, err = s.SendTransaction("0", &testContractsAddress, data, blobs)
 	assert.NoError(t, err)
 
 	var txHash common.Hash
@@ -953,10 +893,10 @@ func testSendBlobCarryingTxOverLimit(t *testing.T) {
 	assert.NoError(t, err)
 
 	for i := 0; i < int(cfgCopy.MaxPendingBlobTxs); i++ {
-		_, err = s.SendTransaction("0", &common.Address{}, nil, randBlobs(1), 0)
+		_, err = s.SendTransaction("0", &common.Address{}, nil, randBlobs(1))
 		assert.NoError(t, err)
 	}
-	_, err = s.SendTransaction("0", &common.Address{}, nil, randBlobs(1), 0)
+	_, err = s.SendTransaction("0", &common.Address{}, nil, randBlobs(1))
 	assert.ErrorIs(t, err, ErrTooManyPendingBlobTxs)
 	s.Stop()
 }


### PR DESCRIPTION
### Purpose or design rationale of this PR

The fallback gas limit logic is not used anymore, and in the meantime, `commitBatches` already commits multiple batches per transaction, ~~and the number per `commitBatches` will grow in the future as well~~. This PR removes related configuration and parameters for conciseness.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] No, this PR doesn't involve a new deployment, git tag, docker image tag

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version number to v4.5.14.
  - Updated configuration to remove the gas limit multiplier setting.

- **Refactor**
  - Simplified gas estimation by removing fallback gas limit logic and parameters.
  - All gas estimates now consistently include a 20% buffer for reliability.
  - Updated transaction sending methods to streamline parameters.

- **Tests**
  - Removed tests related to fallback gas limit.
  - Updated existing tests to match the new method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->