### PR TITLE
change l2watcher from w.GetBlockByNumberOrHash to BlockByNumber

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.36"
+var tag = "v4.5.37"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/watcher/l2_watcher.go
+++ b/rollup/internal/controller/watcher/l2_watcher.go
@@ -88,9 +88,9 @@ func (w *L2WatcherClient) getAndStoreBlocks(ctx context.Context, from, to uint64
 	var blocks []*encoding.Block
 	for number := from; number <= to; number++ {
 		log.Debug("retrieving block", "height", number)
-		block, err := w.GetBlockByNumberOrHash(ctx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(number)))
+		block, err := w.BlockByNumber(ctx, new(big.Int).SetUint64(number))
 		if err != nil {
-			return fmt.Errorf("failed to GetBlockByNumberOrHash: %v. number: %v", err, number)
+			return fmt.Errorf("failed to BlockByNumber: %v. number: %v", err, number)
 		}
 
 		var count int


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

```
2025-07-31T09:53:10.044599405Z ERROR[07-31|09:53:10.044|scroll-tech/rollup/internal/controller/watcher/l2_watcher.go:79]       fail to getAndStoreBlockTraces           from=17,114,024 to=17,114,033 err="failed to GetBlockByNumberOrHash: Method not found. number: 17114024"
```

Since reth don't implement scroll_* api, so change getBlock method

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block retrieval logic for more consistent performance during block synchronization.

* **Chores**
  * Updated version number to v4.5.37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->