### PR TITLE
build: update setup-node to v4

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Install Node.js 16
         if: steps.check_diff.outputs.result == 'bump'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: bump version in common/version/version.go


### PR DESCRIPTION
Bumps setup-node to v4 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/actions/setup-node/releases/tag/v4.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Node.js setup step in the workflow to use the latest version of the GitHub Action for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->