### PR TITLE
[Fix] Call GetL1Message in l2watcher

### DIFF
--- a/common/testcontainers/testcontainers.go
+++ b/common/testcontainers/testcontainers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/scroll-tech/go-ethereum/ethclient"
+	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/compose"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -220,11 +221,21 @@ func (t *TestcontainerApps) GetGormDBClient() (*gorm.DB, error) {
 
 // GetL2GethClient returns a ethclient by dialing running L2Geth
 func (t *TestcontainerApps) GetL2GethClient() (*ethclient.Client, error) {
+
+	rpcCli, err := t.GetL2Client()
+	if err != nil {
+		return nil, err
+	}
+	return ethclient.NewClient(rpcCli), nil
+}
+
+// GetL2GethClient returns a rpc client by dialing running L2Geth
+func (t *TestcontainerApps) GetL2Client() (*rpc.Client, error) {
 	endpoint, err := t.GetL2GethEndPoint()
 	if err != nil {
 		return nil, err
 	}
-	client, err := ethclient.Dial(endpoint)
+	client, err := rpc.Dial(endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/rollup/cmd/permissionless_batches/app/app.go
+++ b/rollup/cmd/permissionless_batches/app/app.go
@@ -10,8 +10,8 @@ import (
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/urfave/cli/v2"
 
-	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/log"
+	"github.com/scroll-tech/go-ethereum/rpc"
 
 	"scroll-tech/common/database"
 	"scroll-tech/common/observability"
@@ -91,12 +91,13 @@ func action(ctx *cli.Context) error {
 	bundleProposer := watcher.NewBundleProposer(subCtx, cfg.L2Config.BundleProposerConfig, minCodecVersion, genesis.Config, db, registry)
 
 	// Init l2geth connection
-	l2client, err := ethclient.Dial(cfg.L2Config.Endpoint)
+	l2client, err := rpc.Dial(cfg.L2Config.Endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to connect to L2geth at RPC=%s: %w", cfg.L2Config.Endpoint, err)
 	}
 
-	l2Watcher := watcher.NewL2WatcherClient(subCtx, l2client, cfg.L2Config.Confirmations, cfg.L2Config.L2MessageQueueAddress, cfg.L2Config.WithdrawTrieRootSlot, genesis.Config, db, registry)
+	l2Watcher := watcher.NewL2WatcherClient(subCtx, l2client, cfg.L2Config.Confirmations, cfg.L2Config.L2MessageQueueAddress,
+		cfg.L2Config.WithdrawTrieRootSlot, genesis.Config, db, cfg.L2Config.RelayerConfig.ValidiumMode, registry)
 
 	recovery := permissionless_batches.NewRecovery(subCtx, cfg, genesis, db, chunkProposer, batchProposer, bundleProposer, l2Watcher)
 

--- a/rollup/cmd/rollup_relayer/app/app.go
+++ b/rollup/cmd/rollup_relayer/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/log"
 	"github.com/scroll-tech/go-ethereum/rollup/l1"
+	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
 
 	"scroll-tech/common/database"
@@ -69,10 +70,11 @@ func action(ctx *cli.Context) error {
 	observability.Server(ctx, db)
 
 	// Init l2geth connection
-	l2client, err := ethclient.Dial(cfg.L2Config.Endpoint)
+	l2client, err := rpc.Dial(cfg.L2Config.Endpoint)
 	if err != nil {
 		log.Crit("failed to connect l2 geth", "config file", cfgFile, "error", err)
 	}
+	l2ethClient := ethclient.NewClient(l2client)
 
 	genesisPath := ctx.String(utils.Genesis.Name)
 	genesis, err := utils.ReadGenesis(genesisPath)
@@ -100,7 +102,7 @@ func action(ctx *cli.Context) error {
 		log.Crit("cfg.L2Config.RelayerConfig.SenderConfig.FusakaTimestamp must be set")
 	}
 
-	l2relayer, err := relayer.NewLayer2Relayer(ctx.Context, l2client, db, cfg.L2Config.RelayerConfig, genesis.Config, relayer.ServiceTypeL2RollupRelayer, registry)
+	l2relayer, err := relayer.NewLayer2Relayer(ctx.Context, l2ethClient, db, cfg.L2Config.RelayerConfig, genesis.Config, relayer.ServiceTypeL2RollupRelayer, registry)
 	if err != nil {
 		log.Crit("failed to create l2 relayer", "config file", cfgFile, "error", err)
 	}
@@ -144,7 +146,7 @@ func action(ctx *cli.Context) error {
 
 	// Watcher loop to fetch missing blocks
 	go utils.LoopWithContext(subCtx, 2*time.Second, func(ctx context.Context) {
-		number, loopErr := rutils.GetLatestConfirmedBlockNumber(ctx, l2client, cfg.L2Config.Confirmations)
+		number, loopErr := rutils.GetLatestConfirmedBlockNumber(ctx, l2ethClient, cfg.L2Config.Confirmations)
 		if loopErr != nil {
 			log.Error("failed to get block number", "err", loopErr)
 			return

--- a/rollup/go.mod
+++ b/rollup/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/crate-crypto/go-eth-kzg v1.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.5 // indirect
 	github.com/fjl/memsize v0.0.2 // indirect
@@ -111,7 +110,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/scroll-tech/ecies-go/v2 v2.0.10-beta.1 // indirect
 	github.com/scroll-tech/zktrie v0.8.4 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/smartystreets/assertions v1.13.1 // indirect

--- a/rollup/go.sum
+++ b/rollup/go.sum
@@ -90,8 +90,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea h1:j4317fAZh7X6GqbFowYdYdI0L9bwxL07jyPZIdepyZ0=
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=

--- a/rollup/internal/controller/watcher/l2_watcher.go
+++ b/rollup/internal/controller/watcher/l2_watcher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
-	"github.com/scroll-tech/go-ethereum/eth"
 	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/event"
 	"github.com/scroll-tech/go-ethereum/log"
@@ -26,6 +25,7 @@ type L2WatcherClient struct {
 	event.Feed
 
 	*ethclient.Client
+	rpcCli *rpc.Client
 
 	l2BlockOrm *orm.L2Block
 
@@ -42,10 +42,11 @@ type L2WatcherClient struct {
 }
 
 // NewL2WatcherClient take a l2geth instance to generate a l2watcherclient instance
-func NewL2WatcherClient(ctx context.Context, client *ethclient.Client, confirmations rpc.BlockNumber, messageQueueAddress common.Address, withdrawTrieRootSlot common.Hash, chainCfg *params.ChainConfig, db *gorm.DB, validiumMode bool, reg prometheus.Registerer) *L2WatcherClient {
+func NewL2WatcherClient(ctx context.Context, client *rpc.Client, confirmations rpc.BlockNumber, messageQueueAddress common.Address, withdrawTrieRootSlot common.Hash, chainCfg *params.ChainConfig, db *gorm.DB, validiumMode bool, reg prometheus.Registerer) *L2WatcherClient {
 	return &L2WatcherClient{
 		ctx:    ctx,
-		Client: client,
+		Client: ethclient.NewClient(client),
+		rpcCli: client,
 
 		l2BlockOrm: orm.NewL2Block(db),
 
@@ -117,7 +118,7 @@ func (w *L2WatcherClient) GetAndStoreBlocks(ctx context.Context, from, to uint64
 
 			if count > 0 {
 				log.Info("Fetching encrypted messages in validium mode")
-				txs, err = w.GetL1MessagesInBlock(context.Background(), block.Hash(), eth.QueryModeSynced)
+				err = w.rpcCli.CallContext(ctx, &txs, "scroll_getL1MessagesInBlock", block.Hash(), "synced")
 				if err != nil {
 					return fmt.Errorf("failed to get L1 messages: %v, block hash: %v", err, block.Hash().Hex())
 				}

--- a/rollup/internal/controller/watcher/l2_watcher_test.go
+++ b/rollup/internal/controller/watcher/l2_watcher_test.go
@@ -2,12 +2,13 @@ package watcher
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"gorm.io/gorm"
 
 	"github.com/scroll-tech/go-ethereum/common"
-	"github.com/scroll-tech/go-ethereum/ethclient"
+	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
 
@@ -20,7 +21,7 @@ import (
 func setupL2Watcher(t *testing.T) (*L2WatcherClient, *gorm.DB) {
 	db := setupDB(t)
 	l2cfg := cfg.L2Config
-	watcher := NewL2WatcherClient(context.Background(), l2Cli, l2cfg.Confirmations, l2cfg.L2MessageQueueAddress, l2cfg.WithdrawTrieRootSlot, nil, db, nil)
+	watcher := NewL2WatcherClient(context.Background(), l2Rpc, l2cfg.Confirmations, l2cfg.L2MessageQueueAddress, l2cfg.WithdrawTrieRootSlot, nil, db, false, nil)
 	return watcher, db
 }
 
@@ -34,7 +35,7 @@ func testFetchRunningMissingBlocks(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		wc := prepareWatcherClient(l2Cli, db)
+		wc := prepareWatcherClient(l2Rpc, db)
 		wc.TryFetchRunningMissingBlocks(latestHeight)
 		fetchedHeight, err := l2BlockOrm.GetL2BlocksLatestHeight(context.Background())
 		return err == nil && fetchedHeight == latestHeight
@@ -42,7 +43,32 @@ func testFetchRunningMissingBlocks(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func prepareWatcherClient(l2Cli *ethclient.Client, db *gorm.DB) *L2WatcherClient {
+func prepareWatcherClient(l2Cli *rpc.Client, db *gorm.DB) *L2WatcherClient {
 	confirmations := rpc.LatestBlockNumber
-	return NewL2WatcherClient(context.Background(), l2Cli, confirmations, common.Address{}, common.Hash{}, nil, db, nil)
+	return NewL2WatcherClient(context.Background(), l2Cli, confirmations, common.Address{}, common.Hash{}, nil, db, false, nil)
+}
+
+// New test for raw RPC GetBlockByHash from an endpoint URL in env.
+func TestRawRPCGetBlockByHash(t *testing.T) {
+	url := os.Getenv("RPC_ENDPOINT_URL")
+	if url == "" {
+		t.Log("warn: RPC_ENDPOINT_URL not set, skipping raw RPC test")
+		t.Skip("missing RPC_ENDPOINT_URL")
+	}
+
+	ctx := context.Background()
+	cli, err := rpc.DialContext(ctx, url)
+	if err != nil {
+		t.Fatalf("failed to dial RPC endpoint %s: %v", url, err)
+	}
+	defer cli.Close()
+
+	var txs []*types.Transaction
+	blkHash := common.HexToHash("0xc80cf12883341827d71c08f734ba9a9d6da7e59eb16921d26e6706887e552c74")
+	err = cli.CallContext(ctx, &txs, "scroll_getL1MessagesInBlock", blkHash, "synced")
+	if err != nil {
+		t.Logf("scroll_getL1MessagesInBlock failed: err=%v", err)
+		t.Fail()
+	}
+	t.Log(txs, txs[0].Hash())
 }

--- a/rollup/internal/controller/watcher/watcher_test.go
+++ b/rollup/internal/controller/watcher/watcher_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/ethclient"
 	"github.com/scroll-tech/go-ethereum/log"
+	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 
@@ -27,6 +28,7 @@ var (
 
 	// l2geth client
 	l2Cli *ethclient.Client
+	l2Rpc *rpc.Client
 
 	// block trace
 	block1 *encoding.Block
@@ -62,8 +64,9 @@ func setupEnv(t *testing.T) (err error) {
 	}
 
 	// Create l2geth client.
-	l2Cli, err = testApps.GetL2GethClient()
+	l2Rpc, err = testApps.GetL2Client()
 	assert.NoError(t, err)
+	l2Cli = ethclient.NewClient(l2Rpc)
 
 	block1 = readBlockFromJSON(t, "../../../testdata/blockTrace_02.json")
 	block2 = readBlockFromJSON(t, "../../../testdata/blockTrace_03.json")


### PR DESCRIPTION
We added a new RPC `scroll_getL1MessagesInBlock` in l2geth validium mode, however, this is not yet implemented in the Go SDK. As as simple workaround, this PR adds the ability to perform raw RPC calls, bypassing `ethClient`.