### PR TITLE
feat: adjustments for launching Cloak with GalileoV2

### DIFF
--- a/coordinator/internal/utils/codec_validium.go
+++ b/coordinator/internal/utils/codec_validium.go
@@ -56,7 +56,7 @@ func (c CodecVersion) DABatchForTaskFromBytes(b []byte) (DABatch, error) {
 
 func decodeDABatchV1(data []byte) (*daBatchValidiumV1, error) {
 	if len(data) != daBatchValidiumEncodedLength {
-		return nil, fmt.Errorf("invalid data length for DABatchV7, expected %d bytes but got %d", daBatchValidiumEncodedLength, len(data))
+		return nil, fmt.Errorf("invalid data length for ValidiumDABatchV1, expected %d bytes but got %d", daBatchValidiumEncodedLength, len(data))
 	}
 
 	const (

--- a/coordinator/internal/utils/version.go
+++ b/coordinator/internal/utils/version.go
@@ -19,7 +19,12 @@ func Version(hardForkName string, ValidiumMode bool) (uint8, error) {
 
 	if ValidiumMode {
 		domain = 1
-		stfVersion = 1
+		switch canonicalName := strings.ToLower(hardForkName); canonicalName {
+		case "galileov2":
+			stfVersion = 1
+		default:
+			return 0, errors.New("unsupported fork in validium mode " + canonicalName)
+		}
 	} else {
 		domain = 0
 		switch canonicalName := strings.ToLower(hardForkName); canonicalName {

--- a/rollup/cmd/rollup_relayer/app/app.go
+++ b/rollup/cmd/rollup_relayer/app/app.go
@@ -111,6 +111,9 @@ func action(ctx *cli.Context) error {
 	if minCodecVersion < encoding.CodecV7 {
 		log.Crit("min codec version must be greater than or equal to CodecV7", "minCodecVersion", minCodecVersion)
 	}
+	if cfg.L2Config.RelayerConfig.ValidiumMode && minCodecVersion < encoding.CodecV10 {
+		log.Crit("min codec version must be greater than or equal to CodecV10 in validium mode", "minCodecVersion", minCodecVersion)
+	}
 
 	chunkProposer := watcher.NewChunkProposer(subCtx, cfg.L2Config.ChunkProposerConfig, minCodecVersion, genesis.Config, db, registry)
 	batchProposer := watcher.NewBatchProposer(subCtx, cfg.L2Config.BatchProposerConfig, minCodecVersion, genesis.Config, db, cfg.L2Config.RelayerConfig.ValidiumMode, registry)

--- a/rollup/internal/controller/relayer/l2_relayer.go
+++ b/rollup/internal/controller/relayer/l2_relayer.go
@@ -1053,7 +1053,7 @@ func (r *Layer2Relayer) constructCommitBatchPayloadValidium(batch *dbBatchWithCh
 	var version uint8
 	if encoding.CodecVersion(batch.Batch.CodecVersion) == encoding.CodecV8 || encoding.CodecVersion(batch.Batch.CodecVersion) == encoding.CodecV9 || encoding.CodecVersion(batch.Batch.CodecVersion) == encoding.CodecV10 {
 		// Validium version line starts with v1,
-		// but rollup-relayer behavior follows v8.
+		// but rollup-relayer behavior follows v10.
 		version = 1
 	} else {
 		return nil, 0, 0, fmt.Errorf("unexpected codec version %d for validium mode", batch.Batch.CodecVersion)

--- a/rollup/internal/utils/utils.go
+++ b/rollup/internal/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/scroll-tech/da-codec/encoding"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/crypto"
-	"github.com/scroll-tech/go-ethereum/log"
 )
 
 // ChunkMetrics indicates the metrics for proposing a chunk.
@@ -141,25 +140,6 @@ func encodeBatchHeaderValidium(b *encoding.Batch, codecVersion encoding.CodecVer
 	commitment := lastBlock.Header.Hash()
 	stateRoot := b.StateRoot()
 
-	// Temporary workaround for the wrong genesis state root configuration issue.
-	if lastBlock.Header.Number.Uint64() == 0 {
-		if commitment == common.HexToHash("0x76a8e1359fe1a51ec3917ca98dec95ba005f1a73bcdbc2c7f87c7683e828fbb1") && stateRoot == common.HexToHash("0x08d535cc60f40af5dd3b31e0998d7567c2d568b224bed2ba26070aeb078d1339") {
-			// cloak-xen/sepolia
-			stateRoot = common.HexToHash("0x0711f02d6f85b0597c4705298e01ee27159fdd8bd8bdeda670ae8b9073091246")
-		} else if commitment == common.HexToHash("0x8005a02271085eaded2565f3e252013cd9d3cd0a4775d89f9ba4224289671276") && stateRoot == common.HexToHash("0x08d535cc60f40af5dd3b31e0998d7567c2d568b224bed2ba26070aeb078d1339") {
-			// cloak-xen/mainnet
-			stateRoot = common.HexToHash("0x8da1aaf41660ddf7870ab5ff4f6a3ab4b2e652568d341ede87ada56aad5fb097")
-		} else if commitment == common.HexToHash("0xa7e50dfc812039410c2009c74cdcb0c0797aa5485dec062985eaa43b17d333ea") && stateRoot == common.HexToHash("0x08d535cc60f40af5dd3b31e0998d7567c2d568b224bed2ba26070aeb078d1339") {
-			// cloak-etherfi/sepolia
-			stateRoot = common.HexToHash("0x7b44ea23770dda8810801779eb6847d56be0399e35de7c56465ccf8b7578ddf6")
-		} else if commitment == common.HexToHash("0xeccf4fab24f8b5dd3b72667c6bf5e28b17ccffdea01e3e5c08f393edaa9e7657") && stateRoot == common.HexToHash("0x08d535cc60f40af5dd3b31e0998d7567c2d568b224bed2ba26070aeb078d1339") {
-			// cloak-shiga/sepolia
-			stateRoot = common.HexToHash("0x05973227854ac82c22f164ed3d4510b7df516a0eecdfd9bed5f2446efc9994b9")
-		}
-
-		log.Warn("Using genesis state root", "stateRoot", stateRoot.Hex())
-	}
-
 	// Batch header field sizes
 	const (
 		versionSize      = 1
@@ -188,7 +168,7 @@ func encodeBatchHeaderValidium(b *encoding.Batch, codecVersion encoding.CodecVer
 	var version uint8
 	if codecVersion == encoding.CodecV8 || codecVersion == encoding.CodecV9 || codecVersion == encoding.CodecV10 {
 		// Validium version line starts with v1,
-		// but rollup-relayer behavior follows v8.
+		// but rollup-relayer behavior follows v10.
 		version = 1
 	} else if codecVersion == encoding.CodecV0 {
 		// Special case for genesis batch


### PR DESCRIPTION
### Purpose or design rationale of this PR

The codebase already maps CodecV10 (GalileoV2) to Validium V1, which is the intended behavior. Just added a few cleanups and clarifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages and validation for Validium mode configurations
  * Enhanced Validium batch encoding by removing legacy workarounds
  * Tightened codec version requirements for Validium operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->