### PR TITLE
fix(gas-oracle): nonce too low when resubmission

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.35"
+var tag = "v4.5.36"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -648,10 +648,19 @@ func (s *Sender) checkPendingTransaction() {
 			if err := s.client.SendTransaction(s.ctx, newSignedTx); err != nil {
 				if strings.Contains(err.Error(), "nonce too low") {
 					// When we receive a 'nonce too low' error but cannot find the transaction receipt, it indicates another transaction with this nonce has already been processed, so this transaction will never be mined and should be marked as failed.
-					log.Warn("nonce too low detected, marking all non-confirmed transactions with same nonce as failed", "nonce", originalTx.Nonce(), "address", s.transactionSigner.GetAddr().Hex(), "txHash", originalTx.Hash().Hex(), "err", err)
+					log.Warn("nonce too low detected, marking all non-confirmed transactions with same nonce as failed", "nonce", originalTx.Nonce(), "address", s.transactionSigner.GetAddr().Hex(), "txHash", originalTx.Hash().Hex(), "newTxHash", newSignedTx.Hash().Hex(), "err", err)
 
-					if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, originalTx.Hash(), types.TxStatusConfirmedFailed); updateErr != nil {
-						log.Error("failed to update status of original transaction to confirmed failed", "txHash", originalTx.Hash().Hex(), "nonce", originalTx.Nonce(), "from", s.transactionSigner.GetAddr().Hex(), "err", updateErr)
+					// Handle both original and replacement transactions in a database transaction
+					if dbErr := s.db.Transaction(func(dbTX *gorm.DB) error {
+						if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, originalTx.Hash(), types.TxStatusConfirmedFailed, dbTX); updateErr != nil {
+							return fmt.Errorf("failed to update original transaction status, hash: %s, err: %w", originalTx.Hash().Hex(), updateErr)
+						}
+						if updateErr := s.pendingTransactionOrm.DeleteTransactionByTxHash(s.ctx, newSignedTx.Hash(), dbTX); updateErr != nil {
+							return fmt.Errorf("failed to delete replacement transaction, hash: %s, err: %w", newSignedTx.Hash().Hex(), updateErr)
+						}
+						return nil
+					}); dbErr != nil {
+						log.Error("failed to handle nonce too low scenario in database", "err", dbErr)
 						return
 					}
 					return

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -655,8 +655,9 @@ func (s *Sender) checkPendingTransaction() {
 						if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, originalTx.Hash(), types.TxStatusConfirmedFailed, dbTX); updateErr != nil {
 							return fmt.Errorf("failed to update original transaction status, hash: %s, err: %w", originalTx.Hash().Hex(), updateErr)
 						}
-						if updateErr := s.pendingTransactionOrm.DeleteTransactionByTxHash(s.ctx, newSignedTx.Hash(), dbTX); updateErr != nil {
-							return fmt.Errorf("failed to delete replacement transaction, hash: %s, err: %w", newSignedTx.Hash().Hex(), updateErr)
+						// Mark the replacement transaction as failed
+						if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, newSignedTx.Hash(), types.TxStatusConfirmedFailed, dbTX); updateErr != nil {
+							return fmt.Errorf("failed to update replacement transaction status, hash: %s, err: %w", newSignedTx.Hash().Hex(), updateErr)
 						}
 						return nil
 					}); dbErr != nil {

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -105,12 +105,29 @@ func NewSender(ctx context.Context, config *config.SenderConfig, signerConfig *c
 		return nil, fmt.Errorf("failed to create transaction signer, err: %w", err)
 	}
 
-	// Set pending nonce
-	nonce, err := client.PendingNonceAt(ctx, transactionSigner.GetAddr())
+	// Get maximum nonce from database
+	dbNonce, err := orm.NewPendingTransaction(db).GetMaxNonceBySenderAddress(ctx, transactionSigner.GetAddr().Hex())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pending nonce for address %s, err: %w", transactionSigner.GetAddr(), err)
+		return nil, fmt.Errorf("failed to get max nonce from database for address %s, err: %w", transactionSigner.GetAddr().Hex(), err)
 	}
-	transactionSigner.SetNonce(nonce)
+
+	// Get pending nonce from the client
+	pendingNonce, err := client.PendingNonceAt(ctx, transactionSigner.GetAddr())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pending nonce for address %s, err: %w", transactionSigner.GetAddr().Hex(), err)
+	}
+
+	// Take the maximum of both values
+	var finalNonce uint64
+	if pendingNonce > dbNonce {
+		finalNonce = pendingNonce
+	} else {
+		finalNonce = dbNonce
+	}
+
+	log.Info("nonce initialization", "address", transactionSigner.GetAddr().Hex(), "pendingNonce", pendingNonce, "dbNonce", dbNonce, "finalNonce", finalNonce)
+
+	transactionSigner.SetNonce(finalNonce)
 
 	sender := &Sender{
 		ctx:                   ctx,
@@ -612,19 +629,14 @@ func (s *Sender) checkPendingTransaction() {
 			}
 
 			if err := s.client.SendTransaction(s.ctx, newSignedTx); err != nil {
-				// Check if it's a nonce too low error
 				if strings.Contains(err.Error(), "nonce too low") {
-					// nonce too low means a transaction with this nonce has already been mined
-					// Mark all non-confirmed transactions with the same nonce as failed
-					if updateErr := s.pendingTransactionOrm.UpdateNonConfirmedTransactionsAsFailedByNonce(s.ctx, txnToCheck.SenderAddress, originalTx.Nonce()); updateErr != nil {
-						log.Error("failed to update transactions as failed by nonce", "nonce", originalTx.Nonce(), "senderAddress", txnToCheck.SenderAddress, "err", updateErr)
+					// When we receive a 'nonce too low' error but cannot find the transaction receipt, it indicates another transaction with this nonce has already been processed, so this transaction will never be mined and should be marked as failed.
+					log.Warn("nonce too low detected, marking all non-confirmed transactions with same nonce as failed", "nonce", originalTx.Nonce(), "address", s.transactionSigner.GetAddr().Hex(), "txHash", originalTx.Hash().Hex(), "err", err)
+
+					if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, originalTx.Hash(), types.TxStatusConfirmedFailed); updateErr != nil {
+						log.Error("failed to update status of original transaction to confirmed failed", "txHash", originalTx.Hash().Hex(), "nonce", originalTx.Nonce(), "from", s.transactionSigner.GetAddr().Hex(), "err", updateErr)
 						return
 					}
-
-					// Reset nonce
-					s.resetNonce(context.Background())
-
-					log.Info("nonce too low detected, marked all non-confirmed transactions with same nonce as failed", "nonce", originalTx.Nonce(), "address", s.transactionSigner.GetAddr().String())
 					return
 				}
 				// SendTransaction failed, need to rollback the previous database changes

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -612,6 +612,21 @@ func (s *Sender) checkPendingTransaction() {
 			}
 
 			if err := s.client.SendTransaction(s.ctx, newSignedTx); err != nil {
+				// Check if it's a nonce too low error
+				if strings.Contains(err.Error(), "nonce too low") {
+					// nonce too low means a transaction with this nonce has already been mined
+					// Mark all non-confirmed transactions with the same nonce as failed
+					if updateErr := s.pendingTransactionOrm.UpdateNonConfirmedTransactionsAsFailedByNonce(s.ctx, txnToCheck.SenderAddress, originalTx.Nonce()); updateErr != nil {
+						log.Error("failed to update transactions as failed by nonce", "nonce", originalTx.Nonce(), "senderAddress", txnToCheck.SenderAddress, "err", updateErr)
+						return
+					}
+
+					// Reset nonce
+					s.resetNonce(context.Background())
+
+					log.Info("nonce too low detected, marked all non-confirmed transactions with same nonce as failed", "nonce", originalTx.Nonce(), "address", s.transactionSigner.GetAddr().String())
+					return
+				}
 				// SendTransaction failed, need to rollback the previous database changes
 				if rollbackErr := s.db.Transaction(func(tx *gorm.DB) error {
 					// Restore original transaction status back to pending

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -63,7 +63,7 @@ type FeeData struct {
 	gasLimit uint64
 }
 
-// Sender Transaction sender to send transaction to l1/l2 geth
+// Sender Transaction sender to send transaction to l1/l2
 type Sender struct {
 	config            *config.SenderConfig
 	gethClient        *gethclient.Client
@@ -105,30 +105,7 @@ func NewSender(ctx context.Context, config *config.SenderConfig, signerConfig *c
 		return nil, fmt.Errorf("failed to create transaction signer, err: %w", err)
 	}
 
-	// Get maximum nonce from database
-	dbNonce, err := orm.NewPendingTransaction(db).GetMaxNonceBySenderAddress(ctx, transactionSigner.GetAddr().Hex())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get max nonce from database for address %s, err: %w", transactionSigner.GetAddr().Hex(), err)
-	}
-
-	// Get pending nonce from the client
-	pendingNonce, err := client.PendingNonceAt(ctx, transactionSigner.GetAddr())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pending nonce for address %s, err: %w", transactionSigner.GetAddr().Hex(), err)
-	}
-
-	// Take the maximum of both values
-	var finalNonce uint64
-	if pendingNonce > dbNonce {
-		finalNonce = pendingNonce
-	} else {
-		finalNonce = dbNonce
-	}
-
-	log.Info("nonce initialization", "address", transactionSigner.GetAddr().Hex(), "pendingNonce", pendingNonce, "dbNonce", dbNonce, "finalNonce", finalNonce)
-
-	transactionSigner.SetNonce(finalNonce)
-
+	// Create sender instance first and then initialize nonce
 	sender := &Sender{
 		ctx:                   ctx,
 		config:                config,
@@ -144,8 +121,13 @@ func NewSender(ctx context.Context, config *config.SenderConfig, signerConfig *c
 		service:               service,
 		senderType:            senderType,
 	}
-	sender.metrics = initSenderMetrics(reg)
 
+	// Initialize nonce using the new method
+	if err := sender.resetNonce(); err != nil {
+		return nil, fmt.Errorf("failed to reset nonce: %w", err)
+	}
+
+	sender.metrics = initSenderMetrics(reg)
 	go sender.loop(ctx)
 
 	return sender, nil
@@ -259,7 +241,10 @@ func (s *Sender) SendTransaction(contextID string, target *common.Address, data 
 		// Check if contain nonce, and reset nonce
 		// only reset nonce when it is not from resubmit
 		if strings.Contains(err.Error(), "nonce too low") {
-			s.resetNonce(context.Background())
+			if err := s.resetNonce(); err != nil {
+				log.Warn("failed to reset nonce after failed send transaction", "address", s.transactionSigner.GetAddr().String(), "err", err)
+				return common.Hash{}, 0, fmt.Errorf("failed to reset nonce after failed send transaction, err: %w", err)
+			}
 		}
 		return common.Hash{}, 0, fmt.Errorf("failed to send transaction, err: %w", err)
 	}
@@ -344,14 +329,46 @@ func (s *Sender) createTx(feeData *FeeData, target *common.Address, data []byte,
 	return signedTx, nil
 }
 
-// resetNonce reset nonce if send signed tx failed.
-func (s *Sender) resetNonce(ctx context.Context) {
-	nonce, err := s.client.PendingNonceAt(ctx, s.transactionSigner.GetAddr())
+// initializeNonce initializes the nonce by taking the maximum of database nonce and pending nonce.
+func (s *Sender) initializeNonce() (uint64, error) {
+	// Get maximum nonce from database
+	dbNonce, err := s.pendingTransactionOrm.GetMaxNonceBySenderAddress(s.ctx, s.transactionSigner.GetAddr().Hex())
 	if err != nil {
-		log.Warn("failed to reset nonce", "address", s.transactionSigner.GetAddr().String(), "err", err)
-		return
+		return 0, fmt.Errorf("failed to get max nonce from database for address %s, err: %w", s.transactionSigner.GetAddr().Hex(), err)
 	}
+
+	// Get pending nonce from the client
+	pendingNonce, err := s.client.PendingNonceAt(s.ctx, s.transactionSigner.GetAddr())
+	if err != nil {
+		return 0, fmt.Errorf("failed to get pending nonce for address %s, err: %w", s.transactionSigner.GetAddr().Hex(), err)
+	}
+
+	// Take the maximum of pending nonce and (db nonce + 1)
+	// Database stores the used nonce, so the next available nonce should be dbNonce + 1
+	// When dbNonce is -1 (no records), dbNonce + 1 = 0, which is correct
+	nextDbNonce := uint64(dbNonce + 1)
+	var finalNonce uint64
+	if pendingNonce > nextDbNonce {
+		finalNonce = pendingNonce
+	} else {
+		finalNonce = nextDbNonce
+	}
+
+	log.Info("nonce initialization", "address", s.transactionSigner.GetAddr().Hex(), "maxDbNonce", dbNonce, "nextDbNonce", nextDbNonce, "pendingNonce", pendingNonce, "finalNonce", finalNonce)
+
+	return finalNonce, nil
+}
+
+// resetNonce reset nonce if send signed tx failed.
+func (s *Sender) resetNonce() error {
+	nonce, err := s.initializeNonce()
+	if err != nil {
+		log.Error("failed to reset nonce", "address", s.transactionSigner.GetAddr().String(), "err", err)
+		return fmt.Errorf("failed to reset nonce, err: %w", err)
+	}
+	log.Info("reset nonce", "address", s.transactionSigner.GetAddr().String(), "nonce", nonce)
 	s.transactionSigner.SetNonce(nonce)
+	return nil
 }
 
 func (s *Sender) createReplacingTransaction(tx *gethTypes.Transaction, baseFee, blobBaseFee uint64) (*gethTypes.Transaction, error) {

--- a/rollup/internal/controller/sender/sender.go
+++ b/rollup/internal/controller/sender/sender.go
@@ -649,19 +649,9 @@ func (s *Sender) checkPendingTransaction() {
 				if strings.Contains(err.Error(), "nonce too low") {
 					// When we receive a 'nonce too low' error but cannot find the transaction receipt, it indicates another transaction with this nonce has already been processed, so this transaction will never be mined and should be marked as failed.
 					log.Warn("nonce too low detected, marking all non-confirmed transactions with same nonce as failed", "nonce", originalTx.Nonce(), "address", s.transactionSigner.GetAddr().Hex(), "txHash", originalTx.Hash().Hex(), "newTxHash", newSignedTx.Hash().Hex(), "err", err)
-
-					// Handle both original and replacement transactions in a database transaction
-					if dbErr := s.db.Transaction(func(dbTX *gorm.DB) error {
-						if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, originalTx.Hash(), types.TxStatusConfirmedFailed, dbTX); updateErr != nil {
-							return fmt.Errorf("failed to update original transaction status, hash: %s, err: %w", originalTx.Hash().Hex(), updateErr)
-						}
-						// Mark the replacement transaction as failed
-						if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHash(s.ctx, newSignedTx.Hash(), types.TxStatusConfirmedFailed, dbTX); updateErr != nil {
-							return fmt.Errorf("failed to update replacement transaction status, hash: %s, err: %w", newSignedTx.Hash().Hex(), updateErr)
-						}
-						return nil
-					}); dbErr != nil {
-						log.Error("failed to handle nonce too low scenario in database", "err", dbErr)
+					txHashes := []string{originalTx.Hash().Hex(), newSignedTx.Hash().Hex()}
+					if updateErr := s.pendingTransactionOrm.UpdateTransactionStatusByTxHashes(s.ctx, txHashes, types.TxStatusConfirmedFailed); updateErr != nil {
+						log.Error("failed to update transaction status", "hashes", txHashes, "err", updateErr)
 						return
 					}
 					return

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -603,10 +603,10 @@ func TestPendingTransaction_GetMaxNonceBySenderAddress(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, migrate.ResetDB(sqlDB))
 
-	// When there are no transactions for this sender address, should return 0
+	// When there are no transactions for this sender address, should return -1
 	maxNonce, err := pendingTransactionOrm.GetMaxNonceBySenderAddress(context.Background(), "0xdeadbeef")
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(0), maxNonce)
+	assert.Equal(t, int64(-1), maxNonce)
 
 	// Insert two transactions with different nonces for the same sender address
 	senderMeta := &SenderMeta{
@@ -653,5 +653,5 @@ func TestPendingTransaction_GetMaxNonceBySenderAddress(t *testing.T) {
 	// Now the max nonce for this sender should be 3
 	maxNonce, err = pendingTransactionOrm.GetMaxNonceBySenderAddress(context.Background(), senderMeta.Address.String())
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(3), maxNonce)
+	assert.Equal(t, int64(3), maxNonce)
 }

--- a/rollup/internal/orm/orm_test.go
+++ b/rollup/internal/orm/orm_test.go
@@ -597,3 +597,61 @@ func TestPendingTransactionOrm(t *testing.T) {
 	err = pendingTransactionOrm.DeleteTransactionByTxHash(context.Background(), common.HexToHash("0x123"))
 	assert.Error(t, err) // Should return error for non-existent transaction
 }
+
+func TestPendingTransaction_GetMaxNonceBySenderAddress(t *testing.T) {
+	sqlDB, err := db.DB()
+	assert.NoError(t, err)
+	assert.NoError(t, migrate.ResetDB(sqlDB))
+
+	// When there are no transactions for this sender address, should return 0
+	maxNonce, err := pendingTransactionOrm.GetMaxNonceBySenderAddress(context.Background(), "0xdeadbeef")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), maxNonce)
+
+	// Insert two transactions with different nonces for the same sender address
+	senderMeta := &SenderMeta{
+		Name:    "testName",
+		Service: "testService",
+		Address: common.HexToAddress("0xdeadbeef"),
+		Type:    types.SenderTypeCommitBatch,
+	}
+
+	tx0 := gethTypes.NewTx(&gethTypes.DynamicFeeTx{
+		Nonce:      1,
+		To:         &common.Address{},
+		Data:       []byte{},
+		Gas:        21000,
+		AccessList: gethTypes.AccessList{},
+		Value:      big.NewInt(0),
+		ChainID:    big.NewInt(1),
+		GasTipCap:  big.NewInt(0),
+		GasFeeCap:  big.NewInt(1),
+		V:          big.NewInt(0),
+		R:          big.NewInt(0),
+		S:          big.NewInt(0),
+	})
+	tx1 := gethTypes.NewTx(&gethTypes.DynamicFeeTx{
+		Nonce:      3,
+		To:         &common.Address{},
+		Data:       []byte{},
+		Gas:        22000,
+		AccessList: gethTypes.AccessList{},
+		Value:      big.NewInt(0),
+		ChainID:    big.NewInt(1),
+		GasTipCap:  big.NewInt(1),
+		GasFeeCap:  big.NewInt(2),
+		V:          big.NewInt(0),
+		R:          big.NewInt(0),
+		S:          big.NewInt(0),
+	})
+
+	err = pendingTransactionOrm.InsertPendingTransaction(context.Background(), "test", senderMeta, tx0, 0)
+	assert.NoError(t, err)
+	err = pendingTransactionOrm.InsertPendingTransaction(context.Background(), "test", senderMeta, tx1, 0)
+	assert.NoError(t, err)
+
+	// Now the max nonce for this sender should be 3
+	maxNonce, err = pendingTransactionOrm.GetMaxNonceBySenderAddress(context.Background(), senderMeta.Address.String())
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), maxNonce)
+}

--- a/rollup/internal/orm/pending_transaction.go
+++ b/rollup/internal/orm/pending_transaction.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -209,18 +210,23 @@ func (o *PendingTransaction) UpdateOtherTransactionsAsFailedByNonce(ctx context.
 }
 
 // GetMaxNonceBySenderAddress retrieves the maximum nonce for a specific sender address.
-// Returns 0 if no transactions are found for the given address.
-func (o *PendingTransaction) GetMaxNonceBySenderAddress(ctx context.Context, senderAddress string) (uint64, error) {
-	db := o.db.WithContext(ctx)
-	db = db.Model(&PendingTransaction{})
-	db = db.Where("sender_address = ?", senderAddress)
-	var maxNonce uint64
-	row := db.Model(&PendingTransaction{}).
-		Select("COALESCE(MAX(nonce), 0)").
+// Returns -1 if no transactions are found for the given address.
+func (o *PendingTransaction) GetMaxNonceBySenderAddress(ctx context.Context, senderAddress string) (int64, error) {
+	var maxNonce sql.NullInt64
+
+	row := o.db.WithContext(ctx).
+		Model(&PendingTransaction{}).
+		Select("MAX(nonce)").
 		Where("sender_address = ?", senderAddress).
 		Row()
+
 	if err := row.Scan(&maxNonce); err != nil {
-		return 0, fmt.Errorf("failed to get max nonce by sender address, address: %s, err: %w", senderAddress, err)
+		return -1, fmt.Errorf("failed to get max nonce by sender address, address: %s, err: %w", senderAddress, err)
 	}
-	return maxNonce, nil
+
+	if !maxNonce.Valid {
+		return -1, nil
+	}
+
+	return maxNonce.Int64, nil
 }

--- a/rollup/internal/orm/pending_transaction.go
+++ b/rollup/internal/orm/pending_transaction.go
@@ -3,7 +3,7 @@ package orm
 import (
 	"bytes"
 	"context"
-	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -212,21 +212,23 @@ func (o *PendingTransaction) UpdateOtherTransactionsAsFailedByNonce(ctx context.
 // GetMaxNonceBySenderAddress retrieves the maximum nonce for a specific sender address.
 // Returns -1 if no transactions are found for the given address.
 func (o *PendingTransaction) GetMaxNonceBySenderAddress(ctx context.Context, senderAddress string) (int64, error) {
-	var maxNonce sql.NullInt64
+	var result struct {
+		Nonce int64 `gorm:"column:nonce"`
+	}
 
-	row := o.db.WithContext(ctx).
+	err := o.db.WithContext(ctx).
 		Model(&PendingTransaction{}).
-		Select("MAX(nonce)").
+		Select("nonce").
 		Where("sender_address = ?", senderAddress).
-		Row()
+		Order("nonce DESC").
+		First(&result).Error
 
-	if err := row.Scan(&maxNonce); err != nil {
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return -1, nil
+		}
 		return -1, fmt.Errorf("failed to get max nonce by sender address, address: %s, err: %w", senderAddress, err)
 	}
 
-	if !maxNonce.Valid {
-		return -1, nil
-	}
-
-	return maxNonce.Int64, nil
+	return result.Nonce, nil
 }

--- a/rollup/internal/orm/pending_transaction.go
+++ b/rollup/internal/orm/pending_transaction.go
@@ -211,14 +211,16 @@ func (o *PendingTransaction) UpdateOtherTransactionsAsFailedByNonce(ctx context.
 // GetMaxNonceBySenderAddress retrieves the maximum nonce for a specific sender address.
 // Returns 0 if no transactions are found for the given address.
 func (o *PendingTransaction) GetMaxNonceBySenderAddress(ctx context.Context, senderAddress string) (uint64, error) {
-	var maxNonce uint64
 	db := o.db.WithContext(ctx)
 	db = db.Model(&PendingTransaction{})
 	db = db.Where("sender_address = ?", senderAddress)
-
-	if err := db.Pluck("COALESCE(MAX(nonce), 0)", &maxNonce).Error; err != nil {
+	var maxNonce uint64
+	row := db.Model(&PendingTransaction{}).
+		Select("COALESCE(MAX(nonce), 0)").
+		Where("sender_address = ?", senderAddress).
+		Row()
+	if err := row.Scan(&maxNonce); err != nil {
 		return 0, fmt.Errorf("failed to get max nonce by sender address, address: %s, err: %w", senderAddress, err)
 	}
-
 	return maxNonce, nil
 }

--- a/rollup/internal/orm/pending_transaction.go
+++ b/rollup/internal/orm/pending_transaction.go
@@ -208,20 +208,17 @@ func (o *PendingTransaction) UpdateOtherTransactionsAsFailedByNonce(ctx context.
 	return nil
 }
 
-// UpdateNonConfirmedTransactionsAsFailedByNonce updates the status of all non-confirmed transactions to TxStatusConfirmedFailed
-// for a specific nonce and sender address.
-func (o *PendingTransaction) UpdateNonConfirmedTransactionsAsFailedByNonce(ctx context.Context, senderAddress string, nonce uint64, dbTX ...*gorm.DB) error {
-	db := o.db
-	if len(dbTX) > 0 && dbTX[0] != nil {
-		db = dbTX[0]
-	}
-	db = db.WithContext(ctx)
+// GetMaxNonceBySenderAddress retrieves the maximum nonce for a specific sender address.
+// Returns 0 if no transactions are found for the given address.
+func (o *PendingTransaction) GetMaxNonceBySenderAddress(ctx context.Context, senderAddress string) (uint64, error) {
+	var maxNonce uint64
+	db := o.db.WithContext(ctx)
 	db = db.Model(&PendingTransaction{})
 	db = db.Where("sender_address = ?", senderAddress)
-	db = db.Where("nonce = ?", nonce)
-	db = db.Where("status != ?", types.TxStatusConfirmed) // Don't update confirmed transactions
-	if err := db.Update("status", types.TxStatusConfirmedFailed).Error; err != nil {
-		return fmt.Errorf("failed to update non-confirmed transactions as failed by nonce, senderAddress: %s, nonce: %d, error: %w", senderAddress, nonce, err)
+
+	if err := db.Pluck("COALESCE(MAX(nonce), 0)", &maxNonce).Error; err != nil {
+		return 0, fmt.Errorf("failed to get max nonce by sender address, address: %s, err: %w", senderAddress, err)
 	}
-	return nil
+
+	return maxNonce, nil
 }

--- a/rollup/internal/orm/pending_transaction.go
+++ b/rollup/internal/orm/pending_transaction.go
@@ -207,3 +207,21 @@ func (o *PendingTransaction) UpdateOtherTransactionsAsFailedByNonce(ctx context.
 	}
 	return nil
 }
+
+// UpdateNonConfirmedTransactionsAsFailedByNonce updates the status of all non-confirmed transactions to TxStatusConfirmedFailed
+// for a specific nonce and sender address.
+func (o *PendingTransaction) UpdateNonConfirmedTransactionsAsFailedByNonce(ctx context.Context, senderAddress string, nonce uint64, dbTX ...*gorm.DB) error {
+	db := o.db
+	if len(dbTX) > 0 && dbTX[0] != nil {
+		db = dbTX[0]
+	}
+	db = db.WithContext(ctx)
+	db = db.Model(&PendingTransaction{})
+	db = db.Where("sender_address = ?", senderAddress)
+	db = db.Where("nonce = ?", nonce)
+	db = db.Where("status != ?", types.TxStatusConfirmed) // Don't update confirmed transactions
+	if err := db.Update("status", types.TxStatusConfirmedFailed).Error; err != nil {
+		return fmt.Errorf("failed to update non-confirmed transactions as failed by nonce, senderAddress: %s, nonce: %d, error: %w", senderAddress, nonce, err)
+	}
+	return nil
+}

--- a/rollup/internal/orm/pending_transaction.go
+++ b/rollup/internal/orm/pending_transaction.go
@@ -192,6 +192,25 @@ func (o *PendingTransaction) UpdateTransactionStatusByTxHash(ctx context.Context
 	return nil
 }
 
+// UpdateTransactionStatusByTxHashes updates the status of multiple transactions by their hashes in one SQL statement
+func (o *PendingTransaction) UpdateTransactionStatusByTxHashes(ctx context.Context, txHashes []string, status types.TxStatus, dbTX ...*gorm.DB) error {
+	if len(txHashes) == 0 {
+		return nil
+	}
+	db := o.db
+	if len(dbTX) > 0 && dbTX[0] != nil {
+		db = dbTX[0]
+	}
+	db = db.WithContext(ctx)
+	db = db.Model(&PendingTransaction{})
+	db = db.Where("hash IN ?", txHashes)
+	if err := db.Update("status", status).Error; err != nil {
+		return fmt.Errorf("failed to update transaction status for hashes %v to status %d: %w", txHashes, status, err)
+	}
+
+	return nil
+}
+
 // UpdateOtherTransactionsAsFailedByNonce updates the status of all transactions to TxStatusConfirmedFailed for a specific nonce and sender address, excluding a specified transaction hash.
 func (o *PendingTransaction) UpdateOtherTransactionsAsFailedByNonce(ctx context.Context, senderAddress string, nonce uint64, hash common.Hash, dbTX ...*gorm.DB) error {
 	db := o.db


### PR DESCRIPTION
### Purpose or design rationale of this PR

When resubmission receives "nonce too low" error, it means the transaction has already been mined. In such cases sender can skip resubmitting such transactions.

This PR also adds another robustness fix about initializing/resetting nonce by setting it as `max(pending nonce from the nonce, max db's nonce + 1)`.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [x] Yes

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for "nonce too low" cases during transaction resubmission, ensuring affected transactions are marked as failed and the nonce is reset automatically.

* **New Features**
  * Added retrieval of the highest nonce for a sender’s pending transactions to enhance transaction management.

* **Chores**
  * Updated the application version to v4.5.36.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->