### PR TITLE
docs: fix typos in libzkp comments

### DIFF
--- a/crates/libzkp/src/lib.rs
+++ b/crates/libzkp/src/lib.rs
@@ -84,16 +84,16 @@ pub fn univ_task_compatibility_fix(task_json: &str) -> eyre::Result<String> {
 
     #[derive(Serialize)]
     struct CompatibleProvingTask {
-        /// seralized witness which should be written into stdin first
+        /// serialized witness which should be written into stdin first
         pub serialized_witness: Vec<Vec<u8>>,
         /// aggregated proof carried by babybear fields, should be written into stdin
         /// followed `serialized_witness`
         pub aggregated_proofs: Vec<VmInternalStarkProof>,
         /// Fork name specify
         pub fork_name: String,
-        /// The vk of app which is expcted to prove this task
+        /// The vk of app which is expected to prove this task
         pub vk: Vec<u8>,
-        /// An identifier assigned by coordinator, it should be kept identify for the
+        /// An identifier assigned by coordinator, it should be kept identical for the
         /// same task (for example, using chunk, batch and bundle hashes)
         pub identifier: String,
     }
@@ -109,7 +109,7 @@ pub fn univ_task_compatibility_fix(task_json: &str) -> eyre::Result<String> {
     Ok(serde_json::to_string(&compatible_u_task)?)
 }
 
-/// Generate required staff for proving tasks
+/// Generate required data for proving tasks
 /// return (pi_hash, metadata, task)
 pub fn gen_universal_task(
     task_type: i32,
@@ -132,7 +132,7 @@ pub fn gen_universal_task(
     let (pi_hash, metadata, mut u_task) = match task_type {
         x if x == TaskType::Chunk as i32 => {
             let mut task = serde_json::from_str::<ChunkProvingTask>(task_json)?;
-            // normailze fork name field in task
+            // normalize fork name field in task
             task.fork_name = task.fork_name.to_lowercase();
             let version = Version::from(task.version);
             // always respect the fork_name_str (which has been normalized) being passed

--- a/crates/libzkp/src/tasks.rs
+++ b/crates/libzkp/src/tasks.rs
@@ -58,7 +58,7 @@ impl ProvingTaskExt {
     }
 }
 
-/// Generate required staff for chunk proving
+/// Generate required data for chunk proving
 pub fn gen_universal_chunk_task(
     task: ChunkProvingTask,
 ) -> eyre::Result<(B256, ChunkProofMetadata, ProvingTask)> {
@@ -74,7 +74,7 @@ pub fn gen_universal_chunk_task(
     ))
 }
 
-/// Generate required staff for batch proving
+/// Generate required data for batch proving
 pub fn gen_universal_batch_task(
     task: BatchProvingTask,
 ) -> eyre::Result<(B256, BatchProofMetadata, ProvingTask)> {
@@ -86,7 +86,7 @@ pub fn gen_universal_batch_task(
     ))
 }
 
-/// Generate required staff for bundle proving
+/// Generate required data for bundle proving
 pub fn gen_universal_bundle_task(
     task: BundleProvingTask,
 ) -> eyre::Result<(B256, BundleProofMetadata, ProvingTask)> {


### PR DESCRIPTION
## Summary
Fixed several typos in the libzkp crate comments:

**In `crates/libzkp/src/lib.rs`:**
- "seralized" -> "serialized"
- "expcted" -> "expected"
- "kept identify" -> "kept identical"
- "normailze" -> "normalize"
- "staff" -> "data" (in context of "Generate required staff for proving tasks")

**In `crates/libzkp/src/tasks.rs`:**
- "staff" -> "data" (in three function documentation comments)

## Test plan
- Documentation/comment-only changes, no testing required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple typos and wording inconsistencies in internal documentation to improve clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->