### PR TITLE
[Upgrade] feynman 0.5.0rc1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ repository = "https://github.com/scroll-tech/scroll"
 version = "4.5.8"
 
 [workspace.dependencies]
-scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "0dd7b19", package = "scroll-zkvm-prover" }
-scroll-zkvm-verifier-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "0dd7b19", package = "scroll-zkvm-verifier" }
-scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "0dd7b19" }
+scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.5.0rc1", package = "scroll-zkvm-prover" }
+scroll-zkvm-verifier-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.5.0rc1", package = "scroll-zkvm-verifier" }
+scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.5.0rc1" }
 
-sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/upgrade", features = ["scroll"] }
-sbv-utils = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/upgrade" }
+sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3", features = ["scroll"] }
+sbv-utils = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3" }
 
 metrics = "0.23.0"
 metrics-util = "0.17"
@@ -46,18 +46,18 @@ once_cell = "1.20"
 base64 = "0.22"
 
 [patch.crates-io]
-revm = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-bytecode = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-context = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-context-interface = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-database = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-database-interface = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-handler = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-inspector = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-interpreter = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-precompile = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
-revm-state = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v74" }
+revm = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-bytecode = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-context = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-context-interface = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-database = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-database-interface = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-handler = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-inspector = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-interpreter = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-precompile = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-primitives = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
+revm-state = { git = "https://github.com/scroll-tech/revm", branch = "feat/reth-v78" }
 
 ruint = { git = "https://github.com/scroll-tech/uint.git", branch = "v1.15.0" }
 alloy-primitives = { git = "https://github.com/scroll-tech/alloy-core", branch = "v1.2.0" }

--- a/coordinator/Makefile
+++ b/coordinator/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint docker clean coordinator coordinator_skip_libzkp mock_coordinator
+.PHONY: lint docker clean coordinator coordinator_skip_libzkp mock_coordinator libzkp
 
 IMAGE_VERSION=latest
 REPO_ROOT_DIR=./..

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -86,6 +86,10 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 		var tmpBatchTask *orm.Batch
 
 		if taskCtx.hasAssignedTask != nil {
+			if taskCtx.hasAssignedTask.TaskType != int16(message.ProofTypeBatch) {
+				return nil, fmt.Errorf("prover with publicKey %s is already assigned a task. ProverName: %s, ProverVersion: %s", taskCtx.PublicKey, taskCtx.ProverName, taskCtx.ProverVersion)
+			}
+
 			tmpBatchTask, getTaskError = bp.batchOrm.GetBatchByHash(ctx.Copy(), taskCtx.hasAssignedTask.TaskID)
 			if getTaskError != nil {
 				log.Error("failed to get batch has assigned to prover", "taskID", taskCtx.hasAssignedTask.TaskID, "err", getTaskError)
@@ -94,6 +98,14 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 				// if the assigned batch dropped, there would be too much issue to assign another
 				return nil, fmt.Errorf("prover with publicKey %s is already assigned a dropped batch. ProverName: %s, ProverVersion: %s",
 					taskCtx.PublicKey, taskCtx.ProverName, taskCtx.ProverVersion)
+			}
+		} else if getTaskParameter.TaskID != "" {
+			tmpBatchTask, getTaskError = bp.batchOrm.GetBatchByHash(ctx.Copy(), getTaskParameter.TaskID)
+			if getTaskError != nil {
+				log.Error("failed to get expected batch", "taskID", getTaskParameter.TaskID, "err", getTaskError)
+				return nil, ErrCoordinatorInternalFailure
+			} else if tmpBatchTask == nil {
+				return nil, fmt.Errorf("Expected task (%s) is already dropped", getTaskParameter.TaskID)
 			}
 		}
 

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -84,6 +84,10 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 		var tmpBundleTask *orm.Bundle
 
 		if taskCtx.hasAssignedTask != nil {
+			if taskCtx.hasAssignedTask.TaskType != int16(message.ProofTypeBundle) {
+				return nil, fmt.Errorf("prover with publicKey %s is already assigned a task. ProverName: %s, ProverVersion: %s", taskCtx.PublicKey, taskCtx.ProverName, taskCtx.ProverVersion)
+			}
+
 			tmpBundleTask, getTaskError = bp.bundleOrm.GetBundleByHash(ctx.Copy(), taskCtx.hasAssignedTask.TaskID)
 			if getTaskError != nil {
 				log.Error("failed to get bundle has assigned to prover", "taskID", taskCtx.hasAssignedTask.TaskID, "err", getTaskError)
@@ -92,6 +96,14 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 				// if the assigned chunk dropped, there would be too much issue to assign another
 				return nil, fmt.Errorf("prover with publicKey %s is already assigned a dropped bundle. ProverName: %s, ProverVersion: %s",
 					taskCtx.PublicKey, taskCtx.ProverName, taskCtx.ProverVersion)
+			}
+		} else if getTaskParameter.TaskID != "" {
+			tmpBundleTask, getTaskError = bp.bundleOrm.GetBundleByHash(ctx.Copy(), getTaskParameter.TaskID)
+			if getTaskError != nil {
+				log.Error("failed to get expected bundle", "taskID", getTaskParameter.TaskID, "err", getTaskError)
+				return nil, ErrCoordinatorInternalFailure
+			} else if tmpBundleTask == nil {
+				return nil, fmt.Errorf("Expected task (%s) is already dropped", getTaskParameter.TaskID)
 			}
 		}
 
@@ -234,9 +246,14 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 		return nil, fmt.Errorf("failed to get batch proofs for bundle task id:%s, no batch found", task.TaskID)
 	}
 
-	parentBatch, err := bp.batchOrm.GetBatchByHash(ctx, batches[0].ParentBatchHash)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get parent batch for batch task id:%s err:%w", task.TaskID, err)
+	var prevStateRoot common.Hash
+	// this would be common in test cases: the first batch has empty parent
+	if batches[0].Index > 1 {
+		parentBatch, err := bp.batchOrm.GetBatchByHash(ctx, batches[0].ParentBatchHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get parent batch for batch task id:%s err:%w", task.TaskID, err)
+		}
+		prevStateRoot = common.HexToHash(parentBatch.StateRoot)
 	}
 
 	var batchProofs []*message.OpenVMBatchProof
@@ -255,7 +272,7 @@ func (bp *BundleProverTask) formatProverTask(ctx context.Context, task *orm.Prov
 
 	taskDetail.BundleInfo = &message.OpenVMBundleInfo{
 		ChainID:       bp.cfg.L2.ChainID,
-		PrevStateRoot: common.HexToHash(parentBatch.StateRoot),
+		PrevStateRoot: prevStateRoot,
 		PostStateRoot: common.HexToHash(batches[len(batches)-1].StateRoot),
 		WithdrawRoot:  common.HexToHash(batches[len(batches)-1].WithdrawRoot),
 		NumBatches:    uint32(len(batches)),

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -80,7 +80,12 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 	for i := 0; i < 5; i++ {
 		var getTaskError error
 		var tmpChunkTask *orm.Chunk
+
 		if taskCtx.hasAssignedTask != nil {
+			if taskCtx.hasAssignedTask.TaskType != int16(message.ProofTypeChunk) {
+				return nil, fmt.Errorf("prover with publicKey %s is already assigned a task. ProverName: %s, ProverVersion: %s", taskCtx.PublicKey, taskCtx.ProverName, taskCtx.ProverVersion)
+			}
+
 			log.Debug("retrieved assigned task chunk", "taskID", taskCtx.hasAssignedTask.TaskID, "prover", taskCtx.ProverName)
 			tmpChunkTask, getTaskError = cp.chunkOrm.GetChunkByHash(ctx.Copy(), taskCtx.hasAssignedTask.TaskID)
 			if getTaskError != nil {
@@ -90,6 +95,14 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 				// if the assigned chunk dropped, there would be too much issue to assign another
 				return nil, fmt.Errorf("prover with publicKey %s is already assigned a dropped chunk. ProverName: %s, ProverVersion: %s",
 					taskCtx.PublicKey, taskCtx.ProverName, taskCtx.ProverVersion)
+			}
+		} else if getTaskParameter.TaskID != "" {
+			tmpChunkTask, getTaskError = cp.chunkOrm.GetChunkByHash(ctx.Copy(), getTaskParameter.TaskID)
+			if getTaskError != nil {
+				log.Error("failed to get expected chunk", "taskID", getTaskParameter.TaskID, "err", getTaskError)
+				return nil, ErrCoordinatorInternalFailure
+			} else if tmpChunkTask == nil {
+				return nil, fmt.Errorf("Expected task (%s) is already dropped", getTaskParameter.TaskID)
 			}
 		}
 
@@ -221,7 +234,7 @@ func (cp *ChunkProverTask) formatProverTask(ctx context.Context, task *orm.Prove
 	// Get block hashes.
 	blockHashes, dbErr := cp.blockOrm.GetL2BlockHashesByChunkHash(ctx, task.TaskID)
 	if dbErr != nil || len(blockHashes) == 0 {
-		return nil, fmt.Errorf("failed to fetch block hashes of a chunk, chunk hash:%s err:%w", task.TaskID, dbErr)
+		return nil, fmt.Errorf("failed to fetch block hashes of a chunk, chunk hash:%s err:%v", task.TaskID, dbErr)
 	}
 
 	var taskDetailBytes []byte

--- a/coordinator/internal/logic/verifier/verifier.go
+++ b/coordinator/internal/logic/verifier/verifier.go
@@ -5,10 +5,12 @@ package verifier
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/scroll-tech/go-ethereum/log"
 
@@ -117,6 +119,16 @@ func (v *Verifier) VerifyBundleProof(proof *message.OpenVMBundleProof, forkName 
 	return libzkp.VerifyBundleProof(string(buf), forkName), nil
 }
 
+/*
+add vk of imcompatilbe circuit app here to avoid we had used them unexpectedly
+25/07/15: 0.5.0rc0 is no longer compatible since a breaking change
+*/
+const blocked_vks = `
+	rSJNNBpsxBdKlstbIIU/aYc7bHau98Qb2yjZMc5PmDhmGOolp5kYRbvF/VcWcO5HN5ujGs6S00W8pZcCoNQRLQ==,
+	2Lo7Cebm6SFtcsYXipkcMxIBmVY7UpoMXik/Msm7t2nyvi9EaNGsSnDnaCurscYEF+IcdjPUtVtY9EcD7IKwWg==,
+	D6YFHwTLZF/U2zpYJPQ3LwJZRm85yA5Vq2iFBqd3Mk4iwOUpS8sbOp3vg2+NDxhhKphgYpuUlykpdsoRhEt+cw==,
+`
+
 func (v *Verifier) loadOpenVMVks(cfg config.AssetConfig) error {
 
 	vkFileName := cfg.Vkfile
@@ -138,6 +150,16 @@ func (v *Verifier) loadOpenVMVks(cfg config.AssetConfig) error {
 	if err := json.Unmarshal(byt, &dump); err != nil {
 		return err
 	}
+	if strings.Contains(blocked_vks, dump.Chunk) {
+		return fmt.Errorf("loaded blocked chunk vk %s", dump.Chunk)
+	}
+	if strings.Contains(blocked_vks, dump.Batch) {
+		return fmt.Errorf("loaded blocked batch vk %s", dump.Batch)
+	}
+	if strings.Contains(blocked_vks, dump.Bundle) {
+		return fmt.Errorf("loaded blocked bundle vk %s", dump.Bundle)
+	}
+
 	v.OpenVMVkMap[dump.Chunk] = struct{}{}
 	v.OpenVMVkMap[dump.Batch] = struct{}{}
 	v.OpenVMVkMap[dump.Bundle] = struct{}{}

--- a/crates/gpu_override/.cargo/config.toml
+++ b/crates/gpu_override/.cargo/config.toml
@@ -13,33 +13,33 @@ openvm-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-gpu.git", branch =
 openvm-transpiler = { git = "ssh://git@github.com/scroll-tech/openvm-gpu.git", branch = "patch-v1.2.1-rc.1-pipe", default-features = false }
 
 [patch."https://github.com/openvm-org/stark-backend.git"]
-openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "sync/upstream-250702", features = ["gpu"] }
-openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "sync/upstream-250702", features = ["gpu"] }
+openvm-stark-backend = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
+openvm-stark-sdk = { git = "ssh://git@github.com/scroll-tech/openvm-stark-gpu.git", branch = "main", features = ["gpu"] }
 
 [patch."https://github.com/Plonky3/Plonky3.git"]
-p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
+p3-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-field = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-commit = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-matrix = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
 p3-baby-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", features = [
     "nightly-features",
-], rev = "450ec18" }
-p3-koala-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
-p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
-p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", rev = "450ec18" }
+], tag = "v0.2.1" }
+p3-koala-bear = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-util = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-challenger = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-dft = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-fri = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-goldilocks = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-keccak = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-keccak-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-blake3 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-mds = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-merkle-tree = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-monty-31 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-poseidon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-poseidon2 = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-poseidon2-air = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-symmetric = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-uni-stark = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }
+p3-maybe-rayon = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" } # the "parallel" feature is NOT on by default to allow single-threaded benchmarking
+p3-bn254-fr = { git = "ssh://git@github.com/scroll-tech/plonky3-gpu.git", tag = "v0.2.1" }

--- a/crates/gpu_override/Cargo.lock
+++ b/crates/gpu_override/Cargo.lock
@@ -739,6 +739,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,7 +1315,7 @@ dependencies = [
  "arrayvec",
  "bitcode_derive",
  "bytemuck",
- "glam",
+ "glam 0.30.3",
  "serde",
 ]
 
@@ -1512,6 +1521,20 @@ name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "byteorder"
@@ -1907,6 +1930,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "cust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6cc71911e179f12483b9734120b45bd00bf64fab085cc4818428523eedd469"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "cust_core",
+ "cust_derive",
+ "cust_raw",
+ "find_cuda_helper",
+]
+
+[[package]]
+name = "cust_core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039f79662cb8f890cbf335e818cd522d6e3a53fe63f61d1aaaf859cd3d975f06"
+dependencies = [
+ "cust_derive",
+ "glam 0.20.5",
+ "mint",
+ "vek",
+]
+
+[[package]]
+name = "cust_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3bc95fe629aed92b2423de6ccff9e40174b21d19cb6ee6281a4d04ac72f66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cust_raw"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf40d6ade12cb9828bbc844b9875c7b93d25e67a3c9bf61c7aa3ae09e402bf8"
+dependencies = [
+ "find_cuda_helper",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2169,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2479,6 +2569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find_cuda_helper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2845,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3086,6 +3194,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3700,6 +3817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libredox"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,6 +3930,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -3896,6 +4029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +4128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mint"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,6 +4200,20 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+ "rayon",
 ]
 
 [[package]]
@@ -4411,11 +4574,11 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1)",
+ "openvm-custom-insn 0.1.0 (git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe)",
  "openvm-platform 1.2.1-rc.0",
  "openvm-rv32im-guest 1.2.1-rc.0",
  "serde",
@@ -4439,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4468,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-macros-common 1.2.1-rc.0",
  "quote",
@@ -4488,14 +4651,14 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
  "once_cell",
  "openvm-algebra-complex-macros 1.2.1-rc.0",
  "openvm-algebra-moduli-macros 1.2.1-rc.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1)",
+ "openvm-custom-insn 0.1.0 (git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe)",
  "openvm-rv32im-guest 1.2.1-rc.0",
  "serde-big-array",
  "strum_macros 0.26.4",
@@ -4520,7 +4683,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4544,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-algebra-guest 1.2.1-rc.0",
  "openvm-instructions",
@@ -4558,7 +4721,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4580,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-platform 1.2.1-rc.0",
  "strum_macros 0.26.4",
@@ -4589,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4604,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4616,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4647,7 +4810,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4657,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4672,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4682,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4697,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4717,7 +4880,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4747,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4756,7 +4919,7 @@ dependencies = [
  "once_cell",
  "openvm 1.2.1-rc.0",
  "openvm-algebra-guest 1.2.1-rc.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1)",
+ "openvm-custom-insn 0.1.0 (git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe)",
  "openvm-ecc-sw-macros 1.2.1-rc.0",
  "openvm-rv32im-guest 1.2.1-rc.0",
  "serde",
@@ -4785,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-macros-common 1.2.1-rc.0",
  "quote",
@@ -4805,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-ecc-guest 1.2.1-rc.0",
  "openvm-instructions",
@@ -4819,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4836,7 +4999,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -4845,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4871,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-platform 1.2.1-rc.0",
 ]
@@ -4879,7 +5042,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4893,7 +5056,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "syn 2.0.101",
 ]
@@ -4909,7 +5072,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4928,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4955,7 +5118,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4979,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -4988,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -5016,7 +5179,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -5051,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5082,7 +5245,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal",
@@ -5093,7 +5256,7 @@ dependencies = [
  "openvm 1.2.1-rc.0",
  "openvm-algebra-guest 1.2.1-rc.0",
  "openvm-algebra-moduli-macros 1.2.1-rc.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1)",
+ "openvm-custom-insn 0.1.0 (git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe)",
  "openvm-ecc-guest 1.2.1-rc.0",
  "rand 0.8.5",
  "serde",
@@ -5124,7 +5287,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5138,10 +5301,10 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "libm",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1)",
+ "openvm-custom-insn 0.1.0 (git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe)",
  "openvm-rv32im-guest 1.2.1-rc.0",
 ]
 
@@ -5158,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -5175,7 +5338,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -5195,7 +5358,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5218,9 +5381,9 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1)",
+ "openvm-custom-insn 0.1.0 (git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe)",
  "p3-field 0.1.0",
  "strum_macros 0.26.4",
 ]
@@ -5238,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5254,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -5317,7 +5480,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5328,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5351,7 +5514,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-platform 1.2.1-rc.0",
 ]
@@ -5367,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5381,7 +5544,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "1.1.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=f48090c9febd021f8ee0349bc929a775fb1fa3ad#f48090c9febd021f8ee0349bc929a775fb1fa3ad"
+source = "git+ssh://git@github.com/scroll-tech/openvm-stark-gpu.git?branch=main#92a37442264d31baed64abb9b895eaef81cfb2f5"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -5393,6 +5556,9 @@ dependencies = [
  "p3-challenger",
  "p3-commit",
  "p3-field 0.1.0",
+ "p3-gpu-backend",
+ "p3-gpu-base",
+ "p3-gpu-module",
  "p3-matrix 0.1.0",
  "p3-maybe-rayon 0.1.0",
  "p3-uni-stark",
@@ -5407,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "1.1.1"
-source = "git+https://github.com/openvm-org/stark-backend.git?rev=f48090c9febd021f8ee0349bc929a775fb1fa3ad#f48090c9febd021f8ee0349bc929a775fb1fa3ad"
+source = "git+ssh://git@github.com/scroll-tech/openvm-stark-gpu.git?branch=main#92a37442264d31baed64abb9b895eaef81cfb2f5"
 dependencies = [
  "derivative",
  "derive_more 0.99.20",
@@ -5423,6 +5589,7 @@ dependencies = [
  "p3-dft 0.1.0",
  "p3-fri",
  "p3-goldilocks",
+ "p3-gpu-backend",
  "p3-keccak",
  "p3-koala-bear",
  "p3-merkle-tree",
@@ -5443,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.2.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.2.1-rc.1#152b6b6c85eda34b367ec261f2f65b0457b9b2d9"
+source = "git+ssh://git@github.com/scroll-tech/openvm-gpu.git?branch=patch-v1.2.1-rc.1-pipe#7dd6d1620d07c2c3faa5b91105cbb3d19ff0c9b0"
 dependencies = [
  "elf",
  "eyre",
@@ -5453,6 +5620,12 @@ dependencies = [
  "rrs-lib",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -5484,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "p3-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-field 0.1.0",
  "p3-matrix 0.1.0",
@@ -5493,7 +5666,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-field 0.1.0",
  "p3-mds 0.1.0",
@@ -5522,7 +5695,7 @@ dependencies = [
 [[package]]
 name = "p3-blake3"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "blake3",
  "p3-symmetric 0.1.0",
@@ -5532,7 +5705,7 @@ dependencies = [
 [[package]]
 name = "p3-bn254-fr"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "ff 0.13.1",
  "halo2curves",
@@ -5547,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-field 0.1.0",
  "p3-maybe-rayon 0.1.0",
@@ -5559,12 +5732,14 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
+ "anyhow",
  "itertools 0.14.0",
  "p3-challenger",
  "p3-dft 0.1.0",
  "p3-field 0.1.0",
+ "p3-gpu-base",
  "p3-matrix 0.1.0",
  "p3-util 0.1.0",
  "serde",
@@ -5573,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.1.0",
@@ -5599,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5630,26 +5805,31 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
+ "anyhow",
  "itertools 0.14.0",
  "p3-challenger",
  "p3-commit",
  "p3-dft 0.1.0",
  "p3-field 0.1.0",
+ "p3-gpu-backend",
+ "p3-gpu-base",
  "p3-interpolation",
  "p3-matrix 0.1.0",
  "p3-maybe-rayon 0.1.0",
+ "p3-merkle-tree",
  "p3-util 0.1.0",
  "rand 0.8.5",
  "serde",
  "tracing",
+ "zkhash",
 ]
 
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "num-bigint 0.4.6",
  "p3-dft 0.1.0",
@@ -5664,9 +5844,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-gpu-backend"
+version = "0.1.0"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cc",
+ "cust",
+ "cust_raw",
+ "ff 0.13.1",
+ "itertools 0.13.0",
+ "lazy_static",
+ "ndarray",
+ "once_cell",
+ "p3-baby-bear 0.1.0",
+ "p3-commit",
+ "p3-dft 0.1.0",
+ "p3-field 0.1.0",
+ "p3-gpu-base",
+ "p3-gpu-build",
+ "p3-interpolation",
+ "p3-matrix 0.1.0",
+ "p3-maybe-rayon 0.1.0",
+ "p3-poseidon2 0.1.0",
+ "p3-util 0.1.0",
+ "parking_lot 0.12.4",
+ "paste",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "sppark",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-gpu-base"
+version = "0.1.0"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cust",
+ "cust_raw",
+ "hex",
+ "lazy_static",
+ "p3-field 0.1.0",
+ "p3-matrix 0.1.0",
+ "parking_lot 0.12.4",
+ "tracing",
+]
+
+[[package]]
+name = "p3-gpu-build"
+version = "0.1.0"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
+dependencies = [
+ "cc",
+ "directories",
+ "hex",
+ "p3-gpu-field",
+ "sha2 0.10.9",
+ "tempfile",
+]
+
+[[package]]
+name = "p3-gpu-field"
+version = "0.1.0"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
+
+[[package]]
+name = "p3-gpu-module"
+version = "0.1.0"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field 0.1.0",
+ "p3-gpu-base",
+ "p3-matrix 0.1.0",
+ "p3-util 0.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-field 0.1.0",
  "p3-matrix 0.1.0",
@@ -5677,7 +5942,7 @@ dependencies = [
 [[package]]
 name = "p3-keccak"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.1.0",
@@ -5689,21 +5954,23 @@ dependencies = [
 [[package]]
 name = "p3-keccak-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-air",
  "p3-field 0.1.0",
+ "p3-gpu-backend",
  "p3-matrix 0.1.0",
  "p3-maybe-rayon 0.1.0",
  "p3-util 0.1.0",
  "rand 0.8.5",
  "tracing",
+ "zkhash",
 ]
 
 [[package]]
 name = "p3-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-field 0.1.0",
  "p3-mds 0.1.0",
@@ -5717,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.1.0",
@@ -5747,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "rayon",
 ]
@@ -5761,7 +6028,7 @@ checksum = "c3968ad1160310296eb04f91a5f4edfa38fe1d6b2b8cd6b5c64e6f9b7370979e"
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft 0.1.0",
@@ -5790,11 +6057,13 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
+ "anyhow",
  "itertools 0.14.0",
  "p3-commit",
  "p3-field 0.1.0",
+ "p3-gpu-base",
  "p3-matrix 0.1.0",
  "p3-maybe-rayon 0.1.0",
  "p3-symmetric 0.1.0",
@@ -5807,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5828,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-field 0.1.0",
  "p3-mds 0.1.0",
@@ -5839,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "gcd",
  "p3-field 0.1.0",
@@ -5865,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2-air"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "p3-air",
  "p3-field 0.1.0",
@@ -5881,7 +6150,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.1.0",
@@ -5902,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "p3-uni-stark"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "itertools 0.14.0",
  "p3-air",
@@ -5920,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb#539bbc84085efb609f4f62cb03cf49588388abdb"
+source = "git+ssh://git@github.com/scroll-tech/plonky3-gpu.git?tag=v0.2.1#d5a0613e224fd972dda579f03bdce02523b79b1c"
 dependencies = [
  "serde",
 ]
@@ -6585,6 +6854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6620,6 +6895,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8029,6 +8315,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -8036,7 +8335,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -9080,6 +9379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sppark"
+version = "0.1.8"
+source = "git+https://github.com/scroll-tech/sppark.git?branch=sp1-v3.0#07fe0de43a745a395dd718c735cdfe0cfc457b0a"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9324,7 +9632,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -9972,6 +10280,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vek"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8085882662f9bc47fc8b0cdafa5e19df8f592f650c02b9083da8d45ac9eebd17"
+dependencies = [
+ "approx",
+ "num-integer",
+ "num-traits",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10175,6 +10495,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/crates/gpu_override/Makefile
+++ b/crates/gpu_override/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build update clean
+
+ZKVM_COMMIT ?= freebuild
+PLONKY3_GPU_VERSION=$(shell ./print_plonky3gpu_version.sh | sed -n '2p')
+$(info PLONKY3_GPU_VERSION is ${PLONKY3_GPU_VERSION})
+
+GIT_REV ?= $(shell git rev-parse --short HEAD)
+GO_TAG ?= $(shell grep "var tag = " ../../common/version/version.go | cut -d "\"" -f2)
+ZK_VERSION=${ZKVM_COMMIT}-${PLONKY3_GPU_VERSION}
+$(info ZK_GPU_VERSION is ${ZK_VERSION})
+
+clean:
+	cargo clean -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock
+
+# build gpu prover, never touch lock file
+build:
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --locked --lockfile-path ./Cargo.lock
+
+# update Cargo.lock while override config has been updated
+update:
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock

--- a/crates/gpu_override/print_plonky3gpu_version.sh
+++ b/crates/gpu_override/print_plonky3gpu_version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-config_file=~/.cargo/config.toml
+config_file=.cargo/config.toml
 plonky3_gpu_path=$(grep 'path.*plonky3-gpu' "$config_file" | cut -d'"' -f2 | head -n 1)
 plonky3_gpu_path=$(dirname "$plonky3_gpu_path")
 

--- a/crates/l2geth/src/rpc_client.rs
+++ b/crates/l2geth/src/rpc_client.rs
@@ -108,7 +108,7 @@ impl ChunkInterpreter for RpcClient<'_> {
                 .get_block_by_hash(block_hash)
                 .full()
                 .await?
-                .ok_or_else(|| eyre::eyre!("Block not found"))?;
+                .ok_or_else(|| eyre::eyre!("Block {block_hash} not found"))?;
 
             let number = block.header.number;
             if number == 0 {

--- a/crates/libzkp/Cargo.toml
+++ b/crates/libzkp/Cargo.toml
@@ -9,7 +9,7 @@ scroll-zkvm-types.workspace = true
 scroll-zkvm-verifier-euclid.workspace = true
 
 alloy-primitives.workspace = true #depress the effect of "native-keccak"
-sbv-primitives.workspace = true
+sbv-primitives = {workspace = true, features = ["scroll-compress-ratio", "scroll"]}
 base64.workspace = true
 serde.workspace = true
 serde_derive.workspace = true

--- a/crates/libzkp/src/lib.rs
+++ b/crates/libzkp/src/lib.rs
@@ -30,7 +30,7 @@ pub fn checkout_chunk_task(
 pub fn gen_universal_task(
     task_type: i32,
     task_json: &str,
-    fork_name: &str,
+    fork_name_str: &str,
     expected_vk: &[u8],
     interpreter: Option<impl ChunkInterpreter>,
 ) -> eyre::Result<(B256, String, String)> {
@@ -48,19 +48,40 @@ pub fn gen_universal_task(
 
     let (pi_hash, metadata, mut u_task) = match task_type {
         x if x == TaskType::Chunk as i32 => {
-            let task = serde_json::from_str::<ChunkProvingTask>(task_json)?;
-            let (pi_hash, metadata, u_task) =
-                gen_universal_chunk_task(task, fork_name.into(), interpreter)?;
+            let mut task = serde_json::from_str::<ChunkProvingTask>(task_json)?;
+            // normailze fork name field in task
+            task.fork_name = task.fork_name.to_lowercase();
+            // always respect the fork_name_str (which has been normalized) being passed
+            // if the fork_name wrapped in task is not match, consider it a malformed task
+            if fork_name_str != task.fork_name.as_str() {
+                eyre::bail!("fork name in chunk task not match the calling arg, expected {fork_name_str}, get {}", task.fork_name);
+            }
+            let (pi_hash, metadata, u_task) = utils::panic_catch(move || {
+                gen_universal_chunk_task(task, fork_name_str.into(), interpreter)
+            })
+            .map_err(|e| eyre::eyre!("catched panic in chunk task{e}"))??;
             (pi_hash, AnyMetaData::Chunk(metadata), u_task)
         }
         x if x == TaskType::Batch as i32 => {
-            let task = serde_json::from_str::<BatchProvingTask>(task_json)?;
-            let (pi_hash, metadata, u_task) = gen_universal_batch_task(task, fork_name.into())?;
+            let mut task = serde_json::from_str::<BatchProvingTask>(task_json)?;
+            task.fork_name = task.fork_name.to_lowercase();
+            if fork_name_str != task.fork_name.as_str() {
+                eyre::bail!("fork name in batch task not match the calling arg, expected {fork_name_str}, get {}", task.fork_name);
+            }
+            let (pi_hash, metadata, u_task) =
+                utils::panic_catch(move || gen_universal_batch_task(task, fork_name_str.into()))
+                    .map_err(|e| eyre::eyre!("catched panic in chunk task{e}"))??;
             (pi_hash, AnyMetaData::Batch(metadata), u_task)
         }
         x if x == TaskType::Bundle as i32 => {
-            let task = serde_json::from_str::<BundleProvingTask>(task_json)?;
-            let (pi_hash, metadata, u_task) = gen_universal_bundle_task(task, fork_name.into())?;
+            let mut task = serde_json::from_str::<BundleProvingTask>(task_json)?;
+            task.fork_name = task.fork_name.to_lowercase();
+            if fork_name_str != task.fork_name.as_str() {
+                eyre::bail!("fork name in bundle task not match the calling arg, expected {fork_name_str}, get {}", task.fork_name);
+            }
+            let (pi_hash, metadata, u_task) =
+                utils::panic_catch(move || gen_universal_bundle_task(task, fork_name_str.into()))
+                    .map_err(|e| eyre::eyre!("catched panic in chunk task{e}"))??;
             (pi_hash, AnyMetaData::Bundle(metadata), u_task)
         }
         _ => return Err(eyre::eyre!("unrecognized task type {task_type}")),
@@ -111,24 +132,6 @@ pub fn verify_proof(proof: Vec<u8>, fork_name: &str, task_type: TaskType) -> eyr
     let verifier = verifier::get_verifier(fork_name)?;
 
     let ret = verifier.lock().unwrap().verify(task_type, &proof)?;
-
-    if let Ok(debug_value) = std::env::var("ZKVM_DEBUG_PROOF") {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        if !ret && debug_value.to_lowercase() == "true" {
-            // Dump req.input to a temporary file
-            let timestamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let filename = format!("/tmp/proof_{}.json", timestamp);
-            if let Err(e) = std::fs::write(&filename, &proof) {
-                eprintln!("Failed to write proof to file {}: {}", filename, e);
-            } else {
-                println!("Dumped failed proof to {}", filename);
-            }
-        }
-    }
-
     Ok(ret)
 }
 

--- a/crates/libzkp/src/lib.rs
+++ b/crates/libzkp/src/lib.rs
@@ -59,7 +59,7 @@ pub fn gen_universal_task(
             let (pi_hash, metadata, u_task) = utils::panic_catch(move || {
                 gen_universal_chunk_task(task, fork_name_str.into(), interpreter)
             })
-            .map_err(|e| eyre::eyre!("catched panic in chunk task{e}"))??;
+            .map_err(|e| eyre::eyre!("caught panic in chunk task{e}"))??;
             (pi_hash, AnyMetaData::Chunk(metadata), u_task)
         }
         x if x == TaskType::Batch as i32 => {
@@ -70,7 +70,7 @@ pub fn gen_universal_task(
             }
             let (pi_hash, metadata, u_task) =
                 utils::panic_catch(move || gen_universal_batch_task(task, fork_name_str.into()))
-                    .map_err(|e| eyre::eyre!("catched panic in chunk task{e}"))??;
+                    .map_err(|e| eyre::eyre!("caught panic in chunk task{e}"))??;
             (pi_hash, AnyMetaData::Batch(metadata), u_task)
         }
         x if x == TaskType::Bundle as i32 => {
@@ -81,7 +81,7 @@ pub fn gen_universal_task(
             }
             let (pi_hash, metadata, u_task) =
                 utils::panic_catch(move || gen_universal_bundle_task(task, fork_name_str.into()))
-                    .map_err(|e| eyre::eyre!("catched panic in chunk task{e}"))??;
+                    .map_err(|e| eyre::eyre!("caught panic in chunk task{e}"))??;
             (pi_hash, AnyMetaData::Bundle(metadata), u_task)
         }
         _ => return Err(eyre::eyre!("unrecognized task type {task_type}")),

--- a/crates/libzkp/src/tasks.rs
+++ b/crates/libzkp/src/tasks.rs
@@ -9,7 +9,10 @@ pub use chunk::{ChunkProvingTask, ChunkTask};
 pub use chunk_interpreter::ChunkInterpreter;
 pub use scroll_zkvm_types::task::ProvingTask;
 
-use crate::proofs::{self, BatchProofMetadata, BundleProofMetadata, ChunkProofMetadata};
+use crate::{
+    proofs::{self, BatchProofMetadata, BundleProofMetadata, ChunkProofMetadata},
+    utils::panic_catch,
+};
 use sbv_primitives::B256;
 use scroll_zkvm_types::public_inputs::{ForkName, MultiVersionPublicInputs};
 
@@ -20,25 +23,14 @@ fn check_aggregation_proofs<Metadata>(
 where
     Metadata: proofs::ProofMetadata,
 {
-    use std::panic::{self, AssertUnwindSafe};
-
-    panic::catch_unwind(AssertUnwindSafe(|| {
+    panic_catch(|| {
         for w in proofs.windows(2) {
             w[1].metadata
                 .pi_hash_info()
                 .validate(w[0].metadata.pi_hash_info(), fork_name);
         }
-    }))
-    .map_err(|e| {
-        let error_msg = if let Some(string) = e.downcast_ref::<String>() {
-            string.clone()
-        } else if let Some(str) = e.downcast_ref::<&str>() {
-            str.to_string()
-        } else {
-            "Unknown validation error occurred".to_string()
-        };
-        eyre::eyre!("Chunk data validation failed: {}", error_msg)
-    })?;
+    })
+    .map_err(|e| eyre::eyre!("Chunk data validation failed: {}", e))?;
 
     Ok(())
 }

--- a/crates/libzkp/src/tasks/batch.rs
+++ b/crates/libzkp/src/tasks/batch.rs
@@ -4,8 +4,9 @@ use eyre::Result;
 use sbv_primitives::{B256, U256};
 use scroll_zkvm_types::{
     batch::{
-        BatchHeader, BatchHeaderV6, BatchHeaderV7, BatchInfo, BatchWitness, Envelope, EnvelopeV6,
-        EnvelopeV7, PointEvalWitness, ReferenceHeader, ToArchievedWitness, N_BLOB_BYTES,
+        BatchHeader, BatchHeaderV6, BatchHeaderV7, BatchHeaderV8, BatchInfo, BatchWitness,
+        Envelope, EnvelopeV6, EnvelopeV7, EnvelopeV8, PointEvalWitness, ReferenceHeader,
+        ToArchievedWitness, N_BLOB_BYTES,
     },
     public_inputs::ForkName,
     task::ProvingTask,
@@ -23,37 +24,35 @@ use utils::{base64, point_eval};
 #[serde(untagged)]
 pub enum BatchHeaderV {
     V6(BatchHeaderV6),
-    V7(BatchHeaderV7),
-}
-
-impl From<BatchHeaderV> for ReferenceHeader {
-    fn from(value: BatchHeaderV) -> Self {
-        match value {
-            BatchHeaderV::V6(h) => ReferenceHeader::V6(h),
-            BatchHeaderV::V7(h) => ReferenceHeader::V7(h),
-        }
-    }
+    V7_8(BatchHeaderV7),
 }
 
 impl BatchHeaderV {
     pub fn batch_hash(&self) -> B256 {
         match self {
             BatchHeaderV::V6(h) => h.batch_hash(),
-            BatchHeaderV::V7(h) => h.batch_hash(),
+            BatchHeaderV::V7_8(h) => h.batch_hash(),
         }
     }
 
     pub fn must_v6_header(&self) -> &BatchHeaderV6 {
         match self {
             BatchHeaderV::V6(h) => h,
-            BatchHeaderV::V7(_) => panic!("try to pick v7 header"),
+            _ => panic!("try to pick other header type"),
         }
     }
 
     pub fn must_v7_header(&self) -> &BatchHeaderV7 {
         match self {
-            BatchHeaderV::V7(h) => h,
-            BatchHeaderV::V6(_) => panic!("try to pick v6 header"),
+            BatchHeaderV::V7_8(h) => h,
+            _ => panic!("try to pick other header type"),
+        }
+    }
+
+    pub fn must_v8_header(&self) -> &BatchHeaderV8 {
+        match self {
+            BatchHeaderV::V7_8(h) => h,
+            _ => panic!("try to pick other header type"),
         }
     }
 }
@@ -120,20 +119,28 @@ impl BatchProvingTask {
                     EnvelopeV6::from_slice(self.blob_bytes.as_slice())
                         .challenge_digest(versioned_hash)
                 }
-                BatchHeaderV::V7(_) => {
-                    match fork_name {
-                        ForkName::EuclidV2 => (),
-                        _ => unreachable!("hardfork mismatch for da-codec@v6 header: found={fork_name:?}, expected={:?}",
-                                [ForkName::EuclidV2],
-                            ),
-                    }
+                BatchHeaderV::V7_8(_) => {
                     let padded_blob_bytes = {
                         let mut padded_blob_bytes = self.blob_bytes.to_vec();
                         padded_blob_bytes.resize(N_BLOB_BYTES, 0);
                         padded_blob_bytes
                     };
-                    EnvelopeV7::from_slice(padded_blob_bytes.as_slice())
-                        .challenge_digest(versioned_hash)
+
+                    match fork_name {
+                        ForkName::EuclidV2 => {
+                            <EnvelopeV7 as Envelope>::from_slice(padded_blob_bytes.as_slice())
+                                .challenge_digest(versioned_hash)
+                        }
+                        ForkName::Feynman => {
+                            <EnvelopeV8 as Envelope>::from_slice(padded_blob_bytes.as_slice())
+                                .challenge_digest(versioned_hash)
+                        }
+                        f => unreachable!(
+                            "hardfork mismatch for da-codec@v7 header: found={}, expected={:?}",
+                            f,
+                            [ForkName::EuclidV2, ForkName::Feynman],
+                        ),
+                    }
                 }
             };
 
@@ -159,7 +166,11 @@ impl BatchProvingTask {
             kzg_proof: kzg_proof.into_inner(),
         };
 
-        let reference_header = self.batch_header.clone().into();
+        let reference_header = match fork_name {
+            ForkName::EuclidV1 => ReferenceHeader::V6(*self.batch_header.must_v6_header()),
+            ForkName::EuclidV2 => ReferenceHeader::V7(*self.batch_header.must_v7_header()),
+            ForkName::Feynman => ReferenceHeader::V8(*self.batch_header.must_v8_header()),
+        };
 
         BatchWitness {
             fork_name,

--- a/crates/libzkp_c/src/lib.rs
+++ b/crates/libzkp_c/src/lib.rs
@@ -9,6 +9,16 @@ use std::sync::OnceLock;
 
 static LOG_SETTINGS: OnceLock<Result<(), String>> = OnceLock::new();
 
+fn enable_dump() -> bool {
+    static ZKVM_DEBUG_DUMP: OnceLock<bool> = OnceLock::new();
+    *ZKVM_DEBUG_DUMP.get_or_init(|| {
+        std::env::var("ZKVM_DEBUG")
+            .or_else(|_| std::env::var("ZKVM_DEBUG_PROOF"))
+            .map(|s| s.to_lowercase() == "true")
+            .unwrap_or(false)
+    })
+}
+
 /// # Safety
 #[no_mangle]
 pub unsafe extern "C" fn init_tracing() {
@@ -52,6 +62,7 @@ pub unsafe extern "C" fn init_l2geth(config: *const c_char) {
 
 fn verify_proof(proof: *const c_char, fork_name: *const c_char, task_type: TaskType) -> c_char {
     let fork_name_str = c_char_to_str(fork_name);
+    let proof_str = proof;
     let proof = c_char_to_vec(proof);
 
     match libzkp::verify_proof(proof, fork_name_str, task_type) {
@@ -59,7 +70,24 @@ fn verify_proof(proof: *const c_char, fork_name: *const c_char, task_type: TaskT
             tracing::error!("{:?} verify failed, error: {:#}", task_type, e);
             false as c_char
         }
-        Ok(result) => result as c_char,
+        Ok(result) => {
+            if !result && enable_dump() {
+                use std::time::{SystemTime, UNIX_EPOCH};
+                // Dump req.input to a temporary file
+                let timestamp = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let filename = format!("/tmp/proof_{}.json", timestamp);
+                let cstr = unsafe { std::ffi::CStr::from_ptr(proof_str) };
+                if let Err(e) = std::fs::write(&filename, cstr.to_bytes()) {
+                    eprintln!("Failed to write proof to file {}: {}", filename, e);
+                } else {
+                    println!("Dumped failed proof to {}", filename);
+                }
+            }
+            result as c_char
+        }
     }
 }
 
@@ -167,6 +195,22 @@ pub unsafe extern "C" fn gen_universal_task(
             expected_pi_hash,
         }
     } else {
+        if enable_dump() {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            // Dump req.input to a temporary file
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let c_str = unsafe { std::ffi::CStr::from_ptr(fork_name) };
+            let filename = format!("/tmp/task_{}_{}.json", c_str.to_str().unwrap(), timestamp);
+            if let Err(e) = std::fs::write(&filename, task_json.as_bytes()) {
+                eprintln!("Failed to write task to file {}: {}", filename, e);
+            } else {
+                println!("Dumped failed task to {}", filename);
+            }
+        }
+
         tracing::error!("gen_universal_task failed, error: {:#}", ret.unwrap_err());
         failed_handling_result()
     }

--- a/crates/prover-bin/src/main.rs
+++ b/crates/prover-bin/src/main.rs
@@ -5,9 +5,10 @@ mod zk_circuits_handler;
 use clap::{ArgAction, Parser, Subcommand};
 use prover::{LocalProver, LocalProverConfig};
 use scroll_proving_sdk::{
-    prover::ProverBuilder,
+    prover::{types::ProofType, ProverBuilder},
     utils::{get_version, init_tracing},
 };
+use std::{fs::File, io::BufReader, path::Path};
 
 #[derive(Parser, Debug)]
 #[command(disable_version_flag = true)]
@@ -38,6 +39,17 @@ enum Commands {
         /// path to save the verifier's asset
         asset_path: String,
     },
+    Handle {
+        /// path to save the verifier's asset
+        task_path: String,
+    },
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct HandleSet {
+    chunks: Vec<String>,
+    batches: Vec<String>,
+    bundles: Vec<String>,
 }
 
 #[tokio::main]
@@ -61,6 +73,40 @@ async fn main() -> eyre::Result<()> {
             let fork_name = args.fork_name.unwrap_or(default_fork_name);
             println!("dump assets for {fork_name} into {asset_path}");
             local_prover.dump_verifier_assets(&fork_name, asset_path.as_ref())?;
+        }
+        Some(Commands::Handle { task_path }) => {
+            let file = File::open(Path::new(&task_path))?;
+            let reader = BufReader::new(file);
+            let handle_set: HandleSet = serde_json::from_reader(reader)?;
+
+            let prover = ProverBuilder::new(sdk_config, local_prover)
+                .build()
+                .await
+                .map_err(|e| eyre::eyre!("build prover fail: {e}"))?;
+
+            let prover = std::sync::Arc::new(prover);
+            println!("Handling task set 1: chunks ...");
+            assert!(
+                prover
+                    .clone()
+                    .one_shot(&handle_set.chunks, ProofType::Chunk)
+                    .await
+            );
+            println!("Done! Handling task set 2: batches ...");
+            assert!(
+                prover
+                    .clone()
+                    .one_shot(&handle_set.batches, ProofType::Batch)
+                    .await
+            );
+            println!("Done! Handling task set 3: bundles ...");
+            assert!(
+                prover
+                    .clone()
+                    .one_shot(&handle_set.bundles, ProofType::Bundle)
+                    .await
+            );
+            println!("All done!");
         }
         None => {
             let prover = ProverBuilder::new(sdk_config, local_prover)

--- a/crates/prover-bin/src/prover.rs
+++ b/crates/prover-bin/src/prover.rs
@@ -203,6 +203,10 @@ impl LocalProver {
             .get(hard_fork_name)
             .ok_or_else(|| eyre::eyre!("no corresponding config for fork {hard_fork_name}"))?;
 
+        if !config.vks.is_empty() {
+            eyre::bail!("clean vks cache first or we will have wrong dumped vk");
+        }
+
         let workspace_path = &config.workspace_path;
         let universal_prover = EuclidV2Handler::new(config);
         let _ = universal_prover

--- a/zkvm-prover/Makefile
+++ b/zkvm-prover/Makefile
@@ -3,7 +3,7 @@
 RUST_MIN_STACK ?= 16777216
 export RUST_MIN_STACK
 
-CIRCUIT_STUFF = .work/chunk/app.vmexe .work/batch/app.vmexe .work/bundle/app.vmexe
+CIRCUIT_STUFF = .work/euclid/chunk/app.vmexe .work/feynman/chunk/app.vmexe
 
 ifeq (4.3,$(firstword $(sort $(MAKE_VERSION) 4.3)))
     PLONKY3_VERSION=$(shell grep -m 1 "Plonky3.git" ../Cargo.lock | cut -d "#" -f2 | cut -c-7)
@@ -21,7 +21,7 @@ endif
 ZKVM_COMMIT=$(shell echo ${ZKVM_VERSION} | cut -d " " -f2)
 $(info ZKVM_COMMIT is ${ZKVM_COMMIT})
 
-#PLONKY3_GPU_VERSION=$(shell ./print_plonky3gpu_version.sh | sed -n '2p')
+$(info PLONKY3_VERSION is ${PLONKY3_VERSION})
 
 GIT_REV=$(shell git rev-parse --short HEAD)
 GO_TAG=$(shell grep "var tag = " ../common/version/version.go | cut -d "\"" -f2)
@@ -33,25 +33,15 @@ else
 endif
 
 ZK_VERSION=${ZKVM_COMMIT}-${PLONKY3_VERSION}
-#ifeq (${PLONKY3_GPU_VERSION},)
-#	# use plonky3 with CPU
-#    ZK_VERSION=${ZKVM_COMMIT}-${PLONKY3_VERSION}
-#else
-#	# use gpu
-#    ZK_VERSION=${ZKVM_COMMIT}-${PLONKY3_GPU_VERSION}
-#endif
 
-prover_gpu:
-	cd ../crates/gpu_override && cargo tree >/dev/null
-	$(eval PLONKY3_GPU_VERSION:=$(shell ./print_plonky3gpu_version.sh | sed -n '2p'))
-	$(eval ZK_VERSION:=${ZKVM_COMMIT}-${PLONKY3_GPU_VERSION})
-	@echo "Updated ZK_VERSION to ${ZK_VERSION} after prover_gpu"
+E2E_HANDLE_SET = ../tests/prover-e2e/testset.json
+DUMP_DIR = .work
 
-prover: prover_gpu
-	cd ../crates/gpu_override && GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build --release -p prover
+prover:
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZKVM_COMMIT=${ZKVM_COMMIT} $(MAKE) -C ../crates/gpu_override build
 
 prover_cpu:
-	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build --release -p prover
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build --locked --release -p prover
 
 
 tests_binary:
@@ -64,7 +54,15 @@ lint:
 	cargo fmt --all
 
 $(CIRCUIT_STUFF):
-	bash .work/download-release.sh
+	@echo "Download stuff with download-release.sh, and put them into correct directory";
+	@exit 1;
 
 test_run: $(CIRCUIT_STUFF)
 	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo run --release -p prover -- --config ./config.json
+
+test_e2e_run: $(CIRCUIT_STUFF) ${E2E_HANDLE_SET}
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo run --release -p prover -- --config ./config.json handle ${E2E_HANDLE_SET}
+
+gen_verifier_stuff:
+	mkdir -p ${DUMP_DIR}
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo run --release -p prover -- --config ./config.json --forkname feynman dump ${DUMP_DIR}

--- a/zkvm-prover/download-release.sh
+++ b/zkvm-prover/download-release.sh
@@ -3,7 +3,7 @@
 # Define version mapping
 declare -A VERSION_MAP
 VERSION_MAP["euclid"]="0.4.3"
-VERSION_MAP["feynman"]="0.5.0rc0"
+VERSION_MAP["feynman"]="0.5.0rc1"
 
 # release version
 if [ -z "${SCROLL_ZKVM_VERSION}" ]; then

--- a/zkvm-prover/release-verifier-stuff.sh
+++ b/zkvm-prover/release-verifier-stuff.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# release version
+SCROLL_ZKVM_STUFFDIR ?= `realpath .work`
+SCROLL_ZKVM_VERSION ?= 0.5.0rc1
+DIR_OUTPUT="releases/${SCROLL_ZKVM_VERSION}/verifier"
+
+STUFF_FILES=('root-verifier-committed-exe' 'root-verifier-vm-config' 'verifier.bin' 'openVmVk.json')
+
+for stuff_file in "${STUFF_FILES[@]}"; do
+  SRC="${SCROLL_ZKVM_STUFFDIR}/${stuff_file}"
+  TARGET="${DIR_OUTPUT}/${stuff_file}"
+  aws --profile default s3 cp $SRC s3://circuit-release/scroll-zkvm/$TARGET
+done


### PR DESCRIPTION
This PR squash commits from #1694 with all updates towards latest feynman zkvm-prover, include:

+ Update dependencies of libzkp to zkvm-prover's `0.5.0rc1`
+ Support `task_id` argument in `get_task` API, enable prover handle specified task for debugging purpose
+ More debug features, constraint panic within rust code and do not throw into golang side
+ better building scripts, including one-click gpu prover building


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new batch header version and fork, improving compatibility with future protocol updates.
  * Introduced a new CLI subcommand for batch task handling.
  * Added a Makefile and build automation for GPU override components.
  * Added a script to automate uploading verifier artifacts to AWS S3.

* **Improvements**
  * Enhanced error messages for missing blocks and task assignment conflicts.
  * Stricter validation for task assignments and verification key compatibility.
  * Updated dependency versions and references for improved stability.
  * Improved debug and diagnostic output for failed proof verifications and task generation.
  * Refined logic for handling batch, bundle, and chunk tasks, including better handling of parent state roots.
  * Updated Makefiles for streamlined build processes and artifact management.

* **Bug Fixes**
  * Prevented dumping verifier assets when cached verification keys are present to avoid incorrect outputs.

* **Refactor**
  * Simplified panic handling and error formatting in proof validation logic.
  * Updated function and parameter names for clarity and consistency.

* **Chores**
  * Updated configuration files and scripts to reference new dependency tags and branches.
  * Disabled automatic circuit artifact downloads in build scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->