### PR TITLE
fix(bridge-history): unclaimed withdrawals

### DIFF
--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -154,7 +154,7 @@ func (c *CrossMessage) GetL2UnclaimedWithdrawalsByAddress(ctx context.Context, s
 	db := c.db.WithContext(ctx)
 	db = db.Model(&CrossMessage{})
 	db = db.Where("message_type = ?", btypes.MessageTypeL2SentMessage)
-	db = db.Where("tx_status = ?", types.TxStatusTypeSent)
+	db = db.Where("tx_status != ?", types.TxStatusTypeRelayed)
 	db = db.Where("sender = ?", sender)
 	db = db.Order("block_timestamp desc")
 	db = db.Limit(500)

--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -154,7 +154,7 @@ func (c *CrossMessage) GetL2UnclaimedWithdrawalsByAddress(ctx context.Context, s
 	db := c.db.WithContext(ctx)
 	db = db.Model(&CrossMessage{})
 	db = db.Where("message_type = ?", btypes.MessageTypeL2SentMessage)
-	db = db.Where("tx_status != ?", types.TxStatusTypeRelayed)
+	db = db.Where("tx_status in (?)", []types.TxStatusType{types.TxStatusTypeSent, types.TxStatusTypeFailedRelayed, types.TxStatusTypeRelayTxReverted})
 	db = db.Where("sender = ?", sender)
 	db = db.Order("block_timestamp desc")
 	db = db.Limit(500)

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.19"
+var tag = "v4.5.20"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

This PR fixes a bug in bridge-history, the new logic treats all unsuccessful withdrawals as unclaimed.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced retrieval of L2 unclaimed withdrawal messages to include additional transaction statuses.

- **Chores**
  - Updated version to v4.5.20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->