### PR TITLE
fix(rollup-relayer): add transaction support to insert l2 blocks

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.20"
+var tag = "v4.5.21"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -220,7 +220,7 @@ func (r *Layer2Relayer) initializeGenesis() error {
 	chunk := &encoding.Chunk{Blocks: []*encoding.Block{{Header: genesis}}}
 
 	err = r.db.Transaction(func(dbTX *gorm.DB) error {
-		if err = r.l2BlockOrm.InsertL2Blocks(r.ctx, chunk.Blocks); err != nil {
+		if err = r.l2BlockOrm.InsertL2Blocks(r.ctx, chunk.Blocks, dbTX); err != nil {
 			return fmt.Errorf("failed to insert genesis block: %v", err)
 		}
 

--- a/rollup/internal/orm/l2_block.go
+++ b/rollup/internal/orm/l2_block.go
@@ -173,7 +173,7 @@ func (o *L2Block) GetL2BlocksInRange(ctx context.Context, startBlockNumber uint6
 }
 
 // InsertL2Blocks inserts l2 blocks into the "l2_block" table.
-func (o *L2Block) InsertL2Blocks(ctx context.Context, blocks []*encoding.Block) error {
+func (o *L2Block) InsertL2Blocks(ctx context.Context, blocks []*encoding.Block, dbTX ...*gorm.DB) error {
 	var l2Blocks []L2Block
 	for _, block := range blocks {
 		header, err := json.Marshal(block.Header)
@@ -203,7 +203,11 @@ func (o *L2Block) InsertL2Blocks(ctx context.Context, blocks []*encoding.Block) 
 		l2Blocks = append(l2Blocks, l2Block)
 	}
 
-	db := o.db.WithContext(ctx)
+	db := o.db
+	if len(dbTX) > 0 && dbTX[0] != nil {
+		db = dbTX[0]
+	}
+	db = db.WithContext(ctx)
 	db = db.Model(&L2Block{})
 
 	if err := db.Create(&l2Blocks).Error; err != nil {


### PR DESCRIPTION
### Purpose or design rationale of this PR

The following error will occur if `commitGenesisBatch` or other db updates fail; this PR aims to address this issue.

```
CRIT [06-05|12:04:16.787|scroll-tech/rollup/cmd/rollup_relayer/app/app.go:102]             failed to create l2 relayer              config file=/rollup-relayer/config.json error="failed to initialize and commit genesis batch, err: update genesis transaction failed: failed to insert genesis block: L2Block.InsertL2Blocks error: ERROR: duplicate key value violates unique constraint \"l2_block_hash_uindex\" (SQLSTATE 23505)"
```

The root cause of this specific issue (to open this PR) is due to not updating the submodule commit:
```
CRIT [06-05|13:38:04.896|scroll-tech/rollup/cmd/rollup_relayer/app/app.go:102]             failed to create l2 relayer              config file=/rollup-relayer/config.json error="failed to initialize and commit genesis batch, err: update genesis transaction failed: failed to insert batch: Batch.InsertBatch error: ERROR: column \"challenge_digest\" of relation \"batch\" does not exist (SQLSTATE 42703)"
```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version number to v4.5.21.

- **Refactor**
	- Improved database transaction handling for inserting L2 blocks, ensuring more consistent operations within transaction contexts. No user-facing functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->