### PR TITLE
docs: improve clarity in prover-e2e README

### DIFF
--- a/tests/prover-e2e/README.md
+++ b/tests/prover-e2e/README.md
@@ -3,7 +3,7 @@
 It contains data from some blocks in a specified testnet, and helps to generate a series of chunks/batches/bundles from these blocks, filling the DB for the coordinator, so an e2e test (from chunk to bundle) can be run completely local
 
 Prepare:
-link the staff dir as "conf" from one of the dir with staff set, currently we have following staff sets:
+link the data dir as "conf" from one of the directories with data sets, currently we have the following data sets:
 + sepolia: with blocks from scroll sepolia
 + cloak-xen: with blocks from xen sepolia, which is a cloak network
 
@@ -13,4 +13,4 @@ Steps:
 3. in `coordinator/build/bin/conf`, update necessary items in `config.template.json` and rename it as `config.json`
 4. build and launch `coordinator_api` service locally
 5. setup the `config.json` for zkvm prover to connect with the locally launched coordinator api
-6. in `zkvm-prover`, launch `make test_e2e_run`, which would specific prover run locally, connect to the local coordinator api service according to the `config.json`, and prove all tasks being injected to db in step 1.
+6. in `zkvm-prover`, launch `make test_e2e_run`, which will run the prover locally, connect to the local coordinator api service according to the `config.json`, and prove all tasks injected into the DB in step 1.


### PR DESCRIPTION
## Summary
- Changed "staff" to "data" for consistency and clarity
- Fixed grammar: "which would specific prover run locally" -> "which will run the prover locally"
- Minor improvements to sentence structure

## Test plan
- Documentation-only changes, no testing required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup instructions with improved grammar, consistency, and technical terminology for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->