### PR TITLE
chore: suggest using errors.New instead of fmt.Errorf with no parameters

### DIFF
--- a/rollup/cmd/permissionless_batches/app/app.go
+++ b/rollup/cmd/permissionless_batches/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -53,16 +54,16 @@ func action(ctx *cli.Context) error {
 
 	// Sanity check config. Make sure the required fields are set.
 	if cfg.RecoveryConfig == nil {
-		return fmt.Errorf("recovery config must be specified")
+		return errors.New("recovery config must be specified")
 	}
 	if cfg.RecoveryConfig.L1BeaconNodeEndpoint == "" {
-		return fmt.Errorf("L1 beacon node endpoint must be specified")
+		return errors.New("L1 beacon node endpoint must be specified")
 	}
 	if cfg.RecoveryConfig.L1BlockHeight == 0 {
-		return fmt.Errorf("L1 block height must be specified")
+		return errors.New("L1 block height must be specified")
 	}
 	if cfg.RecoveryConfig.LatestFinalizedBatch == 0 {
-		return fmt.Errorf("latest finalized batch must be specified")
+		return errors.New("latest finalized batch must be specified")
 	}
 
 	// init db connection

--- a/rollup/internal/controller/relayer/l2_relayer_sanity.go
+++ b/rollup/internal/controller/relayer/l2_relayer_sanity.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -18,7 +19,7 @@ import (
 // This ensures the constructed transaction data is correct and consistent with the database state.
 func (r *Layer2Relayer) sanityChecksCommitBatchCodecV7CalldataAndBlobs(calldata []byte, blobs []*kzg4844.Blob) error {
 	if r.l1RollupABI == nil {
-		return fmt.Errorf("l1RollupABI is nil: cannot parse commitBatches calldata")
+		return errors.New("l1RollupABI is nil: cannot parse commitBatches calldata")
 	}
 	calldataInfo, err := parseCommitBatchesCalldata(r.l1RollupABI, calldata)
 	if err != nil {

--- a/rollup/internal/controller/sender/transaction_signer.go
+++ b/rollup/internal/controller/sender/transaction_signer.go
@@ -2,6 +2,7 @@ package sender
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -51,7 +52,7 @@ func NewTransactionSigner(config *config.SignerConfig, chainID *big.Int) (*Trans
 		}, nil
 	case RemoteSignerType:
 		if config.RemoteSignerConfig.SignerAddress == "" {
-			return nil, fmt.Errorf("failed to create RemoteSigner, signer address is empty")
+			return nil, errors.New("failed to create RemoteSigner, signer address is empty")
 		}
 		rpcClient, err := rpc.Dial(config.RemoteSignerConfig.RemoteSignerUrl)
 		if err != nil {
@@ -94,7 +95,7 @@ func (ts *TransactionSigner) SignTransaction(ctx context.Context, tx *gethTypes.
 		return signedTx, nil
 	default:
 		// this shouldn't happen, because SignerType is checked during creation
-		return nil, fmt.Errorf("shouldn't happen, unknown signer type")
+		return nil, errors.New("shouldn't happen, unknown signer type")
 	}
 }
 


### PR DESCRIPTION
chore: suggest using errors.New instead of fmt.Errorf with no parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across components for consistency and maintainability. No changes to functionality or user experience.
* **Chores**
  * Updated imports to align with the new error handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->