### PR TITLE
[Fix] Compatible with prover from 4.5.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8395,7 +8395,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8433,7 +8433,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8455,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.16",
@@ -8470,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "halo2curves-axiom",
@@ -8490,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8503,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8523,7 +8523,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ repository = "https://github.com/scroll-tech/scroll"
 version = "4.5.8"
 
 [workspace.dependencies]
-scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "ad0efe7" }
-scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "ad0efe7" }
-scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "ad0efe7" }
+scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "07ecd62" }
+scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "07ecd62" }
+scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", rev = "07ecd62" }
 
 sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3", features = ["scroll"] }
 sbv-utils = { git = "https://github.com/scroll-tech/stateless-block-verifier", branch = "chore/openvm-1.3" }

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.5.45"
+var tag = "v4.5.46"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/libzkp/lib.go
+++ b/coordinator/internal/logic/libzkp/lib.go
@@ -140,3 +140,20 @@ func DumpVk(forkName, filePath string) error {
 
 	return nil
 }
+
+// UnivTaskCompatibilityFix calls the universal task compatibility fix function
+func UnivTaskCompatibilityFix(taskJSON string) (string, error) {
+	cTaskJSON := goToCString(taskJSON)
+	defer freeCString(cTaskJSON)
+
+	resultPtr := C.univ_task_compatibility_fix(cTaskJSON)
+	if resultPtr == nil {
+		return "", fmt.Errorf("univ_task_compatibility_fix failed")
+	}
+
+	// Convert result to Go string and free C memory
+	result := C.GoString(resultPtr)
+	C.release_string(resultPtr)
+
+	return result, nil
+}

--- a/coordinator/internal/logic/libzkp/libzkp.h
+++ b/coordinator/internal/logic/libzkp/libzkp.h
@@ -54,4 +54,7 @@ char* gen_wrapped_proof(char* proof_json, char* metadata, char* vk, size_t vk_le
 // Release memory allocated for a string returned by gen_wrapped_proof
 void release_string(char* string_ptr);
 
+// Universal task compatibility fix function
+char* univ_task_compatibility_fix(char* task_json);
+
 #endif /* LIBZKP_H */

--- a/coordinator/internal/logic/provertask/batch_prover_task.go
+++ b/coordinator/internal/logic/provertask/batch_prover_task.go
@@ -213,6 +213,14 @@ func (bp *BatchProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 			return nil, ErrCoordinatorInternalFailure
 		}
 		proverTask.Metadata = metadata
+
+		if isCompatibilityFixingVersion(taskCtx.ProverVersion) {
+			log.Info("Apply compatibility fixing for prover", "version", taskCtx.ProverVersion)
+			if err := fixCompatibility(taskMsg); err != nil {
+				log.Error("apply compatibility failure", "err", err)
+				return nil, ErrCoordinatorInternalFailure
+			}
+		}
 	}
 
 	// Store session info.

--- a/coordinator/internal/logic/provertask/bundle_prover_task.go
+++ b/coordinator/internal/logic/provertask/bundle_prover_task.go
@@ -211,6 +211,14 @@ func (bp *BundleProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinat
 		// bundle proof require snark
 		taskMsg.UseSnark = true
 		proverTask.Metadata = metadata
+
+		if isCompatibilityFixingVersion(taskCtx.ProverVersion) {
+			log.Info("Apply compatibility fixing for prover", "version", taskCtx.ProverVersion)
+			if err := fixCompatibility(taskMsg); err != nil {
+				log.Error("apply compatibility failure", "err", err)
+				return nil, ErrCoordinatorInternalFailure
+			}
+		}
 	}
 
 	// Store session info.

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/gorm"
 
 	"scroll-tech/common/types/message"
+	"scroll-tech/common/version"
 
 	"scroll-tech/coordinator/internal/config"
 	"scroll-tech/coordinator/internal/logic/libzkp"
@@ -199,6 +200,23 @@ func (b *BaseProverTask) applyUniversal(schema *coordinatorType.GetTaskSchema) (
 
 	schema.TaskData = uTaskData
 	return schema, []byte(metadata), nil
+}
+
+const CompatibilityVersion = "4.5.43"
+
+func isCompatibilityFixingVersion(ver string) bool {
+	return version.CheckScrollRepoVersion(ver, CompatibilityVersion)
+}
+
+func fixCompatibility(schema *coordinatorType.GetTaskSchema) error {
+
+	fixedTask, err := libzkp.UnivTaskCompatibilityFix(schema.TaskData)
+	if err != nil {
+		return err
+	}
+	schema.TaskData = fixedTask
+
+	return nil
 }
 
 func newGetTaskCounterVec(factory promauto.Factory, taskType string) *prometheus.CounterVec {

--- a/coordinator/internal/logic/provertask/prover_task.go
+++ b/coordinator/internal/logic/provertask/prover_task.go
@@ -205,7 +205,7 @@ func (b *BaseProverTask) applyUniversal(schema *coordinatorType.GetTaskSchema) (
 const CompatibilityVersion = "4.5.43"
 
 func isCompatibilityFixingVersion(ver string) bool {
-	return version.CheckScrollRepoVersion(ver, CompatibilityVersion)
+	return !version.CheckScrollRepoVersion(ver, CompatibilityVersion)
 }
 
 func fixCompatibility(schema *coordinatorType.GetTaskSchema) error {

--- a/coordinator/test/api_test.go
+++ b/coordinator/test/api_test.go
@@ -132,7 +132,7 @@ func setupCoordinator(t *testing.T, proversPerSession uint8, coordinatorURL stri
 func setEnv(t *testing.T) {
 	var err error
 
-	version.Version = "v4.4.89"
+	version.Version = "v4.5.45"
 
 	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.LogfmtFormat()))
 	glogger.Verbosity(log.LvlInfo)

--- a/crates/gpu_override/Cargo.lock
+++ b/crates/gpu_override/Cargo.lock
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.16",
@@ -8767,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "halo2curves-axiom",
@@ -8787,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "alloy-primitives",
  "itertools 0.14.0",
@@ -8820,7 +8820,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.5.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?rev=ad0efe7#ad0efe750d5f03781f28037c312e50400ac22a8d"
+source = "git+https://github.com/scroll-tech/zkvm-prover?rev=07ecd62#07ecd629d3dc0c0d78fdea8972cd710fd5f606d2"
 dependencies = [
  "bincode",
  "eyre",

--- a/crates/libzkp/src/lib.rs
+++ b/crates/libzkp/src/lib.rs
@@ -25,6 +25,47 @@ pub fn checkout_chunk_task(
     Ok(ret)
 }
 
+/// Convert the universal task json into compatible form for old prover
+pub fn univ_task_compatibility_fix(task_json: &str) -> eyre::Result<String> {
+    use scroll_zkvm_types::proof::VmInternalStarkProof;
+
+    let u_task: tasks::ProvingTask = serde_json::from_str(task_json)?;
+    let aggregated_proofs: Vec<VmInternalStarkProof> = u_task
+        .aggregated_proofs
+        .into_iter()
+        .map(|proof| VmInternalStarkProof {
+            proofs: proof.proofs,
+            public_values: proof.public_values,
+        })
+        .collect();
+
+    #[derive(Serialize)]
+    struct CompatibleProvingTask {
+        /// seralized witness which should be written into stdin first
+        pub serialized_witness: Vec<Vec<u8>>,
+        /// aggregated proof carried by babybear fields, should be written into stdin
+        /// followed `serialized_witness`
+        pub aggregated_proofs: Vec<VmInternalStarkProof>,
+        /// Fork name specify
+        pub fork_name: String,
+        /// The vk of app which is expcted to prove this task
+        pub vk: Vec<u8>,
+        /// An identifier assigned by coordinator, it should be kept identify for the
+        /// same task (for example, using chunk, batch and bundle hashes)
+        pub identifier: String,
+    }
+
+    let compatible_u_task = CompatibleProvingTask {
+        serialized_witness: u_task.serialized_witness,
+        aggregated_proofs,
+        fork_name: u_task.fork_name,
+        vk: u_task.vk,
+        identifier: u_task.identifier,
+    };
+
+    Ok(serde_json::to_string(&compatible_u_task)?)
+}
+
 /// Generate required staff for proving tasks
 /// return (pi_hash, metadata, task)
 pub fn gen_universal_task(

--- a/crates/libzkp_c/src/lib.rs
+++ b/crates/libzkp_c/src/lib.rs
@@ -250,6 +250,19 @@ pub unsafe extern "C" fn gen_wrapped_proof(
 
 /// # Safety
 #[no_mangle]
+pub unsafe extern "C" fn univ_task_compatibility_fix(task_json: *const c_char) -> *mut c_char {
+    let task_json_str = c_char_to_str(task_json);
+    match libzkp::univ_task_compatibility_fix(task_json_str) {
+        Ok(result) => CString::new(result).unwrap().into_raw(),
+        Err(e) => {
+            tracing::error!("univ_task_compability_fix failed, error: {:#}", e);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// # Safety
+#[no_mangle]
 pub unsafe extern "C" fn release_string(ptr: *mut c_char) {
     if !ptr.is_null() {
         let _ = CString::from_raw(ptr);


### PR DESCRIPTION
Unexpected serde behavior in OpenVm proof has broken the backward compatibility of coordinator. This PR detect the prover version and apply fixing to the encoding of universal task to resume the compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic compatibility handling for universal prover tasks based on prover version; tasks are transformed when required to ensure compatibility.
  - Exposed a compatibility-fix API to convert universal task payloads to legacy-compatible format.

- Bug Fixes
  - Improved error handling and logging during compatibility processing to prevent invalid task dispatch.

- Chores
  - Updated internal dependency revisions for prover, verifier, and types crates.
  - Test environment and package version tags updated to newer prover/version releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->