### PR TITLE
upgrade circuit to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,7 +1273,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1694,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3690,7 +3690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4248,7 +4248,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -6805,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6843,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-eips 1.0.16",
  "alloy-primitives",
@@ -6864,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6876,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6931,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6944,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7048,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7077,7 +7077,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7091,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -7117,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7128,7 +7128,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7150,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-eips 1.0.16",
  "alloy-primitives",
@@ -7166,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7204,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "zstd",
 ]
@@ -8145,7 +8145,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "sbv-core"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#a4d0e2302ffd3ecbeef29e16ddeb361084358f7b"
 dependencies = [
  "sbv-helpers",
  "sbv-kv",
@@ -8158,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "sbv-helpers"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#a4d0e2302ffd3ecbeef29e16ddeb361084358f7b"
 dependencies = [
  "tracing",
 ]
@@ -8166,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "sbv-kv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#a4d0e2302ffd3ecbeef29e16ddeb361084358f7b"
 dependencies = [
  "auto_impl",
  "hashbrown 0.15.3",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "sbv-precompile"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#a4d0e2302ffd3ecbeef29e16ddeb361084358f7b"
 dependencies = [
  "sbv-primitives",
 ]
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "sbv-primitives"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#a4d0e2302ffd3ecbeef29e16ddeb361084358f7b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8222,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "sbv-trie"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#a4d0e2302ffd3ecbeef29e16ddeb361084358f7b"
 dependencies = [
  "alloy-rlp",
  "alloy-trie",
@@ -8289,7 +8289,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8305,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-evm"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8323,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-hardforks"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -8333,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-network"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
+source = "git+https://github.com/scroll-tech/reth?rev=090d7950d169abbfb896875a7b1ff3f8ca356ac8#090d7950d169abbfb896875a7b1ff3f8ca356ac8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8433,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8453,7 +8453,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.16",
@@ -8468,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "alloy-primitives",
  "halo2curves-axiom",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#8f29f60cc73495e8586338a67433a812097427c4"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1694,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3690,7 +3690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4248,7 +4248,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4424,13 +4424,13 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.16",
  "getrandom 0.3.3",
  "num-bigint 0.4.6",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-platform 1.3.0",
  "openvm-rv32im-guest 1.3.0",
  "serde",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "openvm-macros-common 1.3.0",
  "quote",
@@ -4504,14 +4504,14 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
  "once_cell",
  "openvm-algebra-complex-macros 1.3.0",
  "openvm-algebra-moduli-macros 1.3.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-rv32im-guest 1.3.0",
  "serde-big-array",
  "strum_macros 0.26.4",
@@ -4532,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4775,7 +4775,7 @@ dependencies = [
  "once_cell",
  "openvm 1.3.0",
  "openvm-algebra-guest 1.3.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-ecc-sw-macros 1.3.0",
  "openvm-rv32im-guest 1.3.0",
  "serde",
@@ -4795,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "openvm-macros-common 1.3.0",
  "quote",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "syn 2.0.101",
 ]
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -5038,7 +5038,7 @@ dependencies = [
  "openvm-algebra-complex-macros 1.3.0",
  "openvm-algebra-guest 1.3.0",
  "openvm-algebra-moduli-macros 1.3.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-ecc-guest 1.3.0",
  "openvm-ecc-sw-macros 1.3.0",
  "openvm-pairing-guest 1.3.0",
@@ -5103,7 +5103,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal",
@@ -5114,7 +5114,7 @@ dependencies = [
  "openvm 1.3.0",
  "openvm-algebra-guest 1.3.0",
  "openvm-algebra-moduli-macros 1.3.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-ecc-guest 1.3.0",
  "rand 0.8.5",
  "serde",
@@ -5148,10 +5148,10 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "libm",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-rv32im-guest 1.3.0",
 ]
 
@@ -5228,9 +5228,9 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "p3-field 0.1.0",
  "strum_macros 0.26.4",
 ]
@@ -5308,7 +5308,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "openvm-sha256-guest 1.3.0",
  "sha2 0.10.9",
@@ -5359,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.3.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422#4973d38cb3f2e14ebdd59e03802e65bb657ee422"
+source = "git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0#5368d4756993fc1e51092499a816867cf4808de0"
 dependencies = [
  "openvm-platform 1.3.0",
 ]
@@ -6805,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6843,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-eips 1.0.16",
  "alloy-primitives",
@@ -6864,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -6876,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6931,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -6944,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-chainspec"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7031,6 +7031,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-serde 1.0.16",
+ "auto_impl",
  "derive_more 2.0.1",
  "once_cell",
  "reth-chainspec",
@@ -7047,7 +7048,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-evm"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7062,6 +7063,7 @@ dependencies = [
  "reth-scroll-chainspec",
  "reth-scroll-forks",
  "reth-scroll-primitives",
+ "reth-storage-api",
  "revm 26.0.1",
  "revm-primitives 20.0.0",
  "revm-scroll",
@@ -7075,7 +7077,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-forks"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7089,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "reth-scroll-primitives"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7106,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -7115,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -7126,7 +7128,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7148,7 +7150,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-eips 1.0.16",
  "alloy-primitives",
@@ -7164,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -7186,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7202,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7218,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "zstd",
 ]
@@ -8143,7 +8145,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "sbv-core"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "sbv-helpers",
  "sbv-kv",
@@ -8156,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "sbv-helpers"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "tracing",
 ]
@@ -8164,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "sbv-kv"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "auto_impl",
  "hashbrown 0.15.3",
@@ -8174,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "sbv-precompile"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "sbv-primitives",
 ]
@@ -8182,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "sbv-primitives"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8220,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "sbv-trie"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "alloy-rlp",
  "alloy-trie",
@@ -8235,7 +8237,7 @@ dependencies = [
 [[package]]
 name = "sbv-utils"
 version = "2.0.0"
-source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#9901155469efbe42e2f1fbd4178f4919f3255613"
+source = "git+https://github.com/scroll-tech/stateless-block-verifier?branch=chore%2Fopenvm-1.3#cdae537ea05517ed75514d709b69ffedccbcc420"
 dependencies = [
  "alloy-provider",
  "alloy-transport",
@@ -8287,7 +8289,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scroll-alloy-consensus"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8303,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-evm"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8321,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-hardforks"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -8331,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-network"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8346,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "scroll-alloy-rpc-types"
 version = "1.5.0"
-source = "git+https://github.com/scroll-tech/reth?rev=aad1706d3deaf50e0b92a1d005f7228ac52082f8#aad1706d3deaf50e0b92a1d005f7228ac52082f8"
+source = "git+https://github.com/scroll-tech/reth?rev=9fe19092523d5ec4071cd12b5ce924d4c39e46c8#9fe19092523d5ec4071cd12b5ce924d4c39e46c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 1.0.16",
@@ -8393,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8431,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8451,7 +8453,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.16",
@@ -8466,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "alloy-primitives",
  "halo2curves-axiom",
@@ -8486,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8499,12 +8501,12 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
  "openvm 1.3.0",
- "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=4973d38cb3f2e14ebdd59e03802e65bb657ee422)",
+ "openvm-custom-insn 0.1.0 (git+https://github.com/openvm-org/openvm.git?rev=5368d4756993fc1e51092499a816867cf4808de0)",
  "openvm-rv32im-guest 1.3.0",
  "revm-precompile 21.0.0 (git+https://github.com/scroll-tech/revm?branch=feat%2Freth-v74)",
  "rkyv",
@@ -8519,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.5.0rc1#0eb4c11df4909dc6096dfc98875038385578264a"
+source = "git+https://github.com/scroll-tech/zkvm-prover?branch=feat%2F0.5.1#764474052b92719bdc8469a35ec798e66ba122f2"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ repository = "https://github.com/scroll-tech/scroll"
 version = "4.5.8"
 
 [workspace.dependencies]
-scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.5.0rc1", package = "scroll-zkvm-prover" }
-scroll-zkvm-verifier-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.5.0rc1", package = "scroll-zkvm-verifier" }
-scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.5.0rc1" }
+scroll-zkvm-prover-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", branch = "feat/0.5.1", package = "scroll-zkvm-prover" }
+scroll-zkvm-verifier-euclid = { git = "https://github.com/scroll-tech/zkvm-prover", branch = "feat/0.5.1", package = "scroll-zkvm-verifier" }
+scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", branch = "feat/0.5.1" }
 
 sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3", features = ["scroll"] }
 sbv-utils = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3" }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.31"
+var tag = "v4.5.32"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/crates/l2geth/src/rpc_client.rs
+++ b/crates/l2geth/src/rpc_client.rs
@@ -115,7 +115,12 @@ impl ChunkInterpreter for RpcClient<'_> {
                 eyre::bail!("no number in header or use block 0");
             }
 
-            let prev_state_root = if let Some(witness) = prev_witness {
+            let mut witness_builder = WitnessBuilder::new()
+                .block(block)
+                .chain_id(chain_id)
+                .execution_witness(provider.debug_execution_witness(number.into()).await?);
+
+            if let Some(witness) = prev_witness {
                 if witness.header.number != number - 1 {
                     eyre::bail!(
                         "the ref witness is not the previous block, expected {} get {}",
@@ -123,23 +128,10 @@ impl ChunkInterpreter for RpcClient<'_> {
                         witness.header.number,
                     );
                 }
-                witness.header.state_root
-            } else {
-                provider
-                    .scroll_disk_root((number - 1).into())
-                    .await?
-                    .disk_root
-            };
+                witness_builder = witness_builder.prev_state_root(witness.header.state_root);
+            }
 
-            let witness = WitnessBuilder::new()
-                .block(block)
-                .chain_id(chain_id)
-                .execution_witness(provider.debug_execution_witness(number.into()).await?)
-                .state_root(provider.scroll_disk_root(number.into()).await?.disk_root)?
-                .prev_state_root(prev_state_root)
-                .build()?;
-
-            Ok(witness)
+            Ok(witness_builder.build()?)
         }
 
         tracing::debug!("fetch witness for {block_hash}");


### PR DESCRIPTION
### Purpose or design rationale of this PR

coordinator: re-build docker
prover: use 0.5.2 assets


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated certain dependencies to track a development branch instead of a fixed release candidate.
  * Minor formatting improvement by adding a newline at the end of the configuration section.
  * Updated version tag to v4.5.32.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->