### PR TITLE
feat(rollup-relayer): add blob fee tolerance

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.7.9"
+var tag = "v4.7.10"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -59,7 +59,7 @@
         "max_batches": 6,
         "timeout": 7200,
         "backlog_max": 75,
-        "blob_fee_tolerance": 10000000000
+        "blob_fee_tolerance": 500000000
       },
       "gas_oracle_config": {
         "min_gas_price": 0,

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -59,7 +59,7 @@
         "max_batches": 6,
         "timeout": 7200,
         "backlog_max": 75,
-        "blob_fee_tolerance_wei": 10000000000
+        "blob_fee_tolerance": 10000000000
       },
       "gas_oracle_config": {
         "min_gas_price": 0,

--- a/rollup/conf/config.json
+++ b/rollup/conf/config.json
@@ -58,7 +58,8 @@
         "min_batches": 1,
         "max_batches": 6,
         "timeout": 7200,
-        "backlog_max": 75
+        "backlog_max": 75,
+        "blob_fee_tolerance_wei": 10000000000
       },
       "gas_oracle_config": {
         "min_gas_price": 0,

--- a/rollup/internal/config/relayer.go
+++ b/rollup/internal/config/relayer.go
@@ -48,11 +48,11 @@ type BatchSubmission struct {
 	TimeoutSec int64 `json:"timeout"`
 	// The maximum number of pending batches to keep in the backlog.
 	BacklogMax int64 `json:"backlog_max"`
-	// BlobFeeToleranceWei is the absolute tolerance (in wei) added to the target blob fee.
+	// BlobFeeTolerance is the absolute tolerance (in wei) added to the target blob fee.
 	// If the current fee is below target + tolerance, we proceed with submission.
 	// This prevents skipping submission when the price difference is negligible (e.g., 1 wei).
 	// Recommended value: 10 gwei (10000000000 wei).
-	BlobFeeToleranceWei uint64 `json:"blob_fee_tolerance_wei"`
+	BlobFeeTolerance uint64 `json:"blob_fee_tolerance"`
 }
 
 // ChainMonitor this config is used to get batch status from chain_monitor API.

--- a/rollup/internal/config/relayer.go
+++ b/rollup/internal/config/relayer.go
@@ -50,8 +50,7 @@ type BatchSubmission struct {
 	BacklogMax int64 `json:"backlog_max"`
 	// BlobFeeTolerance is the absolute tolerance (in wei) added to the target blob fee.
 	// If the current fee is below target + tolerance, we proceed with submission.
-	// This prevents skipping submission when the price difference is negligible (e.g., 1 wei).
-	// Recommended value: 10 gwei (10000000000 wei).
+	// This prevents skipping submission when the price difference is negligible.
 	BlobFeeTolerance uint64 `json:"blob_fee_tolerance"`
 }
 

--- a/rollup/internal/config/relayer.go
+++ b/rollup/internal/config/relayer.go
@@ -48,6 +48,11 @@ type BatchSubmission struct {
 	TimeoutSec int64 `json:"timeout"`
 	// The maximum number of pending batches to keep in the backlog.
 	BacklogMax int64 `json:"backlog_max"`
+	// BlobFeeToleranceWei is the absolute tolerance (in wei) added to the target blob fee.
+	// If the current fee is below target + tolerance, we proceed with submission.
+	// This prevents skipping submission when the price difference is negligible (e.g., 1 wei).
+	// Recommended value: 10 gwei (10000000000 wei).
+	BlobFeeToleranceWei uint64 `json:"blob_fee_tolerance_wei"`
 }
 
 // ChainMonitor this config is used to get batch status from chain_monitor API.

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -1255,16 +1255,20 @@ func (r *Layer2Relayer) skipSubmitByFee(oldest time.Time, metrics *l2RelayerMetr
 	target := calculateTargetPrice(windowSec, r.batchStrategy, oldest, hist)
 	current := hist[len(hist)-1]
 
+	// apply absolute tolerance offset to target
+	tolerance := new(big.Int).SetUint64(r.cfg.BatchSubmission.BlobFeeToleranceWei)
+	threshold := new(big.Int).Add(target, tolerance)
+
 	currentFloat, _ := current.Float64()
 	targetFloat, _ := target.Float64()
 	metrics.rollupL2RelayerCurrentBlobPrice.Set(currentFloat)
 	metrics.rollupL2RelayerTargetBlobPrice.Set(targetFloat)
 
-	// if current fee > target and still inside the timeout window, skip
-	if current.Cmp(target) > 0 && time.Since(oldest) < time.Duration(windowSec)*time.Second {
+	// if current fee > threshold (target + tolerance) and still inside the timeout window, skip
+	if current.Cmp(threshold) > 0 && time.Since(oldest) < time.Duration(windowSec)*time.Second {
 		return true, fmt.Errorf(
-			"blob-fee above target & window not yet passed; current=%s target=%s age=%s",
-			current.String(), target.String(), time.Since(oldest),
+			"blob-fee above threshold & window not yet passed; current=%s target=%s threshold=%s tolerance=%s age=%s",
+			current.String(), target.String(), threshold.String(), tolerance.String(), time.Since(oldest),
 		)
 	}
 

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -1256,7 +1256,7 @@ func (r *Layer2Relayer) skipSubmitByFee(oldest time.Time, metrics *l2RelayerMetr
 	current := hist[len(hist)-1]
 
 	// apply absolute tolerance offset to target
-	tolerance := new(big.Int).SetUint64(r.cfg.BatchSubmission.BlobFeeToleranceWei)
+	tolerance := new(big.Int).SetUint64(r.cfg.BatchSubmission.BlobFeeTolerance)
 	threshold := new(big.Int).Add(target, tolerance)
 
 	currentFloat, _ := current.Float64()


### PR DESCRIPTION
### Purpose or design rationale of this PR

**Problem**
When blob price stays very low (e.g., 1-2 wei), any tiny increase causes current > target, stopping batch submission unnecessarily.

**Solution**
Add blob_fee_tolerance config. Now we only skip submission when current > target + tolerance, avoiding delays due to negligible price differences.

**The main changes are:**
- in `rollup/internal/config/relayer.go` we introduce a new config field `BlobFeeTolerance uint64 `json:"blob_fee_tolerance"`, which we can configurate the tolerance.
- in `rollup/internal/controller/relayer/l2_relayer.go`, we check if `current > target + tolerance`.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [x] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [x] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable blob fee tolerance added to relayer settings.
  * Submission logic updated to use an absolute tolerance when comparing current vs. target blob fee, allowing submissions to proceed if fees are within the configured tolerance.

* **Chores**
  * Release version updated to v4.7.10.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->