### PR TITLE
ci: bind intermediate-docker workflow inputs via env before shell

### DIFF
--- a/.github/workflows/intermediate-docker.yml
+++ b/.github/workflows/intermediate-docker.yml
@@ -84,21 +84,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: set tag env
+        env:
+          BASE_IMAGE: ${{ github.event.inputs.BASE_IMAGE }}
+          CUDA_VERSION: ${{ github.event.inputs.CUDA_VERSION }}
+          GO_VERSION: ${{ github.event.inputs.GO_VERSION }}
+          RUST_VERSION: ${{ github.event.inputs.RUST_VERSION }}
+          PYTHON_VERSION: ${{ github.event.inputs.PYTHON_VERSION }}
         run: |
-          if [ ${{github.event.inputs.BASE_IMAGE}} == "cuda-go-rust-builder" ]; then
-            echo "TAG=cuda-${{ github.event.inputs.CUDA_VERSION }}-go-${{ github.event.inputs.GO_VERSION }}-rust-${{ github.event.inputs.RUST_VERSION }}" >> $GITHUB_ENV
-          elif [ ${{github.event.inputs.BASE_IMAGE}} == "go-rust-builder" ]; then
-            echo "TAG=go-${{ github.event.inputs.GO_VERSION }}-rust-${{ github.event.inputs.RUST_VERSION }}" >> $GITHUB_ENV
-          elif [ ${{github.event.inputs.BASE_IMAGE}} == "go-alpine-builder" ]; then
-            echo "TAG=${{ github.event.inputs.GO_VERSION }}" >> $GITHUB_ENV
-          elif [ ${{github.event.inputs.BASE_IMAGE}} == "rust-builder" ]; then
-            echo "TAG=${{ github.event.inputs.RUST_VERSION }}" >> $GITHUB_ENV
-          elif [ ${{github.event.inputs.BASE_IMAGE}} == "rust-alpine-builder" ]; then
-            echo "TAG=${{ github.event.inputs.RUST_VERSION }}" >> $GITHUB_ENV
-          elif [ ${{github.event.inputs.BASE_IMAGE}} == "go-rust-alpine-builder" ]; then
-            echo "TAG=go-${{ github.event.inputs.GO_VERSION }}-rust-${{ github.event.inputs.RUST_VERSION }}" >> $GITHUB_ENV
-          elif [ ${{github.event.inputs.BASE_IMAGE}} == "py-runner" ]; then
-            echo "TAG=${{ github.event.inputs.PYTHON_VERSION }}" >> $GITHUB_ENV
+          if [ "$BASE_IMAGE" == "cuda-go-rust-builder" ]; then
+            echo "TAG=cuda-${CUDA_VERSION}-go-${GO_VERSION}-rust-${RUST_VERSION}" >> $GITHUB_ENV
+          elif [ "$BASE_IMAGE" == "go-rust-builder" ]; then
+            echo "TAG=go-${GO_VERSION}-rust-${RUST_VERSION}" >> $GITHUB_ENV
+          elif [ "$BASE_IMAGE" == "go-alpine-builder" ]; then
+            echo "TAG=${GO_VERSION}" >> $GITHUB_ENV
+          elif [ "$BASE_IMAGE" == "rust-builder" ]; then
+            echo "TAG=${RUST_VERSION}" >> $GITHUB_ENV
+          elif [ "$BASE_IMAGE" == "rust-alpine-builder" ]; then
+            echo "TAG=${RUST_VERSION}" >> $GITHUB_ENV
+          elif [ "$BASE_IMAGE" == "go-rust-alpine-builder" ]; then
+            echo "TAG=go-${GO_VERSION}-rust-${RUST_VERSION}" >> $GITHUB_ENV
+          elif [ "$BASE_IMAGE" == "py-runner" ]; then
+            echo "TAG=${PYTHON_VERSION}" >> $GITHUB_ENV
           else
             echo "no BASE_IMAGE match"
           fi


### PR DESCRIPTION
## Summary
- Bind `github.event.inputs.BASE_IMAGE` and related version inputs through `env:` before the `set tag env` shell step.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Intermediate docker workflow still builds the correct TAG for each BASE_IMAGE choice
- [ ] Docker build-push step still receives the expected Dockerfile / tags via existing expressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker workflow tag generation by reliably handling workflow inputs.
  * Existing tag formats and fallback behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->