### PR TITLE
fix: use empty access list if eth_createAccessList returns error

### DIFF
--- a/common/version/version.go
+++ b/common/version/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime/debug"
 )
 
-var tag = "v4.7.12"
+var tag = "v4.7.13"
 
 var commit = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -168,8 +168,15 @@ func finetuneAccessList(accessList *types.AccessList, gasLimitWithAccessList uin
 			// Each storage key saves 100 gas units.
 			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys))
 		} else {
-			// Otherwise, keep the entry in the new access list.
-			newAccessList = append(newAccessList, entry)
+			// Ensure StorageKeys is never nil to avoid "missing required field 'storageKeys'" error during JSON serialization.
+			storageKeys := entry.StorageKeys
+			if storageKeys == nil {
+				storageKeys = []common.Hash{}
+			}
+			newAccessList = append(newAccessList, types.AccessTuple{
+				Address:     entry.Address,
+				StorageKeys: storageKeys,
+			})
 		}
 	}
 	return &newAccessList, gasLimitWithAccessList

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -1,7 +1,6 @@
 package sender
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -134,11 +133,11 @@ func (s *Sender) estimateGasLimit(to *common.Address, data []byte, sidecar *type
 	accessList, gasLimitWithAccessList, errStr, rpcErr := s.gethClient.CreateAccessList(s.ctx, msg)
 	if rpcErr != nil {
 		log.Error("CreateAccessList RPC error", "error", rpcErr)
-		return gasLimitWithoutAccessList, nil, rpcErr
+		return gasLimitWithoutAccessList, nil, nil
 	}
 	if errStr != "" {
 		log.Error("CreateAccessList reported error", "error", errStr)
-		return gasLimitWithoutAccessList, nil, errors.New(errStr)
+		return gasLimitWithoutAccessList, nil, nil
 	}
 
 	// Fine-tune accessList because 'to' address is automatically included in the access list by the Ethereum protocol: https://github.com/ethereum/go-ethereum/blob/v1.13.10/core/state/statedb.go#L1322

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -171,15 +171,8 @@ func finetuneAccessList(accessList *types.AccessList, gasLimitWithAccessList uin
 			// Each storage key saves 100 gas units.
 			gasLimitWithAccessList += uint64(100 * len(entry.StorageKeys))
 		} else {
-			// Ensure StorageKeys is never nil to avoid "missing required field 'storageKeys'" error during JSON serialization.
-			storageKeys := entry.StorageKeys
-			if storageKeys == nil {
-				storageKeys = []common.Hash{}
-			}
-			newAccessList = append(newAccessList, types.AccessTuple{
-				Address:     entry.Address,
-				StorageKeys: storageKeys,
-			})
+			// Otherwise, keep the entry in the new access list.
+			newAccessList = append(newAccessList, entry)
 		}
 	}
 	return &newAccessList, gasLimitWithAccessList

--- a/rollup/internal/controller/sender/estimategas.go
+++ b/rollup/internal/controller/sender/estimategas.go
@@ -133,9 +133,13 @@ func (s *Sender) estimateGasLimit(to *common.Address, data []byte, sidecar *type
 	accessList, gasLimitWithAccessList, errStr, rpcErr := s.gethClient.CreateAccessList(s.ctx, msg)
 	if rpcErr != nil {
 		log.Error("CreateAccessList RPC error", "error", rpcErr)
+		// We ignore errors from eth_createAccessList and proceed
+		// with sending the transaction without an access list.
 		return gasLimitWithoutAccessList, nil, nil
 	}
 	if errStr != "" {
+		// We ignore errors from eth_createAccessList and proceed
+		// with sending the transaction without an access list.
 		log.Error("CreateAccessList reported error", "error", errStr)
 		return gasLimitWithoutAccessList, nil, nil
 	}


### PR DESCRIPTION
### Purpose or design rationale of this PR

Symptom:

```
error="missing required field 'storageKeys' for AccessTuple
```

Root cause: https://github.com/ethereum/go-ethereum/pull/33656 adds `slices.SortedFunc` inside access list tracer, which returns `nil` if the input slice is empty.

Technically it's a bug in upstream geth, but we make our code more robust and defensive.

### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [X] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [X] No, this PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gas estimation now ignores access-list creation errors and continues gracefully, reducing failed estimations.
* **Chores**
  * Version bumped to v4.7.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->