### PR TITLE
feat: force commit batches at hardfork boundary

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.7.5"
+var tag = "v4.7.6"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -452,6 +452,7 @@ func (r *Layer2Relayer) ProcessPendingBatches() {
 		// The next call of ProcessPendingBatches will then start with the batch with the different codec version.
 		batchesToSubmitLen := len(batchesToSubmit)
 		if batchesToSubmitLen > 0 && batchesToSubmit[batchesToSubmitLen-1].Batch.CodecVersion != dbBatch.CodecVersion {
+			forceSubmit = true
 			break
 		}
 


### PR DESCRIPTION
### Purpose or design rationale of this PR

During today's Galileo testnet upgrade, we had the 2 last Feynman batches pending, with a number of Galileo batches after them. We’d expect the Feynman batches to be committed immediately, but this was not the case.

**Root cause**:
- We truncate the list of batches to submit based on the codec version, to ensure that we only commit batches of the same version together: https://github.com/scroll-tech/scroll/blob/2ecc42e2f56843cea6e4eff031456f901e213eb2/rollup/internal/controller/relayer/l2_relayer.go#L454
- But if we have too few batches, then we will not submit the commit tx before the batch submission timeout: https://github.com/scroll-tech/scroll/blob/2ecc42e2f56843cea6e4eff031456f901e213eb2/rollup/internal/controller/relayer/l2_relayer.go#L471

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to v4.7.8

* **Bug Fixes**
  * Ensure pending batches are forced to submit when a codec-version boundary is encountered between consecutive batches, preventing skipped submissions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->