### PR TITLE
[FIX] script for detecting plonky3gpu version

### DIFF
--- a/crates/gpu_override/Makefile
+++ b/crates/gpu_override/Makefile
@@ -16,6 +16,8 @@ clean:
 build:
 	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock
 
+version:
+	echo ${GO_TAG}-${GIT_REV}-${ZK_VERSION}
 # update Cargo.lock while override config has been updated
 #update:
 #	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build -Z unstable-options --release -p prover --lockfile-path ./Cargo.lock

--- a/crates/gpu_override/print_plonky3gpu_version.sh
+++ b/crates/gpu_override/print_plonky3gpu_version.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-config_file=.cargo/config.toml
-plonky3_gpu_path=$(grep 'path.*plonky3-gpu' "$config_file" | cut -d'"' -f2 | head -n 1)
-plonky3_gpu_path=$(dirname "$plonky3_gpu_path")
+higher_plonky3_item=`grep "plonky3-gpu" ./Cargo.lock | sort | uniq | awk -F "[#=]" '{print $3" "$4}' | sort -k 1 | tail -n 1`
 
-if [ -z $plonky3_gpu_path ]; then
-    exit 0
-else
-    pushd $plonky3_gpu_path
-    commit_hash=$(git log --pretty=format:%h -n 1)
-    echo "${commit_hash:0:7}"
+higher_version=`echo $higher_plonky3_item | awk '{print $1}'`
 
-    popd
-fi
+higher_commit=`echo $higher_plonky3_item | cut -d ' ' -f2 | cut -c-7`
+
+echo "$higher_version"
+echo "$higher_commit"

--- a/zkvm-prover/Makefile
+++ b/zkvm-prover/Makefile
@@ -38,6 +38,9 @@ DUMP_DIR = .work
 prover:
 	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZKVM_COMMIT=${ZKVM_COMMIT} $(MAKE) -C ../crates/gpu_override build
 
+version:
+	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZKVM_COMMIT=${ZKVM_COMMIT} $(MAKE) -C ../crates/gpu_override version
+
 prover_cpu:
 	GO_TAG=${GO_TAG} GIT_REV=${GIT_REV} ZK_VERSION=${ZK_VERSION} cargo build --locked --release -p prover
 


### PR DESCRIPTION
This PR fixed the broken script to detect plonky3gpu version. Also add an make entry for printing out the version string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to print a comprehensive version string combining release tag, Git revision, and dependency version/commit.
  * Exposed the version command from both the prover and GPU components for easy access.
  * Standardized dependency version reporting to always output version and short commit, ensuring consistent results.

* **Chores**
  * Aligned version propagation between components to simplify build and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->