### PR TITLE
chore: bump zkvm-prover to rc5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8779,7 +8779,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-prover"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "base64 0.22.1",
  "bincode 1.3.3",
@@ -8806,7 +8806,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "alloy-primitives",
  "base64 0.22.1",
@@ -8830,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-base"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "alloy-primitives",
  "alloy-serde 1.0.41",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-batch"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "alloy-primitives",
  "c-kzg",
@@ -8865,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-bundle"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "rkyv",
  "scroll-zkvm-types-base",
@@ -8875,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-types-chunk"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8900,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "scroll-zkvm-verifier"
 version = "0.7.0"
-source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.4#db70d808b717aeaebb066cb1603e14d3b10e51c7"
+source = "git+https://github.com/scroll-tech/zkvm-prover?tag=v0.7.0-rc.5#4d9af18e540af069cb2de1c73bf4751ff03c35fc"
 dependencies = [
  "bincode 1.3.3",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ repository = "https://github.com/scroll-tech/scroll"
 version = "4.7.1"
 
 [workspace.dependencies]
-scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.0-rc.4" }
-scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.0-rc.4" }
-scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.0-rc.4" }
+scroll-zkvm-prover = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.0-rc.5" }
+scroll-zkvm-verifier = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.0-rc.5" }
+scroll-zkvm-types = { git = "https://github.com/scroll-tech/zkvm-prover", tag = "v0.7.0-rc.5" }
 
 sbv-primitives = { git = "https://github.com/scroll-tech/stateless-block-verifier", tag = "scroll-v91", features = ["scroll", "rkyv"] }
 sbv-utils = { git = "https://github.com/scroll-tech/stateless-block-verifier", tag = "scroll-v91" }


### PR DESCRIPTION
### Purpose or design rationale of this PR

Bump `scroll-zkvm-prover` dependency to `tag = "v0.7.0-rc.5"`

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
