### PR TITLE
fix(coordinator): remove initialize `euclid` VKs

### DIFF
--- a/common/types/message/message.go
+++ b/common/types/message/message.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	EuclidFork   = "euclid"
 	EuclidV2Fork = "euclidV2"
 
 	EuclidV2ForkNameForProver = "euclidv2"
@@ -46,7 +45,7 @@ const (
 
 // ChunkTaskDetail is a type containing ChunkTask detail for chunk task.
 type ChunkTaskDetail struct {
-	// use one of the string of EuclidFork / EuclidV2Fork
+	// use one of the string of "euclidv1" / "euclidv2"
 	ForkName         string        `json:"fork_name"`
 	BlockHashes      []common.Hash `json:"block_hashes"`
 	PrevMsgQueueHash common.Hash   `json:"prev_msg_queue_hash"`
@@ -97,7 +96,7 @@ func (e *Byte48) UnmarshalJSON(input []byte) error {
 
 // BatchTaskDetail is a type containing BatchTask detail.
 type BatchTaskDetail struct {
-	// use one of the string of EuclidFork / EuclidV2Fork
+	// use one of the string of "euclidv1" / "euclidv2"
 	ForkName        string              `json:"fork_name"`
 	ChunkInfos      []*ChunkInfo        `json:"chunk_infos"`
 	ChunkProofs     []*OpenVMChunkProof `json:"chunk_proofs"`
@@ -110,7 +109,7 @@ type BatchTaskDetail struct {
 
 // BundleTaskDetail consists of all the information required to describe the task to generate a proof for a bundle of batches.
 type BundleTaskDetail struct {
-	// use one of the string of EuclidFork / EuclidV2Fork
+	// use one of the string of "euclidv1" / "euclidv2"
 	ForkName    string              `json:"fork_name"`
 	BatchProofs []*OpenVMBatchProof `json:"batch_proofs"`
 	BundleInfo  *OpenVMBundleInfo   `json:"bundle_info,omitempty"`

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.18"
+var tag = "v4.5.19"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/verifier/verifier.go
+++ b/coordinator/internal/logic/verifier/verifier.go
@@ -79,10 +79,6 @@ func NewVerifier(cfg *config.VerifierConfig) (*Verifier, error) {
 		OpenVMVkMap: make(map[string]struct{}),
 	}
 
-	if err := v.loadOpenVMVks(message.EuclidFork); err != nil {
-		return nil, err
-	}
-
 	if err := v.loadOpenVMVks(message.EuclidV2Fork); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR

`euclid` verifier won't be initialized, thus removing `loadOpenVMVks` as well because it will call `euclid` verifier's `dump_vk` function.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version to v4.5.19.

- **Refactor**
  - Removed references to the "euclid" fork and updated related documentation to use explicit fork names.
  - Streamlined initialization by discontinuing the loading of verification keys for the "euclid" fork.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->