### PR TITLE
ci: Do not push latest tag on Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,9 +51,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   rollup_relayer:
     runs-on:
@@ -97,9 +95,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   blob_uploader:
     runs-on:
@@ -143,9 +139,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   rollup-db-cli:
     runs-on:
@@ -189,9 +183,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   bridgehistoryapi-fetcher:
     runs-on:
@@ -235,9 +227,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   bridgehistoryapi-api:
     runs-on:
@@ -281,9 +271,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   bridgehistoryapi-db-cli:
     runs-on:
@@ -327,9 +315,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   coordinator-api:
     runs-on:
@@ -372,9 +358,7 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest
 
   coordinator-cron:
     runs-on:
@@ -418,6 +402,4 @@ jobs:
           push: true
           tags: |
             scrolltech/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            scrolltech/${{ env.REPOSITORY }}:latest
             ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ env.ECR_REGISTRY }}/${{ env.REPOSITORY }}:latest


### PR DESCRIPTION
### Purpose or design rationale of this PR

Removed 'latest' tag from multiple Docker image builds in the workflow.

This tag is brittle and error-prone. E.g. when we push tags on unstable feature branches, the new images are also tagged as latest. It is better to remove this tag and always rely on explicit image versions.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [X] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Docker image publishing policy: images are no longer tagged or pushed as :latest. Only explicit version/IMAGE_TAG tags will be published to registries.
  - Impact: consumers must pull images using a specific tag; any automation or deployments relying on :latest will no longer receive updates and should be updated to use explicit tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->