### PR TITLE
fix: postgres bulk insert issue

### DIFF
--- a/bridge-history-api/internal/logic/history_logic.go
+++ b/bridge-history-api/internal/logic/history_logic.go
@@ -372,7 +372,7 @@ func (h *HistoryLogic) getCachedTxsInfo(ctx context.Context, cacheKey string, pa
 	}
 
 	if start >= total {
-		return nil, 0, false, nil
+		return nil, 0, true, nil
 	}
 
 	values, err := h.redis.ZRevRange(ctx, cacheKey, start, end).Result()

--- a/common/database/db.go
+++ b/common/database/db.go
@@ -51,7 +51,8 @@ func InitDB(config *Config) (*gorm.DB, error) {
 	}
 
 	db, err := gorm.Open(postgres.Open(config.DSN), &gorm.Config{
-		Logger: &tmpGormLogger,
+		CreateBatchSize: 1000,
+		Logger:          &tmpGormLogger,
 		NowFunc: func() time.Time {
 			// why set time to UTC.
 			// if now set this, the inserted data time will use local timezone. like 2023-07-18 18:24:00 CST+8

--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.7.10"
+var tag = "v4.7.11"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {


### PR DESCRIPTION
### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*

scroll repo will encounter: postgres will return `extended protocol limited to 65535 parameters` issue

Fix: 

* Add a batch insert limit, gorm will automatically split it base on your limit

```
func main() {
	b, err := gorm.Open(postgres.Open("postgres://localhost/xx?sslmode=disable"), &gorm.Config{
		CreateBatchSize: 5,
		Logger:          logger.Default.LogMode(logger.Info),
	})
	if err != nil {
		return
	}

	challenges := []Challenge{
		{Challenge: "11"},
		{Challenge: "12"},
		{Challenge: "13"},
		{Challenge: "14"},
		{Challenge: "15"},
		{Challenge: "16"},
		{Challenge: "17"},
		{Challenge: "18"},
		{Challenge: "19"},
		{Challenge: "110"},
	}

	if err = b.Create(&challenges).Error; err != nil {
		panic(err)
	}
}
```

output:
```
2026/01/13 12:05:31 /Users/haohongfan-scroll/goproject/test/gorm/main.go:49
[4.301ms] [rows:5] INSERT INTO "challenge" ("challenge","created_at","updated_at","deleted_at") VALUES ('11','2026-01-13 12:05:31.661','2026-01-13 12:05:31.661',NULL),('12','2026-01-13 12:05:31.661','2026-01-13 12:05:31.661',NULL),('13','2026-01-13 12:05:31.661','2026-01-13 12:05:31.661',NULL),('14','2026-01-13 12:05:31.661','2026-01-13 12:05:31.661',NULL),('15','2026-01-13 12:05:31.661','2026-01-13 12:05:31.661',NULL) RETURNING "id"

2026/01/13 12:05:31 /Users/haohongfan-scroll/goproject/test/gorm/main.go:49
[0.192ms] [rows:5] INSERT INTO "challenge" ("challenge","created_at","updated_at","deleted_at") VALUES ('16','2026-01-13 12:05:31.665','2026-01-13 12:05:31.665',NULL),('17','2026-01-13 12:05:31.665','2026-01-13 12:05:31.665',NULL),('18','2026-01-13 12:05:31.665','2026-01-13 12:05:31.665',NULL),('19','2026-01-13 12:05:31.665','2026-01-13 12:05:31.665',NULL),('110','2026-01-13 12:05:31.665','2026-01-13 12:05:31.665',NULL) RETURNING "id"

```

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-range pagination requests now return empty cached results instead of triggering a miss path.

* **Performance**
  * Increased database batch processing size for more efficient bulk operations.

* **Chores**
  * Updated release version to v4.7.11.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->