### PR TITLE
[FIX] Compatible with current prover (before 0.5.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8433,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8455,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.16",
@@ -8470,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "halo2curves-axiom",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8523,7 +8523,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ repository = "https://github.com/scroll-tech/scroll"
 version = "4.5.8"
 
 [workspace.dependencies]
-scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "89a2dc1" }
-scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "89a2dc1" }
-scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "89a2dc1" }
+scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "ad0efe7" }
+scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "ad0efe7" }
+scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "ad0efe7" }
 
 sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3", features = ["scroll"] }
 sbv-utils = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3" }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.44"
+var tag = "v4.5.45"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/crates/gpu_override/Cargo.lock
+++ b/crates/gpu_override/Cargo.lock
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.16",
@@ -8767,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "halo2curves-axiom",
@@ -8787,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8820,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=89a2dc1#89a2dc19633f0e0de390177a7ba142bfdea164cc"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
 dependencies = [
  "bincode",
  "eyre",


### PR DESCRIPTION
This PR updated the dep of zkvm-prover with a trivial fixing so it can be compatible with the proof send from current prover being deployed (before 0.5.6)

Updating in zkvm-prover: https://github.com/scroll-tech/zkvm-prover/pull/180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped app version to v4.5.45 for release tracking and visibility.
  - Updated underlying proof/verification dependencies to the latest revisions to stay aligned with upstream.
  - Users can expect minor stability and performance improvements; no changes to interfaces or workflows.
  - No migration or configuration changes required; existing integrations continue to work as before.
  - Includes routine maintenance that may incorporate upstream fixes and compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->