### PR TITLE
refactor: remove unused check

### DIFF
--- a/common/types/message/message.go
+++ b/common/types/message/message.go
@@ -10,12 +10,6 @@ import (
 	"github.com/scroll-tech/go-ethereum/common/hexutil"
 )
 
-const (
-	EuclidV2Fork = "euclidV2"
-
-	EuclidV2ForkNameForProver = "euclidv2"
-)
-
 // ProofType represents the type of task.
 type ProofType uint8
 

--- a/coordinator/cmd/api/app/mock_app.go
+++ b/coordinator/cmd/api/app/mock_app.go
@@ -93,7 +93,7 @@ func (c *CoordinatorApp) MockConfig(store bool) error {
 			MinProverVersion: "v4.4.89",
 			Verifiers: []coordinatorConfig.AssetConfig{{
 				AssetsPath: "",
-				ForkName:   "euclidV2",
+				ForkName:   "feynman",
 			},
 			}},
 		BatchCollectionTimeSec: 60,

--- a/coordinator/conf/config.json
+++ b/coordinator/conf/config.json
@@ -8,10 +8,16 @@
     "chunk_collection_time_sec": 180,
     "verifier": {
       "min_prover_version": "v4.4.45",
-      "verifiers": [{
-        "assets_path": "assets",
-        "fork_name": "euclidV2"
-      }]
+      "verifiers": [
+        {
+          "assets_path": "assets",
+          "fork_name": "euclidV2"
+        },
+        {
+          "assets_path": "assets",
+          "fork_name": "feynman"
+        }
+      ]
     }
   },
   "db": {

--- a/coordinator/internal/config/config_test.go
+++ b/coordinator/internal/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				"min_prover_version": "v4.4.45",
 				"verifiers": [{
 					"assets_path": "assets",
-					"fork_name": "euclidV2"
+					"fork_name": "feynman",
 				}]
 			},
 			"max_verifier_workers": 4

--- a/coordinator/internal/config/config_test.go
+++ b/coordinator/internal/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				"min_prover_version": "v4.4.45",
 				"verifiers": [{
 					"assets_path": "assets",
-					"fork_name": "feynman",
+					"fork_name": "feynman"
 				}]
 			},
 			"max_verifier_workers": 4

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -295,13 +295,6 @@ func (bp *BatchProverTask) getBatchTaskDetail(dbBatch *orm.Batch, chunkInfos []*
 		ChunkProofs: chunkProofs,
 	}
 
-	if hardForkName == message.EuclidV2Fork {
-		taskDetail.ForkName = message.EuclidV2ForkNameForProver
-	} else {
-		log.Error("unsupported hard fork name", "hard_fork_name", hardForkName)
-		return nil, fmt.Errorf("unsupported hard fork name: %s", hardForkName)
-	}
-
 	dbBatchCodecVersion := encoding.CodecVersion(dbBatch.CodecVersion)
 	switch dbBatchCodecVersion {
 	case encoding.CodecV3, encoding.CodecV4, encoding.CodecV6, encoding.CodecV7, encoding.CodecV8:

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -293,6 +293,7 @@ func (bp *BatchProverTask) getBatchTaskDetail(dbBatch *orm.Batch, chunkInfos []*
 	taskDetail := &message.BatchTaskDetail{
 		ChunkInfos:  chunkInfos,
 		ChunkProofs: chunkProofs,
+		ForkName:    hardForkName,
 	}
 
 	dbBatchCodecVersion := encoding.CodecVersion(dbBatch.CodecVersion)

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -250,6 +250,7 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 
 	taskDetail := message.BundleTaskDetail{
 		BatchProofs: batchProofs,
+		ForkName:    hardForkName,
 	}
 
 	taskDetail.BundleInfo = &message.OpenVMBundleInfo{

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -252,13 +252,6 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 		BatchProofs: batchProofs,
 	}
 
-	if hardForkName == message.EuclidV2Fork {
-		taskDetail.ForkName = message.EuclidV2ForkNameForProver
-	} else {
-		log.Error("unsupported hard fork name", "hard_fork_name", hardForkName)
-		return nil, fmt.Errorf("unsupported hard fork name: %s", hardForkName)
-	}
-
 	taskDetail.BundleInfo = &message.OpenVMBundleInfo{
 		ChainID:       bp.cfg.L2.ChainID,
 		PrevStateRoot: common.HexToHash(parentBatch.StateRoot),

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -230,13 +230,6 @@ func (cp *ChunkProverTask) formatProverTask(ctx context.Context, task *orm.Prove
 		PrevMsgQueueHash: common.HexToHash(chunk.PrevL1MessageQueueHash),
 	}
 
-	if hardForkName == message.EuclidV2Fork {
-		taskDetail.ForkName = message.EuclidV2ForkNameForProver
-	} else {
-		log.Error("unsupported hard fork name", "hard_fork_name", hardForkName)
-		return nil, fmt.Errorf("unsupported hard fork name: %s", hardForkName)
-	}
-
 	var err error
 	taskDetailBytes, err = json.Marshal(taskDetail)
 	if err != nil {

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -228,6 +228,7 @@ func (cp *ChunkProverTask) formatProverTask(ctx context.Context, task *orm.Prove
 	taskDetail := message.ChunkTaskDetail{
 		BlockHashes:      blockHashes,
 		PrevMsgQueueHash: common.HexToHash(chunk.PrevL1MessageQueueHash),
+		ForkName:         hardForkName,
 	}
 
 	var err error


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple verifier forks in the configuration, allowing the system to recognize both "euclidV2" and "feynman".

* **Bug Fixes**
  * Removed restrictions and error handling related to unsupported hard fork names in prover task processing, enabling broader fork compatibility.

* **Chores**
  * Updated test and mock configurations to use the "feynman" fork name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->