### PR TITLE
chore: Normalize short_git_version strip optional 'g' and take first 7 chars

### DIFF
--- a/crates/libzkp/src/utils.rs
+++ b/crates/libzkp/src/utils.rs
@@ -15,14 +15,9 @@ const GIT_VERSION: &str = git_version!(args = ["--abbrev=7", "--always"]);
 
 /// Shortened git commit ref from [`scroll_zkvm_prover`].
 pub(crate) fn short_git_version() -> String {
-    let commit_version = GIT_VERSION.split('-').next_back().unwrap();
-
-    // Check if use commit object as fallback.
-    if commit_version.len() < 8 {
-        commit_version.to_string()
-    } else {
-        commit_version[1..8].to_string()
-    }
+    let last = GIT_VERSION.split('-').next_back().unwrap();
+    let hash = last.strip_prefix('g').unwrap_or(last);
+    hash.chars().take(7).collect()
 }
 
 /// Wrapper to read JSON that might be deeply nested.


### PR DESCRIPTION
- Ensure short_git_version handles both git describe outputs:
  - tagged form ends with g<hash>
  - non-tagged form returns <hash> without g
- We now strip an optional leading g and consistently take the first 7 characters.
- This prevents dropping the first hex digit when the hash lacks g and aligns with the rest of the codebase, which uses 7-char hashes without the g prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Standardized the displayed Git commit abbreviation to a consistent 7 characters, removing any leading “g” and improving readability across version screens, CLI outputs, and logs.

- Refactor
  - Simplified the logic used to derive the short Git version, reducing edge cases and ensuring consistent behavior across builds and tags without altering public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->