### PR TITLE
fix: update contract deployment link

### DIFF
--- a/common/bytecode/README.md
+++ b/common/bytecode/README.md
@@ -1,5 +1,5 @@
 ## How to pre deploy contracts?
-* Please reference to https://github.com/scroll-tech/genesis-creator.
+* Please reference to https://github.com/scroll-tech/scroll-contract-deploy-demo.
 1. Setup env
 ```bash
    git clone git@github.com:scroll-tech/genesis-creator.git


### PR DESCRIPTION
was checking out the contract deployment section in repo and found out the broken link, idk if it's the right one I fixed, but just wanna let you know there's a broken link in common/bytecode/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reference the new URL for pre-deploying contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->