### PR TITLE
fix bridge history GetL2UnclaimedWithdrawalsByAddress

### DIFF
--- a/bridge-history-api/internal/logic/history_logic.go
+++ b/bridge-history-api/internal/logic/history_logic.go
@@ -97,6 +97,11 @@ func (h *HistoryLogic) GetL2UnclaimedWithdrawalsByAddress(ctx context.Context, a
 		return nil, 0, errors.New("unexpected error")
 	}
 
+	if len(txHistoryInfos) == 0 {
+		log.Error("failed to get L2 claimable withdrawals by address len = 0", "address", address)
+		return nil, 0, errors.New("unexpected error")
+	}
+
 	return h.processAndCacheTxHistoryInfo(ctx, cacheKey, txHistoryInfos, page, pageSize)
 }
 

--- a/bridge-history-api/internal/orm/cross_message.go
+++ b/bridge-history-api/internal/orm/cross_message.go
@@ -157,7 +157,7 @@ func (c *CrossMessage) GetL2UnclaimedWithdrawalsByAddress(ctx context.Context, s
 	db = db.Where("tx_status in (?)", []types.TxStatusType{types.TxStatusTypeSent, types.TxStatusTypeFailedRelayed, types.TxStatusTypeRelayTxReverted})
 	db = db.Where("sender = ?", sender)
 	db = db.Order("block_timestamp desc")
-	db = db.Limit(500)
+	db = db.Limit(10000)
 	if err := db.Find(&messages).Error; err != nil {
 		return nil, fmt.Errorf("failed to get L2 claimable withdrawal messages by sender address, sender: %v, error: %w", sender, err)
 	}

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.7.1"
+var tag = "v4.7.2"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

Fix issue where `bridge-history-api` fails to return results when a user has >500 pending withdrawals (see [discussion](https://scrollco.slack.com/archives/C02PKAQ2430/p1764043272540689?thread_ts=1764013249.402209&cid=C02PKAQ2430)).


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [X] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for withdrawal query operations when no records are found.

* **Improvements**
  * Increased the maximum number of withdrawal records that can be retrieved in a single query.

* **Version**
  * Released version v4.7.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->