### PR TITLE
feat(coordinator): limit parallelism during chunk assignment

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.7.12"
+var tag = "v4.7.13"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/coordinator/internal/logic/provertask/chunk_prover_task.go
+++ b/coordinator/internal/logic/provertask/chunk_prover_task.go
@@ -24,6 +24,13 @@ import (
 	cutils "scroll-tech/coordinator/internal/utils"
 )
 
+// Implement global throttle on debug_executionWitness calls.
+// This API slows down when there are multiple concurrent calls.
+var (
+	applyUniversalMaxParallelism = 2
+	witnessSemaphore             = make(chan struct{}, applyUniversalMaxParallelism)
+)
+
 // ChunkProverTask the chunk prover task
 type ChunkProverTask struct {
 	BaseProverTask
@@ -201,6 +208,17 @@ func (cp *ChunkProverTask) Assign(ctx *gin.Context, getTaskParameter *coordinato
 
 	if getTaskParameter.Universal {
 		var metadata []byte
+
+		select {
+		case witnessSemaphore <- struct{}{}:
+			// Released when Assign returns (defer).
+			defer func() { <-witnessSemaphore }()
+		case <-ctx.Done():
+			log.Warn("context canceled waiting for witness semaphore", "task_id", chunkTask.Hash, "err", ctx.Err())
+			cp.recoverActiveAttempts(ctx, chunkTask)
+			return nil, ctx.Err()
+		}
+
 		taskMsg, metadata, err = cp.applyUniversal(taskMsg)
 		if err != nil {
 			cp.recoverActiveAttempts(ctx, chunkTask)


### PR DESCRIPTION
### Purpose or design rationale of this PR

`applyUniversal` calls `debug_executionWitness`, which degrades significantly under concurrent load. When multiple chunk proof assignments arrive simultaneously, the unthrottled parallel calls cause severe slowdowns.

This PR adds a semaphore (capacity 2) that limits concurrent `applyUniversal` invocations. Requests that arrive while both slots are occupied block until a slot opens or the request context is cancelled, preventing goroutine accumulation.


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized execution witness generation with resource throttling to prevent system overload during concurrent operations and enhance stability.

* **Chores**
  * Version bumped to 4.7.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->