### PR TITLE
fix(rollup-relayer): upgrade boundary message queue hash initialization

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.33"
+var tag = "v4.5.34"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -271,7 +271,7 @@ func (p *ChunkProposer) proposeChunk() error {
 	chunk.PrevL1MessageQueueHash = common.HexToHash(parentChunk.PostL1MessageQueueHash)
 
 	// previous chunk is before CodecV7, this means this is the first chunk of the fork.
-	if encoding.CodecVersion(parentChunk.CodecVersion) < encoding.CodecV7 && encoding.CodecVersion(parentChunk.CodecVersion) < codecVersion {
+	if encoding.CodecVersion(parentChunk.CodecVersion) == encoding.CodecV6 && codecVersion == encoding.CodecV7 {
 		chunk.PrevL1MessageQueueHash = common.Hash{}
 	}
 

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -268,6 +268,7 @@ func (p *ChunkProposer) proposeChunk() error {
 		return fmt.Errorf("failed to get parent chunk: %w", err)
 	}
 
+	// Currently rollup-relayer only supports >= v7 codec version, it checks the minimum codec version after start.
 	// In EuclidV2 transition, empty PostL1MessageQueueHash will be naturally initialized to the first chunk's PrevL1MessageQueueHash.
 	chunk.PrevL1MessageQueueHash = common.HexToHash(parentChunk.PostL1MessageQueueHash)
 	chunk.PostL1MessageQueueHash = chunk.PrevL1MessageQueueHash

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -270,8 +270,8 @@ func (p *ChunkProposer) proposeChunk() error {
 
 	chunk.PrevL1MessageQueueHash = common.HexToHash(parentChunk.PostL1MessageQueueHash)
 
-	// previous chunk is not CodecV7, this means this is the first chunk of the fork.
-	if encoding.CodecVersion(parentChunk.CodecVersion) < codecVersion {
+	// previous chunk is before CodecV7, this means this is the first chunk of the fork.
+	if encoding.CodecVersion(parentChunk.CodecVersion) < encoding.CodecV7 && encoding.CodecVersion(parentChunk.CodecVersion) < codecVersion {
 		chunk.PrevL1MessageQueueHash = common.Hash{}
 	}
 

--- a/rollup/internal/controller/watcher/chunk_proposer.go
+++ b/rollup/internal/controller/watcher/chunk_proposer.go
@@ -268,13 +268,8 @@ func (p *ChunkProposer) proposeChunk() error {
 		return fmt.Errorf("failed to get parent chunk: %w", err)
 	}
 
+	// In EuclidV2 transition, empty PostL1MessageQueueHash will be naturally initialized to the first chunk's PrevL1MessageQueueHash.
 	chunk.PrevL1MessageQueueHash = common.HexToHash(parentChunk.PostL1MessageQueueHash)
-
-	// previous chunk is before CodecV7, this means this is the first chunk of the fork.
-	if encoding.CodecVersion(parentChunk.CodecVersion) == encoding.CodecV6 && codecVersion == encoding.CodecV7 {
-		chunk.PrevL1MessageQueueHash = common.Hash{}
-	}
-
 	chunk.PostL1MessageQueueHash = chunk.PrevL1MessageQueueHash
 
 	var previousPostL1MessageQueueHash common.Hash


### PR DESCRIPTION
### Purpose or design rationale of this PR

Fixes a regression error.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version number to v4.5.34.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->