### PR TITLE
Refactor proving task build process

### DIFF
--- a/crates/libzkp/src/tasks.rs
+++ b/crates/libzkp/src/tasks.rs
@@ -63,10 +63,9 @@ pub fn gen_universal_chunk_task(
     task: ChunkProvingTask,
 ) -> eyre::Result<(B256, ChunkProofMetadata, ProvingTask)> {
     let chunk_total_gas = task.stats().total_gas_used;
-    let (chunk_info, pi_hash) = task.precheck_and_build_metadata()?;
-    let proving_task = task.try_into()?;
+    let (proving_task, chunk_info, chunk_pi_hash) = task.into_proving_task_with_precheck()?;
     Ok((
-        pi_hash,
+        chunk_pi_hash,
         ChunkProofMetadata {
             chunk_info,
             chunk_total_gas,
@@ -79,8 +78,7 @@ pub fn gen_universal_chunk_task(
 pub fn gen_universal_batch_task(
     task: BatchProvingTask,
 ) -> eyre::Result<(B256, BatchProofMetadata, ProvingTask)> {
-    let (batch_info, batch_pi_hash) = task.precheck_and_build_metadata()?;
-    let proving_task = task.try_into()?;
+    let (proving_task, batch_info, batch_pi_hash) = task.into_proving_task_with_precheck()?;
     Ok((
         batch_pi_hash,
         BatchProofMetadata { batch_info },
@@ -92,8 +90,7 @@ pub fn gen_universal_batch_task(
 pub fn gen_universal_bundle_task(
     task: BundleProvingTask,
 ) -> eyre::Result<(B256, BundleProofMetadata, ProvingTask)> {
-    let (bundle_info, bundle_pi_hash) = task.precheck_and_build_metadata()?;
-    let proving_task = task.try_into()?;
+    let (proving_task, bundle_info, bundle_pi_hash) = task.into_proving_task_with_precheck()?;
     Ok((
         bundle_pi_hash,
         BundleProofMetadata {

--- a/crates/libzkp/src/tasks/batch.rs
+++ b/crates/libzkp/src/tasks/batch.rs
@@ -112,33 +112,31 @@ pub struct BatchProvingTask {
     pub fork_name: String,
 }
 
-impl TryFrom<BatchProvingTask> for ProvingTask {
-    type Error = eyre::Error;
-
-    fn try_from(value: BatchProvingTask) -> Result<Self> {
-        let witness = value.build_guest_input(value.version.into());
-        let serialized_witness = if crate::witness_use_legacy_mode(&value.fork_name)? {
+impl BatchProvingTask {
+    pub fn into_proving_task_with_precheck(self) -> Result<(ProvingTask, BatchInfo, B256)> {
+        let (witness, metadata, batch_pi_hash) = self.precheck()?;
+        let serialized_witness = if crate::witness_use_legacy_mode(&self.fork_name)? {
             let legacy_witness = LegacyBatchWitness::from(witness);
             to_rkyv_bytes::<RancorError>(&legacy_witness)?.into_vec()
         } else {
             super::encode_task_to_witness(&witness)?
         };
 
-        Ok(ProvingTask {
-            identifier: value.batch_header.batch_hash().to_string(),
-            fork_name: value.fork_name,
-            aggregated_proofs: value
+        let proving_task = ProvingTask {
+            identifier: self.batch_header.batch_hash().to_string(),
+            fork_name: self.fork_name,
+            aggregated_proofs: self
                 .chunk_proofs
                 .into_iter()
                 .map(|w_proof| w_proof.proof.into_stark_proof().expect("expect root proof"))
                 .collect(),
             serialized_witness: vec![serialized_witness],
             vk: Vec::new(),
-        })
-    }
-}
+        };
 
-impl BatchProvingTask {
+        Ok((proving_task, metadata, batch_pi_hash))
+    }
+
     fn build_guest_input(&self, version: Version) -> BatchWitness {
         tracing::info!(
             "Handling batch task for input, version byte {}, Version data: {:?}",
@@ -281,7 +279,7 @@ impl BatchProvingTask {
         }
     }
 
-    pub fn precheck_and_build_metadata(&self) -> Result<(BatchInfo, B256)> {
+    pub fn precheck(&self) -> Result<(BatchWitness, BatchInfo, B256)> {
         // for every aggregation task, there are two steps needed to build the metadata:
         // 1. generate data for metadata from the witness
         // 2. validate every adjacent proof pair
@@ -294,7 +292,7 @@ impl BatchProvingTask {
         )?;
         let pi_hash = metadata.pi_hash_by_version(version);
 
-        Ok((metadata, pi_hash))
+        Ok((witness, metadata, pi_hash))
     }
 }
 

--- a/crates/libzkp/src/tasks/bundle.rs
+++ b/crates/libzkp/src/tasks/bundle.rs
@@ -25,6 +25,30 @@ pub struct BundleProvingTask {
 }
 
 impl BundleProvingTask {
+    pub fn into_proving_task_with_precheck(self) -> Result<(ProvingTask, BundleInfo, B256)> {
+        let (witness, bundle_info, bundle_pi_hash) = self.precheck()?;
+        let serialized_witness = if crate::witness_use_legacy_mode(&self.fork_name)? {
+            let legacy = LegacyBundleWitness::from(witness);
+            to_rkyv_bytes::<RancorError>(&legacy)?.into_vec()
+        } else {
+            super::encode_task_to_witness(&witness)?
+        };
+
+        let proving_task = ProvingTask {
+            identifier: self.identifier(),
+            fork_name: self.fork_name,
+            aggregated_proofs: self
+                .batch_proofs
+                .into_iter()
+                .map(|w_proof| w_proof.proof.into_stark_proof().expect("expect root proof"))
+                .collect(),
+            serialized_witness: vec![serialized_witness],
+            vk: Vec::new(),
+        };
+
+        Ok((proving_task, bundle_info, bundle_pi_hash))
+    }
+
     fn identifier(&self) -> String {
         assert!(!self.batch_proofs.is_empty(), "{BUNDLE_SANITY_MSG}",);
 
@@ -59,7 +83,7 @@ impl BundleProvingTask {
         }
     }
 
-    pub fn precheck_and_build_metadata(&self) -> Result<(BundleInfo, B256)> {
+    fn precheck(&self) -> Result<(BundleWitness, BundleInfo, B256)> {
         // for every aggregation task, there are two steps needed to build the metadata:
         // 1. generate data for metadata from the witness
         // 2. validate every adjacent proof pair
@@ -72,32 +96,6 @@ impl BundleProvingTask {
         )?;
         let pi_hash = metadata.pi_hash_by_version(version);
 
-        Ok((metadata, pi_hash))
-    }
-}
-
-impl TryFrom<BundleProvingTask> for ProvingTask {
-    type Error = eyre::Error;
-
-    fn try_from(value: BundleProvingTask) -> Result<Self> {
-        let witness = value.build_guest_input(value.version.into());
-        let serialized_witness = if crate::witness_use_legacy_mode(&value.fork_name)? {
-            let legacy = LegacyBundleWitness::from(witness);
-            to_rkyv_bytes::<RancorError>(&legacy)?.into_vec()
-        } else {
-            super::encode_task_to_witness(&witness)?
-        };
-
-        Ok(ProvingTask {
-            identifier: value.identifier(),
-            fork_name: value.fork_name,
-            aggregated_proofs: value
-                .batch_proofs
-                .into_iter()
-                .map(|w_proof| w_proof.proof.into_stark_proof().expect("expect root proof"))
-                .collect(),
-            serialized_witness: vec![serialized_witness],
-            vk: Vec::new(),
-        })
+        Ok((witness, metadata, pi_hash))
     }
 }

--- a/crates/libzkp/src/tasks/chunk.rs
+++ b/crates/libzkp/src/tasks/chunk.rs
@@ -94,28 +94,6 @@ pub struct ChunkDetails {
     pub total_gas_used: u64,
 }
 
-impl TryFrom<ChunkProvingTask> for ProvingTask {
-    type Error = eyre::Error;
-
-    fn try_from(value: ChunkProvingTask) -> Result<Self> {
-        let witness = value.build_guest_input(value.version.into());
-        let serialized_witness = if crate::witness_use_legacy_mode(&value.fork_name)? {
-            let legacy_witness = LegacyChunkWitness::from(witness);
-            to_rkyv_bytes::<RancorError>(&legacy_witness)?.into_vec()
-        } else {
-            super::encode_task_to_witness(&witness)?
-        };
-
-        Ok(ProvingTask {
-            identifier: value.identifier(),
-            fork_name: value.fork_name,
-            aggregated_proofs: Vec::new(),
-            serialized_witness: vec![serialized_witness],
-            vk: Vec::new(),
-        })
-    }
-}
-
 impl ChunkProvingTask {
     pub fn stats(&self) -> ChunkDetails {
         let num_blocks = self.block_witnesses.len();
@@ -135,6 +113,26 @@ impl ChunkProvingTask {
             num_txs,
             total_gas_used,
         }
+    }
+
+    pub fn into_proving_task_with_precheck(self) -> Result<(ProvingTask, ChunkInfo, B256)> {
+        let (witness, chunk_info, chunk_pi_hash) = self.precheck()?;
+        let serialized_witness = if crate::witness_use_legacy_mode(&self.fork_name)? {
+            let legacy_witness = LegacyChunkWitness::from(witness);
+            to_rkyv_bytes::<RancorError>(&legacy_witness)?.into_vec()
+        } else {
+            super::encode_task_to_witness(&witness)?
+        };
+
+        let proving_task = ProvingTask {
+            identifier: self.identifier(),
+            fork_name: self.fork_name,
+            aggregated_proofs: Vec::new(),
+            serialized_witness: vec![serialized_witness],
+            vk: Vec::new(),
+        };
+
+        Ok((proving_task, chunk_info, chunk_pi_hash))
     }
 
     fn identifier(&self) -> String {
@@ -180,13 +178,13 @@ impl ChunkProvingTask {
         self.block_witnesses[0].states.push(node);
     }
 
-    pub fn precheck_and_build_metadata(&self) -> Result<(ChunkInfo, B256)> {
+    fn precheck(&self) -> Result<(ChunkWitness, ChunkInfo, B256)> {
         let version = Version::from(self.version);
         let witness = self.build_guest_input(version);
-        let ret = ChunkInfo::try_from(witness).map_err(|e| eyre::eyre!("{e}"))?;
-        assert_eq!(ret.post_msg_queue_hash, self.post_msg_queue_hash);
-        let pi_hash = ret.pi_hash_by_version(version);
-        Ok((ret, pi_hash))
+        let chunk_info = ChunkInfo::try_from(witness.clone()).map_err(|e| eyre::eyre!("{e}"))?;
+        assert_eq!(chunk_info.post_msg_queue_hash, self.post_msg_queue_hash);
+        let chunk_pi_hash = chunk_info.pi_hash_by_version(version);
+        Ok((witness, chunk_info, chunk_pi_hash))
     }
 
     /// this method check the validate of current task (there may be missing storage node)


### PR DESCRIPTION
### Purpose or design rationale of this PR

`build_guest_input` was being called twice for each of chunk/batch/bundle tasks:
- Once in `precheck_xxx`
- Once in `TryFrom<T> for ProvingTask`

This PR refactors the implementation so that the witness is calculated only once (`build_guest_input`) and re-used for further processing.

### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes
