### PR TITLE
update GitHub actions in CI workflow

### DIFF
--- a/.github/workflows/bridge_history_api.yml
+++ b/.github/workflows/bridge_history_api.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Lint
       run: |
         rm -rf $HOME/.cache/golangci-lint
@@ -48,7 +48,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Test
       run: |
         make test
@@ -67,7 +67,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - run: goimports -local scroll-tech/bridge-history-api/ -w .

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
       - name: check diff

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2
       with:
@@ -56,7 +56,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -81,7 +81,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/coordinator.yml
+++ b/.github/workflows/coordinator.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Lint
       working-directory: 'coordinator'
       run: |
@@ -56,7 +56,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -77,7 +77,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout code
-  #     uses: actions/checkout@v4
+  #     uses: actions/checkout@v5
   #   - name: Set up Docker Buildx
   #     uses: docker/setup-buildx-action@v2
   #   - name: Build and push
@@ -97,7 +97,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Lint
       working-directory: 'database'
       run: |
@@ -49,7 +49,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -74,7 +74,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/docker-coordinator-api-arm64.yml
+++ b/.github/workflows/docker-coordinator-api-arm64.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Set up QEMU
         run: |
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -60,7 +60,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -106,7 +106,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -152,7 +152,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -198,7 +198,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -244,7 +244,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -290,7 +290,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -336,7 +336,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -381,7 +381,7 @@ jobs:
         group: scroll-reth-runner-group
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:

--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:
@@ -60,7 +60,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports
     - name: Run goimports lint
@@ -85,7 +85,7 @@ jobs:
       with:
         go-version: 1.21.x
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Solc
       uses: supplypike/setup-bin@v3
       with:
@@ -117,7 +117,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #   - name: Checkout code
-  #     uses: actions/checkout@v4
+  #     uses: actions/checkout@v5
   #   - name: Set up Docker Buildx
   #     uses: docker/setup-buildx-action@v2
   #   - run: make docker


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded GitHub Actions “checkout” to v5 across all workflows (build, test, lint, integration, Docker, coordinator, database, rollup, bridge history, version bump).
  * Improves CI reliability, security, and compatibility with latest runners.
  * No changes to application behavior or user-facing features; builds and releases proceed as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->