### PR TITLE
[Fix] building failure in gpu image

### DIFF
--- a/crates/gpu_override/Makefile
+++ b/crates/gpu_override/Makefile
@@ -14,8 +14,8 @@ clean:
 
 # build gpu prover, never touch lock file
 build:
-	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --locked --lockfile-path ./Cargo.lock
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock
 
 # update Cargo.lock while override config has been updated
-update:
-	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock
+#update:
+#	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock


### PR DESCRIPTION
Building the gpu image we now use local patch, which cause the lock file changed and `--lock` option block the building

This PR raise the option temporarily until we have update the docker file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to allow building without strict lock file enforcement.
  * Disabled the update command in the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->